### PR TITLE
Example: Drag and drop glTF files

### DIFF
--- a/example/dragDrop.html
+++ b/example/dragDrop.html
@@ -1,0 +1,54 @@
+<html>
+    <head>
+        <title>Drag-and-Drop</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+        <style>
+            html, body {
+                margin: 0;
+                padding: 0;
+				background-color: #111;
+            }
+
+			#info {
+				position: absolute;
+				bottom: 0;
+				left: 0;
+				font-family: 'Courier New', Courier, monospace;
+				color: white;
+				pointer-events: none;
+			}
+
+			#samples, #credits {
+
+				opacity: 0.5;
+				background-color: rgba( 0.0, 0.0, 0.0, 0.5 );
+				padding: 5px;
+				display: inline-block;
+
+			}
+
+			#loading {
+				position: absolute;
+				left: 50%;
+				top: 50%;
+				transform: translate(-50%, -50%);
+				color: white;
+				font-family: 'Courier New', Courier, monospace;
+			}
+        </style>
+
+    </head>
+    <body>
+		<div id="loading">DRAG AND DROP .GLB or .GLTF</div>
+		<div id="info">
+			<div>
+				<div id="samples">--</div>
+			</div>
+			<div>
+				<pre id="credits">--</pre>
+			</div>
+		</div>
+        <script src="./dragDrop.js" type="module"></script>
+    </body>
+</html>

--- a/example/dragDrop.js
+++ b/example/dragDrop.js
@@ -191,8 +191,6 @@ async function updateModel( modelDocument ) {
 	material.materials.updateFrom( materials, textures );
 	material.setDefine( 'MATERIAL_LENGTH', materials.length );
 
-	generator.dispose();
-
 	loadingEl.style.visibility = 'hidden';
 
 	animate();

--- a/example/dragDrop.js
+++ b/example/dragDrop.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { PathTracingRenderer, PhysicalPathTracingMaterial } from '../src/index.js';
+import { PathTracingRenderer, PhysicalPathTracingMaterial, MaterialReducer } from '../src/index.js';
 import { PathTracingSceneWorker } from '../src/workers/PathTracingSceneWorker.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
@@ -151,6 +151,11 @@ async function updateModel( modelDocument ) {
 	const modelView = new DocumentView( modelDocument )
 		.setImageProvider( imageProvider );
 	const model = modelView.view( modelSceneDef );
+
+	// reuse as many materials as possible
+
+	const reducer = new MaterialReducer();
+	reducer.process( model );
 
 	// center the model
 

--- a/example/dragDrop.js
+++ b/example/dragDrop.js
@@ -24,7 +24,7 @@ const samplesEl = document.getElementById( 'samples' );
 
 const params = {
 
-	environmentIntensity: 1,
+	environmentIntensity: 3.0,
 	environmentRotation: 0,
 	emissiveIntensity: 1,
 	bounces: 20,
@@ -67,8 +67,8 @@ async function init() {
 
 	scene = new THREE.Scene();
 
-	camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.025, 500 );
-	camera.position.set( 0.4, 0.6, 2.65 );
+	camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
+	camera.position.set( 0, 0, 2 );
 
 	ptRenderer = new PathTracingRenderer( renderer );
 	ptRenderer.camera = camera;
@@ -80,7 +80,7 @@ async function init() {
 	} ) );
 
 	controls = new OrbitControls( camera, renderer.domElement );
-	controls.target.set( - 0.15, 0.33, - 0.08 );
+	controls.target.set( 0, 0, 0 );
 	camera.lookAt( controls.target );
 	controls.addEventListener( 'change', () => ptRenderer.reset() );
 	controls.update();
@@ -168,6 +168,8 @@ async function updateModel( modelDocument ) {
 
 	model.scale.setScalar( 1 / sphere.radius );
 	model.position.multiplyScalar( 1 / sphere.radius );
+
+	model.updateMatrixWorld();
 
 	scene.add( model );
 

--- a/example/dragDrop.js
+++ b/example/dragDrop.js
@@ -1,232 +1,138 @@
-import { ACESFilmicToneMapping, NoToneMapping, Box3, LoadingManager, EquirectangularReflectionMapping, PMREMGenerator, Sphere, Color, DoubleSide } from 'three';
-import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import * as THREE from 'three';
+import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { PathTracingRenderer, PhysicalPathTracingMaterial } from '../src/index.js';
+import { PathTracingSceneWorker } from '../src/workers/PathTracingSceneWorker.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
-import { LDrawLoader } from 'three/examples/jsm/loaders/LDrawLoader.js';
-import { LDrawUtils } from 'three/examples/jsm/utils/LDrawUtils.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import { PathTracingViewer } from '../src/viewers/PathTracingViewer.js';
-import Stats from 'three/examples/jsm/libs/stats.module.js';
 
-import * as MikkTSpace from './lib/mikktspace.module.js';
 import { WebIO } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
 import { metalRough } from '@gltf-transform/functions';
 import { DocumentView, ImageProvider } from '@gltf-transform/view';
 import { getFilesFromDataTransferItems } from "@placemarkio/flat-drop-files";
 
-const creditEl = document.getElementById( 'credits' );
+let renderer, controls, scene, sceneInfo, ptRenderer, camera, fsQuad;
+
+let frameRequestID;
+
 const loadingEl = document.getElementById( 'loading' );
+const creditEl = document.getElementById( 'credits' );
 const samplesEl = document.getElementById( 'samples' );
 
-const viewer = new PathTracingViewer();
-viewer.init();
-viewer.domElement.style.width = '100%';
-viewer.domElement.style.height = '100%';
-document.body.appendChild( viewer.domElement );
+const params = {
+
+	environmentIntensity: 1,
+	environmentRotation: 0,
+	emissiveIntensity: 1,
+	bounces: 20,
+	samplesPerFrame: 1,
+	resolutionScale: 1 / window.devicePixelRatio,
+	filterGlossyFactor: 0.25,
+	tiles: 2,
+
+};
+
+// clamp value for mobile
+const aspectRatio = window.innerWidth / window.innerHeight;
+if ( aspectRatio < 0.65 ) {
+
+	params.bounces = Math.min( params.bounces, 10 );
+	params.resolutionScale *= 0.5;
+	params.tiles = 3;
+
+}
 
 const io = new WebIO()
 	.registerExtensions(ALL_EXTENSIONS)
 	.registerDependencies({'meshopt.decoder': MeshoptDecoder});
+
 const imageProvider = new ImageProvider();
 
-const envMaps = {
-	'Royal Esplanade': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr',
-	'Moonless Golf': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/moonless_golf_1k.hdr',
-	'Overpass': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/pedestrian_overpass_1k.hdr',
-	'Venice Sunset': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/venice_sunset_1k.hdr',
-};
+const generator = new PathTracingSceneWorker();
 
-const params = {
+//
 
-	acesToneMapping: true,
-	resolutionScale: 0.75 / window.devicePixelRatio,
-	tilesX: 2,
-	tilesY: 2,
-	samplesPerFrame: 1,
+init();
 
-	environment: 'ENVMAP',
-	envMap: envMaps[ 'Royal Esplanade' ],
+//
 
-	gradientTop: '#bfd8ff',
-	gradientBottom: '#ffffff',
+async function init() {
 
-	environmentIntensity: 3.0,
-	environmentBlur: 0.35,
+	renderer = new THREE.WebGLRenderer( { antialias: true } );
+	renderer.toneMapping = THREE.ACESFilmicToneMapping;
+	document.body.appendChild( renderer.domElement );
 
-	backgroundType: 'Gradient',
-	bgGradientTop: '#111111',
-	bgGradientBottom: '#000000',
+	scene = new THREE.Scene();
 
-	enable: true,
-	bounces: 3,
+	camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.025, 500 );
+	camera.position.set( 0.4, 0.6, 2.65 );
 
-	floorColor: '#080808',
-	floorEnabled: true,
+	ptRenderer = new PathTracingRenderer( renderer );
+	ptRenderer.camera = camera;
+	ptRenderer.material = new PhysicalPathTracingMaterial();
+	ptRenderer.tiles.set( params.tiles, params.tiles );
 
-};
+	fsQuad = new FullScreenQuad( new THREE.MeshBasicMaterial( {
+		map: ptRenderer.target.texture,
+	} ) );
 
-let gui = null;
-function buildGui() {
+	controls = new OrbitControls( camera, renderer.domElement );
+	controls.target.set( - 0.15, 0.33, - 0.08 );
+	camera.lookAt( controls.target );
+	controls.addEventListener( 'change', () => ptRenderer.reset() );
+	controls.update();
 
-	if ( gui ) {
+	//
 
-		gui.destroy();
+	const environmentTexture = await new RGBELoader()
+		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr');
 
-	}
+	const pmremGenerator = new THREE.PMREMGenerator( renderer );
+	pmremGenerator.compileCubemapShader();
 
-	gui = new GUI();
+	const envMap = pmremGenerator.fromEquirectangular( environmentTexture );
 
-	const resolutionFolder = gui.addFolder( 'resolution' );
-	resolutionFolder.add( params, 'resolutionScale', 0.1, 1.0, 0.01 ).onChange( v => {
+	ptRenderer.material.environmentMap = envMap.texture;
+	scene.environment = envMap.texture;
 
-		viewer.setScale( parseFloat( v ) );
+	//
 
-	} );
-	resolutionFolder.add( params, 'samplesPerFrame', 1, 10, 1 ).onChange( v => {
+	window.CAMERA = camera;
+	window.CONTROLS = controls;
 
-		viewer.samplesPerFrame = parseInt( v );
+	onResize();
+	window.addEventListener( 'resize', onResize );
 
-	} );
-	resolutionFolder.add( params, 'tilesX', 1, 10, 1 ).onChange( v => {
-
-		viewer.ptRenderer.tiles.x = parseInt( v );
-
-	} );
-	resolutionFolder.add( params, 'tilesY', 1, 10, 1 ).onChange( v => {
-
-		viewer.ptRenderer.tiles.y = parseInt( v );
-
-	} );
-	resolutionFolder.open();
-
-	const environmentFolder = gui.addFolder( 'environment' );
-	environmentFolder.add( params, 'envMap', envMaps ).name( 'map' ).onChange( updateEnvMap );
-	environmentFolder.add( params, 'environmentBlur', 0.0, 1.0, 0.01 ).onChange( v => {
-
-		viewer.ptRenderer.material.environmentBlur = parseFloat( v );
-		viewer.ptRenderer.reset();
-
-	} ).name( 'env map blur' );
-	environmentFolder.add( params, 'environmentIntensity', 0.0, 10.0, 0.01 ).onChange( v => {
-
-		viewer.ptRenderer.material.environmentIntensity = parseFloat( v );
-		viewer.ptRenderer.reset();
-
-	} ).name( 'intensity' );
-	environmentFolder.open();
-
-	const backgroundFolder = gui.addFolder( 'background' );
-	backgroundFolder.add( params, 'backgroundType', [ 'Environment', 'Gradient' ] ).onChange( v => {
-
-		viewer.ptRenderer.material.setDefine( 'GRADIENT_BG', Number( v === 'Gradient' ) );
-		if ( v === 'Gradient' ) {
-
-			viewer.scene.background = new Color( 0x060606 );
-
-		} else {
-
-			viewer.scene.background = viewer.scene.environment;
-
-		}
-
-		viewer.ptRenderer.reset();
-
-	} );
-	backgroundFolder.addColor( params, 'bgGradientTop' ).onChange( v => {
-
-		viewer.ptRenderer.material.uniforms.bgGradientTop.value.set( v );
-		viewer.ptRenderer.reset();
-
-	} );
-	backgroundFolder.addColor( params, 'bgGradientBottom' ).onChange( v => {
-
-		viewer.ptRenderer.material.uniforms.bgGradientBottom.value.set( v );
-		viewer.ptRenderer.reset();
-
-	} );
-	backgroundFolder.open();
-
-	const floorFolder = gui.addFolder( 'floor' );
-	floorFolder.add( params, 'floorEnabled' ).onChange( v => {
-
-		viewer.ptRenderer.material.setDefine( 'DISPLAY_FLOOR', Number( v ) );
-		viewer.ptRenderer.reset();
-
-	} );
-	floorFolder.addColor( params, 'floorColor' ).onChange( v => {
-
-		viewer.ptRenderer.material.uniforms.floorColor.value.set( v );
-		viewer.ptRenderer.reset();
-
-	} );
-
-	const pathTracingFolder = gui.addFolder( 'path tracing' );
-	pathTracingFolder.add( params, 'enable' ).onChange( v => {
-
-		viewer.enablePathTracing = v;
-
-	} );
-	pathTracingFolder.add( params, 'acesToneMapping' ).onChange( v => {
-
-		viewer.renderer.toneMapping = v ? ACESFilmicToneMapping : NoToneMapping;
-		viewer.fsQuad.material.needsUpdate = true;
-
-	} );
-	pathTracingFolder.add( params, 'bounces', 1, 20, 1 ).onChange( v => {
-
-		viewer.ptRenderer.material.setDefine( 'BOUNCES', parseInt( v ) );
-		viewer.ptRenderer.reset();
-
-	} );
-	pathTracingFolder.open();
+	initGUI();
 
 }
 
-function updateEnvMap() {
+function initGUI() {
 
-	new RGBELoader()
-		.load( params.envMap, texture => {
+	const gui = new GUI();
+	gui.add( params, 'tiles', 1, 4, 1 ).onChange( value => ptRenderer.tiles.set( value, value ) );
+	gui.add( params, 'samplesPerFrame', 1, 10, 1 );
+	gui.add( params, 'filterGlossyFactor', 0, 1 ).onChange( () => ptRenderer.reset() );
+	gui.add( params, 'environmentIntensity', 0, 25 ).onChange( () => ptRenderer.reset() );
+	gui.add( params, 'environmentRotation', 0, 40 ).onChange( v => {
 
-			if ( viewer.ptRenderer.material.environmentMap ) {
+		ptRenderer.material.environmentRotation.setFromMatrix4( new THREE.Matrix4().makeRotationY( v ) );
+		ptRenderer.reset();
 
-				viewer.ptRenderer.material.environmentMap.dispose();
-				viewer.scene.environment.dispose();
-
-			}
-
-			const pmremGenerator = new PMREMGenerator( viewer.renderer );
-			pmremGenerator.compileCubemapShader();
-
-			const envMap = pmremGenerator.fromEquirectangular( texture );
-
-			texture.mapping = EquirectangularReflectionMapping;
-			viewer.ptRenderer.material.environmentIntensity = parseFloat( params.environmentIntensity );
-			viewer.ptRenderer.material.environmentMap = envMap.texture;
-			viewer.scene.environment = texture;
-			if ( params.backgroundType !== 'Gradient' ) {
-
-				viewer.scene.background = texture;
-
-			}
-
-			viewer.ptRenderer.reset();
-
-		} );
+	} );
+	gui.add( params, 'bounces', 1, 30, 1 ).onChange( () => ptRenderer.reset() );
+	gui.add( params, 'resolutionScale', 0.1, 1 ).onChange( () => onResize() );
 
 }
 
 async function updateModel( modelDocument ) {
 
-	if ( gui ) {
-
-		gui.destroy();
-		gui = null;
-
-	}
-
-	await MikkTSpace.ready;
-
+	scene.clear();
 	imageProvider.clear();
+	ptRenderer.reset();
 
 	const modelRootDef = modelDocument.getRoot();
 	const modelSceneDef = modelRootDef.getDefaultScene() || modelRootDef.listScenes()[0];
@@ -249,54 +155,92 @@ async function updateModel( modelDocument ) {
 
 	// center the model
 
-	const box = new Box3();
+	model.updateMatrixWorld();
+
+	const box = new THREE.Box3();
 	box.setFromObject( model );
 	model.position
 		.addScaledVector( box.min, - 0.5 )
 		.addScaledVector( box.max, - 0.5 );
 
-	const sphere = new Sphere();
+	const sphere = new THREE.Sphere();
 	box.getBoundingSphere( sphere );
 
 	model.scale.setScalar( 1 / sphere.radius );
 	model.position.multiplyScalar( 1 / sphere.radius );
 
+	scene.add( model );
+
 	// load the model
 
-	await viewer.setModel( model, { onProgress: v => {
+	const result = await generator.generate( scene );
 
-		const percent = Math.floor( 100 * v );
-		loadingEl.innerText = `Building BVH : ${ percent }%`;
+	sceneInfo = result;
 
-	} } );
+	const { bvh, textures, materials } = result;
+	const geometry = bvh.geometry;
+	const material = ptRenderer.material;
+
+	material.bvh.updateFrom( bvh );
+	material.normalAttribute.updateFrom( geometry.attributes.normal );
+	material.tangentAttribute.updateFrom( geometry.attributes.tangent );
+	material.uvAttribute.updateFrom( geometry.attributes.uv );
+	material.materialIndexAttribute.updateFrom( geometry.attributes.materialIndex );
+	material.textures.setTextures( renderer, 2048, 2048, textures );
+	material.materials.updateFrom( materials, textures );
+	material.setDefine( 'MATERIAL_LENGTH', materials.length );
+
+	generator.dispose();
 
 	loadingEl.style.visibility = 'hidden';
 
-	buildGui();
-
-	viewer.pausePathTracing = false;
-	viewer.renderer.domElement.style.visibility = 'visible';
-	viewer.ptRenderer.material.uniforms.floorHeight.value = - ( box.max.y - box.min.y ) / ( 2 * sphere.radius );
+	animate();
 
 }
 
-const stats = new Stats();
-document.body.appendChild( stats.dom );
-viewer.renderer.physicallyCorrectLights = true;
-viewer.renderer.toneMapping = ACESFilmicToneMapping;
-viewer.ptRenderer.material.setDefine( 'GRADIENT_BG', 1 );
-viewer.scene.background = new Color( 0x060606 );
-viewer.ptRenderer.tiles.set( params.tilesX, params.tilesY );
-viewer.setScale( params.resolutionScale );
-viewer.onRender = () => {
+function onResize() {
 
-	stats.update();
-	const samples = Math.floor( viewer.ptRenderer.samples );
-	samplesEl.innerText = `samples: ${ samples }`;
+	const w = window.innerWidth;
+	const h = window.innerHeight;
+	const scale = params.resolutionScale;
+	const dpr = window.devicePixelRatio;
 
-};
+	ptRenderer.target.setSize( w * scale * dpr, h * scale * dpr );
+	ptRenderer.reset();
 
-updateEnvMap();
+	renderer.setSize( w, h );
+	renderer.setPixelRatio( window.devicePixelRatio * scale );
+	camera.aspect = w / h;
+	camera.updateProjectionMatrix();
+
+}
+
+function animate() {
+
+	frameRequestID = requestAnimationFrame( animate );
+
+	ptRenderer.material.materials.updateFrom( sceneInfo.materials, sceneInfo.textures );
+
+	ptRenderer.material.filterGlossyFactor = params.filterGlossyFactor;
+	ptRenderer.material.environmentIntensity = params.environmentIntensity;
+	ptRenderer.material.environmentBlur = 0.35;
+	ptRenderer.material.bounces = params.bounces;
+
+	camera.updateMatrixWorld();
+
+	for ( let i = 0, l = params.samplesPerFrame; i < l; i ++ ) {
+
+		ptRenderer.update();
+
+	}
+
+	renderer.autoClear = false;
+	fsQuad.render( renderer );
+	renderer.autoClear = true;
+
+	samplesEl.innerText = `Samples: ${ Math.floor( ptRenderer.samples ) }`;
+
+}
 
 // drag-and-drop implementation
 
@@ -316,8 +260,8 @@ document.body.addEventListener('drop', ( e ) => {
 
 	e.preventDefault();
 
-	viewer.pausePathTracing = true;
-	viewer.renderer.domElement.style.visibility = 'hidden';
+	cancelAnimationFrame( frameRequestID );
+
 	samplesEl.innerText = '--';
 	creditEl.innerText = '--';
 	loadingEl.innerText = 'Parsing';
@@ -345,4 +289,3 @@ document.body.addEventListener('drop', ( e ) => {
 	});
 
 });
-

--- a/example/dragDrop.js
+++ b/example/dragDrop.js
@@ -1,0 +1,348 @@
+import { ACESFilmicToneMapping, NoToneMapping, Box3, LoadingManager, EquirectangularReflectionMapping, PMREMGenerator, Sphere, Color, DoubleSide } from 'three';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import { LDrawLoader } from 'three/examples/jsm/loaders/LDrawLoader.js';
+import { LDrawUtils } from 'three/examples/jsm/utils/LDrawUtils.js';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import { PathTracingViewer } from '../src/viewers/PathTracingViewer.js';
+import Stats from 'three/examples/jsm/libs/stats.module.js';
+
+import * as MikkTSpace from './lib/mikktspace.module.js';
+import { WebIO } from '@gltf-transform/core';
+import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
+import { metalRough } from '@gltf-transform/functions';
+import { DocumentView, ImageProvider } from '@gltf-transform/view';
+import { getFilesFromDataTransferItems } from "@placemarkio/flat-drop-files";
+
+const creditEl = document.getElementById( 'credits' );
+const loadingEl = document.getElementById( 'loading' );
+const samplesEl = document.getElementById( 'samples' );
+
+const viewer = new PathTracingViewer();
+viewer.init();
+viewer.domElement.style.width = '100%';
+viewer.domElement.style.height = '100%';
+document.body.appendChild( viewer.domElement );
+
+const io = new WebIO()
+	.registerExtensions(ALL_EXTENSIONS)
+	.registerDependencies({'meshopt.decoder': MeshoptDecoder});
+const imageProvider = new ImageProvider();
+
+const envMaps = {
+	'Royal Esplanade': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr',
+	'Moonless Golf': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/moonless_golf_1k.hdr',
+	'Overpass': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/pedestrian_overpass_1k.hdr',
+	'Venice Sunset': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/venice_sunset_1k.hdr',
+};
+
+const params = {
+
+	acesToneMapping: true,
+	resolutionScale: 0.75 / window.devicePixelRatio,
+	tilesX: 2,
+	tilesY: 2,
+	samplesPerFrame: 1,
+
+	environment: 'ENVMAP',
+	envMap: envMaps[ 'Royal Esplanade' ],
+
+	gradientTop: '#bfd8ff',
+	gradientBottom: '#ffffff',
+
+	environmentIntensity: 3.0,
+	environmentBlur: 0.35,
+
+	backgroundType: 'Gradient',
+	bgGradientTop: '#111111',
+	bgGradientBottom: '#000000',
+
+	enable: true,
+	bounces: 3,
+
+	floorColor: '#080808',
+	floorEnabled: true,
+
+};
+
+let gui = null;
+function buildGui() {
+
+	if ( gui ) {
+
+		gui.destroy();
+
+	}
+
+	gui = new GUI();
+
+	const resolutionFolder = gui.addFolder( 'resolution' );
+	resolutionFolder.add( params, 'resolutionScale', 0.1, 1.0, 0.01 ).onChange( v => {
+
+		viewer.setScale( parseFloat( v ) );
+
+	} );
+	resolutionFolder.add( params, 'samplesPerFrame', 1, 10, 1 ).onChange( v => {
+
+		viewer.samplesPerFrame = parseInt( v );
+
+	} );
+	resolutionFolder.add( params, 'tilesX', 1, 10, 1 ).onChange( v => {
+
+		viewer.ptRenderer.tiles.x = parseInt( v );
+
+	} );
+	resolutionFolder.add( params, 'tilesY', 1, 10, 1 ).onChange( v => {
+
+		viewer.ptRenderer.tiles.y = parseInt( v );
+
+	} );
+	resolutionFolder.open();
+
+	const environmentFolder = gui.addFolder( 'environment' );
+	environmentFolder.add( params, 'envMap', envMaps ).name( 'map' ).onChange( updateEnvMap );
+	environmentFolder.add( params, 'environmentBlur', 0.0, 1.0, 0.01 ).onChange( v => {
+
+		viewer.ptRenderer.material.environmentBlur = parseFloat( v );
+		viewer.ptRenderer.reset();
+
+	} ).name( 'env map blur' );
+	environmentFolder.add( params, 'environmentIntensity', 0.0, 10.0, 0.01 ).onChange( v => {
+
+		viewer.ptRenderer.material.environmentIntensity = parseFloat( v );
+		viewer.ptRenderer.reset();
+
+	} ).name( 'intensity' );
+	environmentFolder.open();
+
+	const backgroundFolder = gui.addFolder( 'background' );
+	backgroundFolder.add( params, 'backgroundType', [ 'Environment', 'Gradient' ] ).onChange( v => {
+
+		viewer.ptRenderer.material.setDefine( 'GRADIENT_BG', Number( v === 'Gradient' ) );
+		if ( v === 'Gradient' ) {
+
+			viewer.scene.background = new Color( 0x060606 );
+
+		} else {
+
+			viewer.scene.background = viewer.scene.environment;
+
+		}
+
+		viewer.ptRenderer.reset();
+
+	} );
+	backgroundFolder.addColor( params, 'bgGradientTop' ).onChange( v => {
+
+		viewer.ptRenderer.material.uniforms.bgGradientTop.value.set( v );
+		viewer.ptRenderer.reset();
+
+	} );
+	backgroundFolder.addColor( params, 'bgGradientBottom' ).onChange( v => {
+
+		viewer.ptRenderer.material.uniforms.bgGradientBottom.value.set( v );
+		viewer.ptRenderer.reset();
+
+	} );
+	backgroundFolder.open();
+
+	const floorFolder = gui.addFolder( 'floor' );
+	floorFolder.add( params, 'floorEnabled' ).onChange( v => {
+
+		viewer.ptRenderer.material.setDefine( 'DISPLAY_FLOOR', Number( v ) );
+		viewer.ptRenderer.reset();
+
+	} );
+	floorFolder.addColor( params, 'floorColor' ).onChange( v => {
+
+		viewer.ptRenderer.material.uniforms.floorColor.value.set( v );
+		viewer.ptRenderer.reset();
+
+	} );
+
+	const pathTracingFolder = gui.addFolder( 'path tracing' );
+	pathTracingFolder.add( params, 'enable' ).onChange( v => {
+
+		viewer.enablePathTracing = v;
+
+	} );
+	pathTracingFolder.add( params, 'acesToneMapping' ).onChange( v => {
+
+		viewer.renderer.toneMapping = v ? ACESFilmicToneMapping : NoToneMapping;
+		viewer.fsQuad.material.needsUpdate = true;
+
+	} );
+	pathTracingFolder.add( params, 'bounces', 1, 20, 1 ).onChange( v => {
+
+		viewer.ptRenderer.material.setDefine( 'BOUNCES', parseInt( v ) );
+		viewer.ptRenderer.reset();
+
+	} );
+	pathTracingFolder.open();
+
+}
+
+function updateEnvMap() {
+
+	new RGBELoader()
+		.load( params.envMap, texture => {
+
+			if ( viewer.ptRenderer.material.environmentMap ) {
+
+				viewer.ptRenderer.material.environmentMap.dispose();
+				viewer.scene.environment.dispose();
+
+			}
+
+			const pmremGenerator = new PMREMGenerator( viewer.renderer );
+			pmremGenerator.compileCubemapShader();
+
+			const envMap = pmremGenerator.fromEquirectangular( texture );
+
+			texture.mapping = EquirectangularReflectionMapping;
+			viewer.ptRenderer.material.environmentIntensity = parseFloat( params.environmentIntensity );
+			viewer.ptRenderer.material.environmentMap = envMap.texture;
+			viewer.scene.environment = texture;
+			if ( params.backgroundType !== 'Gradient' ) {
+
+				viewer.scene.background = texture;
+
+			}
+
+			viewer.ptRenderer.reset();
+
+		} );
+
+}
+
+async function updateModel( modelDocument ) {
+
+	if ( gui ) {
+
+		gui.destroy();
+		gui = null;
+
+	}
+
+	await MikkTSpace.ready;
+
+	imageProvider.clear();
+
+	const modelRootDef = modelDocument.getRoot();
+	const modelSceneDef = modelRootDef.getDefaultScene() || modelRootDef.listScenes()[0];
+	const extensionsUsed = modelDocument.getRoot().listExtensionsUsed();
+
+	// prepare model
+
+	if ( extensionsUsed.some( ( ext ) => ext.extensionName === 'KHR_materials_pbrSpecularGlossiness' ) ) {
+
+		await modelDocument.transform( metalRough() );
+
+	}
+
+	// create three.js view of glTF document
+
+	await imageProvider.update( modelRootDef.listTextures() );
+	const modelView = new DocumentView( modelDocument )
+		.setImageProvider( imageProvider );
+	const model = modelView.view( modelSceneDef );
+
+	// center the model
+
+	const box = new Box3();
+	box.setFromObject( model );
+	model.position
+		.addScaledVector( box.min, - 0.5 )
+		.addScaledVector( box.max, - 0.5 );
+
+	const sphere = new Sphere();
+	box.getBoundingSphere( sphere );
+
+	model.scale.setScalar( 1 / sphere.radius );
+	model.position.multiplyScalar( 1 / sphere.radius );
+
+	// load the model
+
+	await viewer.setModel( model, { onProgress: v => {
+
+		const percent = Math.floor( 100 * v );
+		loadingEl.innerText = `Building BVH : ${ percent }%`;
+
+	} } );
+
+	loadingEl.style.visibility = 'hidden';
+
+	buildGui();
+
+	viewer.pausePathTracing = false;
+	viewer.renderer.domElement.style.visibility = 'visible';
+	viewer.ptRenderer.material.uniforms.floorHeight.value = - ( box.max.y - box.min.y ) / ( 2 * sphere.radius );
+
+}
+
+const stats = new Stats();
+document.body.appendChild( stats.dom );
+viewer.renderer.physicallyCorrectLights = true;
+viewer.renderer.toneMapping = ACESFilmicToneMapping;
+viewer.ptRenderer.material.setDefine( 'GRADIENT_BG', 1 );
+viewer.scene.background = new Color( 0x060606 );
+viewer.ptRenderer.tiles.set( params.tilesX, params.tilesY );
+viewer.setScale( params.resolutionScale );
+viewer.onRender = () => {
+
+	stats.update();
+	const samples = Math.floor( viewer.ptRenderer.samples );
+	samplesEl.innerText = `samples: ${ samples }`;
+
+};
+
+updateEnvMap();
+
+// drag-and-drop implementation
+
+document.body.addEventListener( 'dragenter', ( e ) => {
+
+	e.preventDefault();
+
+});
+
+document.body.addEventListener( 'dragover', ( e ) => {
+
+	e.preventDefault();
+
+});
+
+document.body.addEventListener('drop', ( e ) => {
+
+	e.preventDefault();
+
+	viewer.pausePathTracing = true;
+	viewer.renderer.domElement.style.visibility = 'hidden';
+	samplesEl.innerText = '--';
+	creditEl.innerText = '--';
+	loadingEl.innerText = 'Parsing';
+	loadingEl.style.visibility = 'visible';
+
+	getFilesFromDataTransferItems( e.dataTransfer.items ).then( async ( files ) => {
+
+		for ( const file of files ) {
+
+			if ( file.name.endsWith( '.glb' ) ) {
+
+				const arrayBuffer = await file.arrayBuffer();
+				const modelJSONDocument = await io.binaryToJSON( new Uint8Array( arrayBuffer ) );
+				const modelDocument = await io.readJSON( modelJSONDocument );
+
+				creditEl.innerText = JSON.stringify( modelJSONDocument.json.asset, null, 2 );
+
+				updateModel( modelDocument );
+				return;
+
+			}
+
+		}
+
+	});
+
+});
+

--- a/example/dragDrop.js
+++ b/example/dragDrop.js
@@ -1,6 +1,5 @@
 import * as THREE from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { PathTracingRenderer, PhysicalPathTracingMaterial } from '../src/index.js';
 import { PathTracingSceneWorker } from '../src/workers/PathTracingSceneWorker.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,11 @@
         "three-mesh-bvh": "^0.5.10"
       },
       "devDependencies": {
+        "@gltf-transform/core": "^2.1.5",
+        "@gltf-transform/extensions": "^2.1.5",
+        "@gltf-transform/functions": "^2.1.5",
+        "@gltf-transform/view": "^0.4.4",
+        "@placemarkio/flat-drop-files": "^1.0.1",
         "concurrently": "^6.3.0",
         "eslint": "^7.32.0",
         "eslint-config-mdcs": "^5.0.0",
@@ -146,6 +151,53 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@gltf-transform/core": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/core/-/core-2.1.5.tgz",
+      "integrity": "sha512-730+fAPNwabMmH2RRH4aQuzS+Iys7Cd4TIjlQRk8kzb4Un77tNIIGsTvP0VIClSa2GkNrErN9y8ue0/9AQ/aiA==",
+      "dev": true,
+      "dependencies": {
+        "gl-matrix": "~3.4.3",
+        "property-graph": "^0.2.6"
+      }
+    },
+    "node_modules/@gltf-transform/extensions": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/extensions/-/extensions-2.1.5.tgz",
+      "integrity": "sha512-AvSE30gCMtmwJI1DG4cqYQrN0JnHRGUxh1ZbhPGTcjK9D0pPuxYhE4xh29KBnyXfTyNAN/XDIEdKucKeSVf6eA==",
+      "dev": true,
+      "dependencies": {
+        "@gltf-transform/core": "^2.1.5",
+        "ktx-parse": "^0.2.2"
+      }
+    },
+    "node_modules/@gltf-transform/functions": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/functions/-/functions-2.1.5.tgz",
+      "integrity": "sha512-2mtlFyHlP9ckXaQITCPsSCu4Ut4bJBp+v5EG/d1a2Rw7AjWVof+Xc7/iPcd03Tro+d0OnfQgJ60zJvX/+3aA/A==",
+      "dev": true,
+      "dependencies": {
+        "@gltf-transform/core": "^2.1.5",
+        "@gltf-transform/extensions": "^2.1.5",
+        "gl-matrix": "~3.4.3",
+        "ndarray": "^1.0.19",
+        "ndarray-lanczos": "^0.1.2",
+        "ndarray-pixels": "^1.0.0"
+      }
+    },
+    "node_modules/@gltf-transform/view": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/view/-/view-0.4.4.tgz",
+      "integrity": "sha512-Zsqs2lWmY6aAvaAOm6iRTOWJ2Wv2ZwpjpN9HKOiq6h2/wO8g3Hlzc6j2SxGIGfO2D8hj6ErcuPrroVSbdToqpw==",
+      "dev": true,
+      "dependencies": {
+        "@gltf-transform/core": "^2.1.4"
+      },
+      "peerDependencies": {
+        "@types/three": ">=0.130.0",
+        "three": ">=0.130.1"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1469,6 +1521,12 @@
         "@parcel/core": "^2.4.0"
       }
     },
+    "node_modules/@placemarkio/flat-drop-files": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@placemarkio/flat-drop-files/-/flat-drop-files-1.0.1.tgz",
+      "integrity": "sha512-TLx/pyPBPMsaVXLNRqwviQYSXEEpviSRcLgXdrAFsMUBI/hZobToYVvsTnYcB3XM/ahkKpJZtvp/MQKZGGbsGQ==",
+      "dev": true
+    },
     "node_modules/@swc/helpers": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.8.tgz",
@@ -1484,11 +1542,24 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@types/ndarray": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.11.tgz",
+      "integrity": "sha512-hOZVTN24zDHwCHaW7mF9n1vHJt83fZhNZ0YYRBwQGhA96yBWWDPTDDlqJatagHIOJB0a4xoNkNc+t/Cxd+6qUA==",
+      "dev": true
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "node_modules/@types/three": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.139.0.tgz",
+      "integrity": "sha512-4V/jZhyq7Mv05coUzxL3bz8AuBOSi/1F0RY7ujisHTV0Amy/fnYJ+s7TSJ1/hXjZukSkpuFRgV+wvWUEMbsMbQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.3",
@@ -1575,6 +1646,24 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -1583,6 +1672,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1597,6 +1707,15 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/boolbase": {
@@ -1675,6 +1794,12 @@
         }
       ]
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1750,6 +1875,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -1786,6 +1923,24 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/contentstream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/contentstream/-/contentstream-1.0.0.tgz",
+      "integrity": "sha1-C9z6RtowRkqGzo+n7OVlQQ3G+aU=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~1.0.33-1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -1870,6 +2025,33 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+      "dev": true,
+      "dependencies": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.3.tgz",
+      "integrity": "sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo=",
+      "dev": true
+    },
     "node_modules/date-fns": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
@@ -1905,6 +2087,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -2008,6 +2199,16 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.94",
@@ -2280,6 +2481,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2329,6 +2545,29 @@
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2364,6 +2603,25 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-pixels": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/get-pixels/-/get-pixels-3.3.3.tgz",
+      "integrity": "sha512-5kyGBn90i9tSMUVHTqkgCHsoWoR+/lGbl4yC83Gefyr0HLIhgSWEx/2F/3YgsZ7UpYNuM6pDhDK7zebrUJ5nXg==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "0.0.3",
+        "jpeg-js": "^0.4.1",
+        "mime-types": "^2.0.1",
+        "ndarray": "^1.0.13",
+        "ndarray-pack": "^1.1.1",
+        "node-bitmap": "0.0.1",
+        "omggif": "^1.0.5",
+        "parse-data-uri": "^0.2.0",
+        "pngjs": "^3.3.3",
+        "request": "^2.44.0",
+        "through": "^2.3.4"
+      }
+    },
     "node_modules/get-port": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
@@ -2372,6 +2630,45 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/gif-encoder": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/gif-encoder/-/gif-encoder-0.4.3.tgz",
+      "integrity": "sha1-iitP6MqJWkjjoLbLs0CgpqNXGJk=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~1.1.9"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/gif-encoder/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
+      "dev": true
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -2418,6 +2715,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/has-flag": {
@@ -2495,6 +2815,21 @@
         "entities": "^3.0.1"
       }
     },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -2545,10 +2880,22 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc=",
+      "dev": true
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "node_modules/is-extglob": {
@@ -2587,10 +2934,34 @@
       "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=",
       "dev": true
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
+      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
       "dev": true
     },
     "node_modules/js-tokens": {
@@ -2612,10 +2983,22 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -2636,6 +3019,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
@@ -2647,6 +3036,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/ktx-parse": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.2.2.tgz",
+      "integrity": "sha512-cFBc1jnGG2WlUf52NbDUXK2obJ+Mo9WUkBRvr6tP6CKxRMvZwDDFNV3JAS4cewETp5KyexByfWm9sm+O8AffiQ==",
+      "dev": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -2717,6 +3127,27 @@
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "dev": true
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2768,11 +3199,72 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "dev": true,
+      "dependencies": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "node_modules/ndarray-lanczos": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ndarray-lanczos/-/ndarray-lanczos-0.1.2.tgz",
+      "integrity": "sha512-o3dCYwaN0q4rDrhFx+1eMnyn3FIVL66xbpbKpuWb4UtGAwdgRWFc1iWyeCs8aW7fAklkJxLvqAnxDtiRB+Yf4g==",
+      "dev": true,
+      "dependencies": {
+        "@types/ndarray": "^1.0.10",
+        "ndarray": "^1.0.19"
+      }
+    },
+    "node_modules/ndarray-ops": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
+      "dev": true,
+      "dependencies": {
+        "cwise-compiler": "^1.0.0"
+      }
+    },
+    "node_modules/ndarray-pack": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
+      "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
+      "dev": true,
+      "dependencies": {
+        "cwise-compiler": "^1.1.2",
+        "ndarray": "^1.0.13"
+      }
+    },
+    "node_modules/ndarray-pixels": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ndarray-pixels/-/ndarray-pixels-1.0.0.tgz",
+      "integrity": "sha512-vJlxc6yM5uCyQbmGacanhEleG5Ha5NoLZojQh14VitIjf2W0EVwKc06BUayoyKkn8ISVXWDBfL3UQc708/MpgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ndarray": "^1.0.10",
+        "get-pixels": "^3.3.3",
+        "ndarray": "^1.0.19",
+        "ndarray-ops": "^1.2.2",
+        "save-pixels": "^2.3.6"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
       "dev": true
+    },
+    "node_modules/node-bitmap": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/node-bitmap/-/node-bitmap-0.0.1.tgz",
+      "integrity": "sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE=",
+      "dev": true,
+      "engines": {
+        "node": ">=v0.6.5"
+      }
     },
     "node_modules/node-gyp-build": {
       "version": "4.3.0",
@@ -2807,6 +3299,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
       "dev": true
     },
     "node_modules/once": {
@@ -2885,6 +3392,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-data-uri": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/parse-data-uri/-/parse-data-uri-0.2.0.tgz",
+      "integrity": "sha1-vwTYUd1ch7CrI45dAazklLYEtMk=",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "0.0.3"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -2930,11 +3446,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
+    },
+    "node_modules/pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pngjs-nozlib": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs-nozlib/-/pngjs-nozlib-1.0.0.tgz",
+      "integrity": "sha1-nmTWAs/pzOTZ1Zl9BodCmnPwt9c=",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
@@ -3018,6 +3559,36 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/property-graph": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/property-graph/-/property-graph-0.2.6.tgz",
+      "integrity": "sha512-QiBHxNZlwIarbkxsqCY688aP1ANbwtoQFBYgTZopQ0Bvku6/EYp3H4KH0ygxkhWQbJv5DEONspLy1rHi5xIycg==",
+      "dev": true
+    },
+    "node_modules/psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
@@ -3025,6 +3596,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -3043,6 +3626,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-directory": {
@@ -3134,6 +3749,27 @@
         }
       ]
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/save-pixels": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/save-pixels/-/save-pixels-2.3.6.tgz",
+      "integrity": "sha512-/ayfEWBxt0tFpf5lxSU1S0+/TBn7EiaTZD+6GL+mwizHm3BKCBysnzT6Js7BusDUVcNVLkeJJKLZcBgdpM2leQ==",
+      "dev": true,
+      "dependencies": {
+        "contentstream": "^1.0.0",
+        "gif-encoder": "~0.4.1",
+        "jpeg-js": "^0.4.3",
+        "ndarray": "^1.0.18",
+        "ndarray-ops": "^1.2.2",
+        "pngjs-nozlib": "^1.0.0",
+        "through": "^2.3.4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -3218,10 +3854,41 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "node_modules/string-width": {
@@ -3412,11 +4079,30 @@
         "three": ">= 0.123.0"
       }
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "node_modules/timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -3431,6 +4117,24 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "node_modules/type-check": {
@@ -3457,6 +4161,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3464,15 +4174,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uri-js/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/utility-types": {
@@ -3484,10 +4185,40 @@
         "node": ">= 4"
       }
     },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "node_modules/weak-lru-cache": {
@@ -3707,6 +4438,49 @@
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@gltf-transform/core": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/core/-/core-2.1.5.tgz",
+      "integrity": "sha512-730+fAPNwabMmH2RRH4aQuzS+Iys7Cd4TIjlQRk8kzb4Un77tNIIGsTvP0VIClSa2GkNrErN9y8ue0/9AQ/aiA==",
+      "dev": true,
+      "requires": {
+        "gl-matrix": "~3.4.3",
+        "property-graph": "^0.2.6"
+      }
+    },
+    "@gltf-transform/extensions": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/extensions/-/extensions-2.1.5.tgz",
+      "integrity": "sha512-AvSE30gCMtmwJI1DG4cqYQrN0JnHRGUxh1ZbhPGTcjK9D0pPuxYhE4xh29KBnyXfTyNAN/XDIEdKucKeSVf6eA==",
+      "dev": true,
+      "requires": {
+        "@gltf-transform/core": "^2.1.5",
+        "ktx-parse": "^0.2.2"
+      }
+    },
+    "@gltf-transform/functions": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/functions/-/functions-2.1.5.tgz",
+      "integrity": "sha512-2mtlFyHlP9ckXaQITCPsSCu4Ut4bJBp+v5EG/d1a2Rw7AjWVof+Xc7/iPcd03Tro+d0OnfQgJ60zJvX/+3aA/A==",
+      "dev": true,
+      "requires": {
+        "@gltf-transform/core": "^2.1.5",
+        "@gltf-transform/extensions": "^2.1.5",
+        "gl-matrix": "~3.4.3",
+        "ndarray": "^1.0.19",
+        "ndarray-lanczos": "^0.1.2",
+        "ndarray-pixels": "^1.0.0"
+      }
+    },
+    "@gltf-transform/view": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/view/-/view-0.4.4.tgz",
+      "integrity": "sha512-Zsqs2lWmY6aAvaAOm6iRTOWJ2Wv2ZwpjpN9HKOiq6h2/wO8g3Hlzc6j2SxGIGfO2D8hj6ErcuPrroVSbdToqpw==",
+      "dev": true,
+      "requires": {
+        "@gltf-transform/core": "^2.1.4"
       }
     },
     "@humanwhocodes/config-array": {
@@ -4520,6 +5294,12 @@
         "nullthrows": "^1.1.1"
       }
     },
+    "@placemarkio/flat-drop-files": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@placemarkio/flat-drop-files/-/flat-drop-files-1.0.1.tgz",
+      "integrity": "sha512-TLx/pyPBPMsaVXLNRqwviQYSXEEpviSRcLgXdrAFsMUBI/hZobToYVvsTnYcB3XM/ahkKpJZtvp/MQKZGGbsGQ==",
+      "dev": true
+    },
     "@swc/helpers": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.8.tgz",
@@ -4532,11 +5312,24 @@
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true
     },
+    "@types/ndarray": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.11.tgz",
+      "integrity": "sha512-hOZVTN24zDHwCHaW7mF9n1vHJt83fZhNZ0YYRBwQGhA96yBWWDPTDDlqJatagHIOJB0a4xoNkNc+t/Cxd+6qUA==",
+      "dev": true
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/three": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.139.0.tgz",
+      "integrity": "sha512-4V/jZhyq7Mv05coUzxL3bz8AuBOSi/1F0RY7ujisHTV0Amy/fnYJ+s7TSJ1/hXjZukSkpuFRgV+wvWUEMbsMbQ==",
+      "dev": true,
+      "peer": true
     },
     "abortcontroller-polyfill": {
       "version": "1.7.3",
@@ -4599,10 +5392,43 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
     "balanced-match": {
@@ -4618,6 +5444,15 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "boolbase": {
@@ -4665,6 +5500,12 @@
       "version": "1.0.30001320",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
       "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chalk": {
@@ -4726,6 +5567,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -4753,6 +5603,21 @@
         "tree-kill": "^1.2.2",
         "yargs": "^16.2.0"
       }
+    },
+    "contentstream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/contentstream/-/contentstream-1.0.0.tgz",
+      "integrity": "sha1-C9z6RtowRkqGzo+n7OVlQQ3G+aU=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.0.33-1"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -4816,6 +5681,30 @@
         "css-tree": "^1.1.2"
       }
     },
+    "cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+      "dev": true,
+      "requires": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-uri-to-buffer": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.3.tgz",
+      "integrity": "sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo=",
+      "dev": true
+    },
     "date-fns": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
@@ -4835,6 +5724,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "detect-libc": {
@@ -4908,6 +5803,16 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "electron-to-chromium": {
       "version": "1.4.94",
@@ -5115,6 +6020,18 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5158,6 +6075,23 @@
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5183,10 +6117,67 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-pixels": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/get-pixels/-/get-pixels-3.3.3.tgz",
+      "integrity": "sha512-5kyGBn90i9tSMUVHTqkgCHsoWoR+/lGbl4yC83Gefyr0HLIhgSWEx/2F/3YgsZ7UpYNuM6pDhDK7zebrUJ5nXg==",
+      "dev": true,
+      "requires": {
+        "data-uri-to-buffer": "0.0.3",
+        "jpeg-js": "^0.4.1",
+        "mime-types": "^2.0.1",
+        "ndarray": "^1.0.13",
+        "ndarray-pack": "^1.1.1",
+        "node-bitmap": "0.0.1",
+        "omggif": "^1.0.5",
+        "parse-data-uri": "^0.2.0",
+        "pngjs": "^3.3.3",
+        "request": "^2.44.0",
+        "through": "^2.3.4"
+      }
+    },
     "get-port": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
       "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "gif-encoder": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/gif-encoder/-/gif-encoder-0.4.3.tgz",
+      "integrity": "sha1-iitP6MqJWkjjoLbLs0CgpqNXGJk=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.1.9"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
+    "gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
       "dev": true
     },
     "glob": {
@@ -5221,6 +6212,22 @@
         "type-fest": "^0.20.2"
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5248,6 +6255,17 @@
         "domhandler": "^4.2.2",
         "domutils": "^2.8.0",
         "entities": "^3.0.1"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "ignore": {
@@ -5288,10 +6306,22 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc=",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-extglob": {
@@ -5321,10 +6351,34 @@
       "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=",
       "dev": true
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jpeg-js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
+      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
       "dev": true
     },
     "js-tokens": {
@@ -5343,10 +6397,22 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -5367,10 +6433,34 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
+    },
+    "ktx-parse": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.2.2.tgz",
+      "integrity": "sha512-cFBc1jnGG2WlUf52NbDUXK2obJ+Mo9WUkBRvr6tP6CKxRMvZwDDFNV3JAS4cewETp5KyexByfWm9sm+O8AffiQ==",
       "dev": true
     },
     "levn": {
@@ -5435,6 +6525,21 @@
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5482,10 +6587,68 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "dev": true,
+      "requires": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "ndarray-lanczos": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ndarray-lanczos/-/ndarray-lanczos-0.1.2.tgz",
+      "integrity": "sha512-o3dCYwaN0q4rDrhFx+1eMnyn3FIVL66xbpbKpuWb4UtGAwdgRWFc1iWyeCs8aW7fAklkJxLvqAnxDtiRB+Yf4g==",
+      "dev": true,
+      "requires": {
+        "@types/ndarray": "^1.0.10",
+        "ndarray": "^1.0.19"
+      }
+    },
+    "ndarray-ops": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
+      "dev": true,
+      "requires": {
+        "cwise-compiler": "^1.0.0"
+      }
+    },
+    "ndarray-pack": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
+      "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
+      "dev": true,
+      "requires": {
+        "cwise-compiler": "^1.1.2",
+        "ndarray": "^1.0.13"
+      }
+    },
+    "ndarray-pixels": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ndarray-pixels/-/ndarray-pixels-1.0.0.tgz",
+      "integrity": "sha512-vJlxc6yM5uCyQbmGacanhEleG5Ha5NoLZojQh14VitIjf2W0EVwKc06BUayoyKkn8ISVXWDBfL3UQc708/MpgQ==",
+      "dev": true,
+      "requires": {
+        "@types/ndarray": "^1.0.10",
+        "get-pixels": "^3.3.3",
+        "ndarray": "^1.0.19",
+        "ndarray-ops": "^1.2.2",
+        "save-pixels": "^2.3.6"
+      }
+    },
     "node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true
+    },
+    "node-bitmap": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/node-bitmap/-/node-bitmap-0.0.1.tgz",
+      "integrity": "sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE=",
       "dev": true
     },
     "node-gyp-build": {
@@ -5513,6 +6676,18 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
       "dev": true
     },
     "once": {
@@ -5575,6 +6750,15 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-data-uri": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/parse-data-uri/-/parse-data-uri-0.2.0.tgz",
+      "integrity": "sha1-vwTYUd1ch7CrI45dAazklLYEtMk=",
+      "dev": true,
+      "requires": {
+        "data-uri-to-buffer": "0.0.3"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5605,10 +6789,28 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "dev": true
+    },
+    "pngjs-nozlib": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs-nozlib/-/pngjs-nozlib-1.0.0.tgz",
+      "integrity": "sha1-nmTWAs/pzOTZ1Zl9BodCmnPwt9c=",
       "dev": true
     },
     "postcss-value-parser": {
@@ -5674,11 +6876,47 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "property-graph": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/property-graph/-/property-graph-0.2.6.tgz",
+      "integrity": "sha512-QiBHxNZlwIarbkxsqCY688aP1ANbwtoQFBYgTZopQ0Bvku6/EYp3H4KH0ygxkhWQbJv5DEONspLy1rHi5xIycg==",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true
+    },
     "react-refresh": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
       "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
       "dev": true
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
     },
     "regenerator-runtime": {
       "version": "0.13.9",
@@ -5691,6 +6929,34 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -5742,6 +7008,27 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "save-pixels": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/save-pixels/-/save-pixels-2.3.6.tgz",
+      "integrity": "sha512-/ayfEWBxt0tFpf5lxSU1S0+/TBn7EiaTZD+6GL+mwizHm3BKCBysnzT6Js7BusDUVcNVLkeJJKLZcBgdpM2leQ==",
+      "dev": true,
+      "requires": {
+        "contentstream": "^1.0.0",
+        "gif-encoder": "~0.4.1",
+        "jpeg-js": "^0.4.3",
+        "ndarray": "^1.0.18",
+        "ndarray-ops": "^1.2.2",
+        "pngjs-nozlib": "^1.0.0",
+        "through": "^2.3.4"
+      }
     },
     "semver": {
       "version": "7.3.5",
@@ -5806,10 +7093,33 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "string-width": {
@@ -5950,11 +7260,27 @@
       "integrity": "sha512-yOJPT3DhfZB/DvIr0lEfPUPMRX11HJABGapeuBa4GwgsF1NMMsy1nW1wMGxImmVyRCZ61yoor/YVqRRQV1p5VQ==",
       "requires": {}
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -5966,6 +7292,21 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
@@ -5983,6 +7324,12 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5990,14 +7337,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "dev": true
-        }
       }
     },
     "utility-types": {
@@ -6006,11 +7345,36 @@
       "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
       "dev": true
     },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        }
+      }
     },
     "weak-lru-cache": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "three-mesh-bvh": "^0.5.10"
   },
   "devDependencies": {
-    "@gltf-transform/core": "^2.0.5",
-    "@gltf-transform/extensions": "^2.0.5",
-    "@gltf-transform/functions": "^2.0.5",
-    "@gltf-transform/view": "^0.3.0",
+    "@gltf-transform/core": "^2.1.5",
+    "@gltf-transform/extensions": "^2.1.5",
+    "@gltf-transform/functions": "^2.1.5",
+    "@gltf-transform/view": "^0.4.4",
     "@placemarkio/flat-drop-files": "^1.0.1",
     "concurrently": "^6.3.0",
     "eslint": "^7.32.0",
@@ -62,5 +62,8 @@
   "bugs": {
     "url": "https://github.com/gkjohnson/three-gpu-pathtracer/issues"
   },
-  "homepage": "https://github.com/gkjohnson/three-gpu-pathtracer#readme"
+  "homepage": "https://github.com/gkjohnson/three-gpu-pathtracer#readme",
+  "alias": {
+    "buffer": false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
     "three-mesh-bvh": "^0.5.10"
   },
   "devDependencies": {
+    "@gltf-transform/core": "^2.0.5",
+    "@gltf-transform/extensions": "^2.0.5",
+    "@gltf-transform/functions": "^2.0.5",
+    "@gltf-transform/view": "^0.3.0",
+    "@placemarkio/flat-drop-files": "^1.0.1",
     "concurrently": "^6.3.0",
     "eslint": "^7.32.0",
     "eslint-config-mdcs": "^5.0.0",


### PR DESCRIPTION
Totally unsure if this PR is something you actually want in the example, but was a fun way to try out `three-gpu-pathtracer` and let me kick the tires on [`@gltf-transform/view`](https://github.com/donmccurdy/glTF-Transform-View/) at the same time. ~~Adds support in the AO example for drag-and-drop of GLB files, and has an export button (working, minus the AO texture itself) as well.~~ Adds an example of drag-and-drop viewing using the path tracer.

~Related:~

- ~#33~