### PR TITLE
New ray jitter

### DIFF
--- a/src/core/PathTracingRenderer.js
+++ b/src/core/PathTracingRenderer.js
@@ -4,7 +4,6 @@ import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 function* renderTask() {
 
 	const { _fsQuad, _renderer, target, camera, material } = this;
-	material.resolution.set( target.width, target.height );
 
 	while ( true ) {
 
@@ -13,23 +12,7 @@ function* renderTask() {
 
 		const w = target.width;
 		const h = target.height;
-
-		const r1 = Math.random();
-		const r2 = Math.random();
-
-		const len = ( Math.sin( r2 * Math.PI + Math.PI ) + 1.0 ) * 0.5;
-		const u = Math.sin( r1 ) * len;
-		const v = Math.cos( r1 ) * len;
-
-
-		// camera.setViewOffset(
-		// 	w, h,
-		// 	u, v,
-		// 	w, h,
-		// );
-		// camera.updateProjectionMatrix();
-
-		// material.opacity *= ( 1.0 - Math.abs( u * 2 ) ) * ( 1.0 - Math.abs( v * 2 ) );
+		material.resolution.set( w, h );
 
 		const tx = this.tiles.x || 1;
 		const ty = this.tiles.y || 1;

--- a/src/core/PathTracingRenderer.js
+++ b/src/core/PathTracingRenderer.js
@@ -4,6 +4,8 @@ import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 function* renderTask() {
 
 	const { _fsQuad, _renderer, target, camera, material } = this;
+	material.resolution.set( target.width, target.height );
+
 	while ( true ) {
 
 		material.opacity = 1 / ( this.samples + 1 );
@@ -11,12 +13,23 @@ function* renderTask() {
 
 		const w = target.width;
 		const h = target.height;
-		camera.setViewOffset(
-			w, h,
-			Math.random() - 0.5, Math.random() - 0.5,
-			w, h,
-		);
-		camera.updateProjectionMatrix();
+
+		const r1 = Math.random();
+		const r2 = Math.random();
+
+		const len = ( Math.sin( r2 * Math.PI + Math.PI ) + 1.0 ) * 0.5;
+		const u = Math.sin( r1 ) * len;
+		const v = Math.cos( r1 ) * len;
+
+
+		// camera.setViewOffset(
+		// 	w, h,
+		// 	u, v,
+		// 	w, h,
+		// );
+		// camera.updateProjectionMatrix();
+
+		// material.opacity *= ( 1.0 - Math.abs( u * 2 ) ) * ( 1.0 - Math.abs( v * 2 ) );
 
 		const tx = this.tiles.x || 1;
 		const ty = this.tiles.y || 1;

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -1,4 +1,4 @@
-import { Matrix4, Matrix3, Color } from 'three';
+import { Matrix4, Matrix3, Color, Vector2 } from 'three';
 import { MaterialBase } from './MaterialBase.js';
 import {
 	MeshBVHUniformStruct, FloatVertexAttributeTexture, UIntVertexAttributeTexture,
@@ -36,6 +36,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 			},
 
 			uniforms: {
+				resolution: { value: new Vector2() },
+
 				bounces: { value: 3 },
 				physicalCamera: { value: new PhysicalCameraUniform() },
 
@@ -112,8 +114,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 				#endif
 
+				uniform vec2 resolution;
 				uniform int bounces;
-
 				uniform mat4 cameraWorldMatrix;
 				uniform mat4 invProjectionMatrix;
 				uniform sampler2D normalAttribute;
@@ -171,6 +173,23 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 					vec2 ndc = 2.0 * vUv - vec2( 1.0 );
 					vec3 rayOrigin, rayDirection;
 					ndcToCameraRay( ndc, cameraWorldMatrix, invProjectionMatrix, rayOrigin, rayDirection );
+
+					{
+
+						vec3 cameraOrigin = ( cameraWorldMatrix * vec4( 0.0, 0.0, 0.0, 1.0 ) ).xyz;
+						vec3 ss00, ss01, ss10, temp;
+						ndcToCameraRay( vec2( 0.0, 0.0 ), cameraWorldMatrix, invProjectionMatrix, ss00, temp );
+						ndcToCameraRay( vec2( 0.0, 1.0 ), cameraWorldMatrix, invProjectionMatrix, ss01, temp );
+						ndcToCameraRay( vec2( 1.0, 0.0 ), cameraWorldMatrix, invProjectionMatrix, ss10, temp );
+
+						vec3 ssdX = 2.0 * ( ss10 - ss00 ) / resolution.x;
+						vec3 ssdY = 2.0 * ( ss01 - ss00 ) / resolution.y;
+
+						vec3 hs = 0.5 * getHemisphereSample( rayDirection, rand2() );
+						rayOrigin += ( hs.x ) * ssdX + ( hs.y ) * ssdY;
+						rayDirection = normalize( rayOrigin - cameraOrigin );
+
+					}
 
 					#if DOF_SUPPORT
 					{


### PR DESCRIPTION
Related to #65 

Instead of jittering the camera resulting in parallel rays we jitter the rays inside the projected pixel volume for better coverage.

See tent filter implementation [here](https://github.com/erichlof/THREE.js-PathTracing-Renderer/blob/526fdc5ed904b9773b92c3b3fc398b5c7d8338bf/js/PathTracingCommon.js#L2805-L2809).

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/734200/166615932-12c95c70-c6a0-4ae7-ac49-aa3701145d30.png) | ![image](https://user-images.githubusercontent.com/734200/166616925-8b1bcda3-4b40-46ce-a2cb-9202a1baa87c.png) |

**TODO**
- [x] Clean up
- [x] Optimize
- [x] Add "Tent Filter"
- [x] Test / Compare