### PR TITLE
Add Transmission

### DIFF
--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -51,6 +51,7 @@ const params = {
 if ( window.location.hash.includes( 'transmission' ) ) {
 
 	params.material1.metalness = 0.0;
+	params.material1.roughness = 0.05;
 	params.material1.transmission = 1.0;
 	params.material1.color = '#ffffff';
 	params.bounces = 15;

--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -48,6 +48,15 @@ const params = {
 
 };
 
+if ( window.location.hash.includes( 'transmission' ) ) {
+
+	params.material1.metalness = 0.0;
+	params.material1.transmission = 1.0;
+	params.material1.color = '#ffffff';
+	params.bounces = 15;
+
+}
+
 init();
 
 async function init() {

--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -18,7 +18,7 @@ const params = {
 		emissiveIntensity: 1,
 		roughness: 0.1,
 		metalness: 0.8,
-		ior: 1.0,
+		ior: 1.495,
 		transmission: 0.0,
 		opacity: 1.0,
 	},
@@ -28,8 +28,8 @@ const params = {
 		emissiveIntensity: 1,
 		roughness: 0.8,
 		metalness: 0.1,
-		ior: 1.0,
 		transmission: 0.0,
+		ior: 1.495,
 		opacity: 1.0,
 	},
 	material3: {
@@ -39,12 +39,12 @@ const params = {
 	},
 	resetSeed: true,
 	environmentIntensity: 3,
-	bounces: 4,
+	bounces: 5,
 	samplesPerFrame: 1,
 	acesToneMapping: true,
 	resolutionScale: 1.0 / window.devicePixelRatio,
 	transparentTraversals: 20,
-	filterGlossyFactor: 0.25,
+	filterGlossyFactor: 0.5,
 
 };
 
@@ -207,7 +207,7 @@ async function init() {
 		ptRenderer.reset();
 
 	} );
-	ptFolder.add( params, 'bounces', 1, 10, 1 ).onChange( value => {
+	ptFolder.add( params, 'bounces', 1, 30, 1 ).onChange( value => {
 
 		ptRenderer.material.setDefine( 'BOUNCES', value );
 		ptRenderer.reset();
@@ -233,7 +233,7 @@ async function init() {
 	matFolder1.add( params.material1, 'metalness', 0, 1 ).onChange( reset );
 	matFolder1.add( params.material1, 'opacity', 0, 1 ).onChange( reset );
 	matFolder1.add( params.material1, 'transmission', 0, 1 ).onChange( reset );
-	matFolder1.add( params.material1, 'ior', 0.5, 2.0 ).onChange( reset );
+	matFolder1.add( params.material1, 'ior', 0.9, 3.0 ).onChange( reset );
 	matFolder1.open();
 
 	const matFolder2 = gui.addFolder( 'Ball Material' );
@@ -244,7 +244,7 @@ async function init() {
 	matFolder2.add( params.material2, 'metalness', 0, 1 ).onChange( reset );
 	matFolder2.add( params.material2, 'opacity', 0, 1 ).onChange( reset );
 	matFolder2.add( params.material2, 'transmission', 0, 1 ).onChange( reset );
-	matFolder2.add( params.material2, 'ior', 0.5, 2 ).onChange( reset );
+	matFolder2.add( params.material2, 'ior', 0.9, 3.0 ).onChange( reset );
 	matFolder2.open();
 
 	const matFolder3 = gui.addFolder( 'Floor Material' );

--- a/src/materials/PathTracingMaterial.js
+++ b/src/materials/PathTracingMaterial.js
@@ -294,7 +294,6 @@ export class PathTracingMaterial extends ShaderMaterial {
 							1.0
 						);
 
-						// TODO: transform into local basis and then back out
 						mat3 normalBasis = getBasisFromNormal( normal );
 						mat3 invBasis = inverse( normalBasis );
 

--- a/src/materials/PathTracingMaterial.js
+++ b/src/materials/PathTracingMaterial.js
@@ -280,11 +280,12 @@ export class PathTracingMaterial extends ShaderMaterial {
 						materialRec.emission = emission;
 						materialRec.metalness = metalness;
 						materialRec.color = albedo.rgb;
+						materialRec.roughness = roughness;
 
 						// compute the filtered roughness value to use during specular reflection computations. A minimum
 						// value of 1e-6 is needed because the GGX functions do not work with a roughness value of 0 and
 						// the accumulated roughness value is scaled by a user setting and a "magic value" of 5.0.
-						materialRec.roughness = clamp(
+						materialRec.filteredRoughness = clamp(
 							max( material.roughness, accumulatedRoughness * filterGlossyFactor * 5.0 ),
 							1e-3,
 							1.0
@@ -293,7 +294,6 @@ export class PathTracingMaterial extends ShaderMaterial {
 						SurfaceRec surfaceRec;
 						surfaceRec.normal = normal;
 						surfaceRec.faceNormal = faceNormal;
-						surfaceRec.filteredRoughness = materialRec.roughness; // TODO: do we need this?
 						surfaceRec.frontFace = side == 1.0;
 
 						// TODO: transform into local basis and then back out

--- a/src/materials/PathTracingMaterial.js
+++ b/src/materials/PathTracingMaterial.js
@@ -247,6 +247,14 @@ export class PathTracingMaterial extends ShaderMaterial {
 
 						}
 
+						// transmission
+						float transmission = material.transmission;
+						if ( material.transmissionMap != - 1 ) {
+
+							transmission *= texture2D( textures, vec3( uv, material.transmissionMap ) ).r;
+
+						}
+
 						// normal
 						if ( material.normalMap != - 1 ) {
 
@@ -278,7 +286,7 @@ export class PathTracingMaterial extends ShaderMaterial {
 						surfaceRec.normal = normal;
 						surfaceRec.faceNormal = faceNormal;
 						surfaceRec.frontFace = side == 1.0;
-						surfaceRec.transmission = material.transmission;
+						surfaceRec.transmission = transmission;
 						surfaceRec.ior = material.ior;
 						surfaceRec.emission = emission;
 						surfaceRec.metalness = metalness;

--- a/src/materials/PathTracingMaterial.js
+++ b/src/materials/PathTracingMaterial.js
@@ -274,34 +274,32 @@ export class PathTracingMaterial extends ShaderMaterial {
 
 						normal *= side;
 
-						MaterialRec materialRec;
-						materialRec.transmission = material.transmission;
-						materialRec.ior = material.ior;
-						materialRec.emission = emission;
-						materialRec.metalness = metalness;
-						materialRec.color = albedo.rgb;
-						materialRec.roughness = roughness;
+						SurfaceRec surfaceRec;
+						surfaceRec.normal = normal;
+						surfaceRec.faceNormal = faceNormal;
+						surfaceRec.frontFace = side == 1.0;
+						surfaceRec.transmission = material.transmission;
+						surfaceRec.ior = material.ior;
+						surfaceRec.emission = emission;
+						surfaceRec.metalness = metalness;
+						surfaceRec.color = albedo.rgb;
+						surfaceRec.roughness = roughness;
 
 						// compute the filtered roughness value to use during specular reflection computations. A minimum
 						// value of 1e-6 is needed because the GGX functions do not work with a roughness value of 0 and
 						// the accumulated roughness value is scaled by a user setting and a "magic value" of 5.0.
-						materialRec.filteredRoughness = clamp(
+						surfaceRec.filteredRoughness = clamp(
 							max( material.roughness, accumulatedRoughness * filterGlossyFactor * 5.0 ),
 							1e-3,
 							1.0
 						);
 
-						SurfaceRec surfaceRec;
-						surfaceRec.normal = normal;
-						surfaceRec.faceNormal = faceNormal;
-						surfaceRec.frontFace = side == 1.0;
-
 						// TODO: transform into local basis and then back out
-						mat3 normalBasis = getBasisFromNormal( surfaceRec.normal );
+						mat3 normalBasis = getBasisFromNormal( normal );
 						mat3 invBasis = inverse( normalBasis );
 
 						vec3 outgoing = - normalize( invBasis * rayDirection );
-						SampleRec sampleRec = bsdfSample( outgoing, surfaceRec, materialRec );
+						SampleRec sampleRec = bsdfSample( outgoing, surfaceRec );
 
 						// determine if this is a rough normal or not by checking how far off straight up it is
 						vec3 halfVector = normalize( outgoing + sampleRec.direction );

--- a/src/materials/PathTracingMaterial.js
+++ b/src/materials/PathTracingMaterial.js
@@ -285,11 +285,13 @@ export class PathTracingMaterial extends ShaderMaterial {
 						surfaceRec.color = albedo.rgb;
 						surfaceRec.roughness = roughness;
 
-						// compute the filtered roughness value to use during specular reflection computations. A minimum
+						// Compute the filtered roughness value to use during specular reflection computations. A minimum
 						// value of 1e-6 is needed because the GGX functions do not work with a roughness value of 0 and
 						// the accumulated roughness value is scaled by a user setting and a "magic value" of 5.0.
+						// If we're exiting something transmissive then scale the factor down significantly so we can retain
+						// sharp internal reflections
 						surfaceRec.filteredRoughness = clamp(
-							max( material.roughness, accumulatedRoughness * filterGlossyFactor * 5.0 ),
+							max( material.roughness, accumulatedRoughness * filterGlossyFactor * ( side == - 1.0 ? 0.05 : 5.0 ) ),
 							1e-3,
 							1.0
 						);

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -3,12 +3,12 @@ export const shaderMaterialSampling = /* glsl */`
 struct SurfaceRec {
 	vec3 normal;
 	vec3 faceNormal;
-	float filteredRoughness;
 	bool frontFace;
 };
 
 struct MaterialRec {
 	float roughness;
+	float filteredRoughness;
 	float metalness;
 	vec3 color;
 	vec3 emission;
@@ -56,7 +56,7 @@ vec3 diffuseColor( vec3 wo, vec3 wi, MaterialRec material, SurfaceRec hit ) {
 float specularPDF( vec3 wo, vec3 wi, MaterialRec material, SurfaceRec hit ) {
 
 	// See equation (17) in http://jcgt.org/published/0003/02/03/
-	float filteredRoughness = hit.filteredRoughness;
+	float filteredRoughness = material.filteredRoughness;
 	vec3 halfVector = getHalfVector( wi, wo );
 	return ggxPDF( wi, halfVector, filteredRoughness ) / ( 4.0 * dot( wi, halfVector ) );
 
@@ -65,7 +65,7 @@ float specularPDF( vec3 wo, vec3 wi, MaterialRec material, SurfaceRec hit ) {
 vec3 specularDirection( vec3 wo, SurfaceRec hit, MaterialRec material ) {
 
 	// sample ggx vndf distribution which gives a new normal
-	float filteredRoughness = hit.filteredRoughness;
+	float filteredRoughness = material.filteredRoughness;
 	vec3 halfVector = ggxDirection(
 		wo,
 		filteredRoughness,
@@ -85,7 +85,7 @@ vec3 specularColor( vec3 wo, vec3 wi, MaterialRec material, SurfaceRec hit ) {
 	float metalness = material.metalness;
 	float ior = material.ior;
 	bool frontFace = hit.frontFace;
-	float filteredRoughness = hit.filteredRoughness;
+	float filteredRoughness = material.filteredRoughness;
 
 	vec3 halfVector = getHalfVector( wo, wi );
 	float iorRatio = frontFace ? 1.0 / ior : ior;
@@ -189,9 +189,17 @@ vec3 transmissionColor( vec3 wo, vec3 wi, MaterialRec material, SurfaceRec hit )
 
 	float metalness = material.metalness;
 	float transmission = material.transmission;
+	float ior = material.ior;
+	bool frontFace = hit.frontFace;
+
+	float ratio = frontFace ? 1.0 / ior : ior;
+	float cosTheta = min( wo.z, 1.0 );
+	float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
+	float reflectance = schlickFresnelFromIor( cosTheta, ratio );
+
 	vec3 color = material.color;
 	color *= ( 1.0 - metalness );
-	color *= abs( wi.z );
+	color *= 1.0 - reflectance;
 	color *= transmission;
 
 	// Color is clamped to [0, 1] to make up for incorrect PDF and over sampling

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -164,8 +164,6 @@ function transmissionColor( wo, wi, material, hit, colorTarget ) {
 // incorrect PDF value at the moment. Update it to correctly use a GGX distribution
 float transmissionPDF( vec3 wo, vec3 wi, SurfaceRec surf ) {
 
-	float metalness = surf.metalness;
-	float transmission = surf.transmission;
 	float ior = surf.ior;
 	bool frontFace = surf.frontFace;
 
@@ -176,7 +174,7 @@ float transmissionPDF( vec3 wo, vec3 wi, SurfaceRec surf ) {
 	bool cannotRefract = ratio * sinTheta > 1.0;
 	if ( cannotRefract ) {
 
-		reflectance = 1.0;
+		return 0.0;
 
 	}
 

--- a/src/uniforms/MaterialStructUniform.js
+++ b/src/uniforms/MaterialStructUniform.js
@@ -60,7 +60,7 @@ export class MaterialStructUniform {
 		if ( 'transmission' in material ) this.transmission = material.transmission;
 		else this.transmission = 0.0;
 
-		this.transmissionMap = textures.indexOf( material.transmissionMap );
+		if ( 'transmissionMap' in material ) this.transmissionMap = textures.indexOf( material.transmissionMap );
 
 		// emission
 		if ( 'emissive' in material ) this.emissive.copy( material.emissive );


### PR DESCRIPTION
Fix #46 

**TODO**
- [x] Make issue to track proper GGX transmission (#63)
- [x] Move transmission color attenuation of reflectance to BSDF sample direction instead
- [x] Adjust cpu implementation with attenuation fix
- [x] Support absorption based on distance (#66)
- [x] Consider tuning the glossy filtering behavior so glass looks more correct (w/ filtering some sharpness is lost quickly. Perhaps don't filter if running transmission?)
- [ ] ~Consider implicitly using more bounces if passing through a transmissive material~

| roughness 0.1, filter factor 0.5 | roughness 0.0, filter factor 0.0 |
|---|---|
| ![image](https://user-images.githubusercontent.com/734200/161358142-d46daa4c-f983-4cb0-83fa-d033746fdde4.png) | ![image](https://user-images.githubusercontent.com/734200/161359200-be8a3885-9109-4f55-bae7-c7b25d588d71.png) |
