### PR TITLE
Provide defaults for material's normalScale and emissive values.

### DIFF
--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -126,15 +126,26 @@ export class MaterialsTexture extends DataTexture {
 			floatArray[ index ++ ] = getField( m, 'emissiveIntensity', 0.0 );
 
 			// emission
-			floatArray[ index ++ ] = m.emissive.r;
-			floatArray[ index ++ ] = m.emissive.g;
-			floatArray[ index ++ ] = m.emissive.b;
+			if ('emissive' in m) {
+				floatArray[ index ++ ] = m.emissive.r;
+				floatArray[ index ++ ] = m.emissive.g;
+				floatArray[ index ++ ] = m.emissive.b;
+			} else {
+				floatArray[ index ++ ] = 0.0;
+				floatArray[ index ++ ] = 0.0;
+				floatArray[ index ++ ] = 0.0;
+			}
 			intArray[ index ++ ] = getTexture( m, 'emissiveMap' );
 
 			// normals
 			intArray[ index ++ ] = getTexture( m, 'normalMap' );
-			floatArray[ index ++ ] = m.normalScale.x;
-			floatArray[ index ++ ] = m.normalScale.y;
+			if ('normalScale' in m) {
+				floatArray[ index ++ ] = m.normalScale.x;
+				floatArray[ index ++ ] = m.normalScale.y;
+ 			} else {
+ 				floatArray[ index ++ ] = 1;
+ 				floatArray[ index ++ ] = 1;
+ 			}
 			index ++;
 
 			// side & matte

--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -126,26 +126,36 @@ export class MaterialsTexture extends DataTexture {
 			floatArray[ index ++ ] = getField( m, 'emissiveIntensity', 0.0 );
 
 			// emission
-			if ('emissive' in m) {
+			if ( 'emissive' in m ) {
+
 				floatArray[ index ++ ] = m.emissive.r;
 				floatArray[ index ++ ] = m.emissive.g;
 				floatArray[ index ++ ] = m.emissive.b;
+
 			} else {
+
 				floatArray[ index ++ ] = 0.0;
 				floatArray[ index ++ ] = 0.0;
 				floatArray[ index ++ ] = 0.0;
+
 			}
+
 			intArray[ index ++ ] = getTexture( m, 'emissiveMap' );
 
 			// normals
 			intArray[ index ++ ] = getTexture( m, 'normalMap' );
-			if ('normalScale' in m) {
+			if ( 'normalScale' in m ) {
+
 				floatArray[ index ++ ] = m.normalScale.x;
 				floatArray[ index ++ ] = m.normalScale.y;
+
  			} else {
+
  				floatArray[ index ++ ] = 1;
  				floatArray[ index ++ ] = 1;
+
  			}
+
 			index ++;
 
 			// side & matte


### PR DESCRIPTION
Provide for defaults for these properties when parsing them in updateFrom.

Ideally this behaves more like it did at https://github.com/gkjohnson/three-gpu-pathtracer/blob/4fc62182d4fe03c834515de388d0af7a6fb8ea24/src/uniforms/MaterialStructUniform.js