### PR TITLE
Remove usage of floatBitsToInt to fix Android Bug

### DIFF
--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -62,22 +62,22 @@ export const shaderMaterialStructs = /* glsl */ `
 
 		Material m;
 		m.color = s0.rgb;
-		m.map = floatBitsToInt( s0.a );
+		m.map = int( round( s0.a ) );
 
 		m.metalness = s1.r;
-		m.metalnessMap = floatBitsToInt( s1.g );
+		m.metalnessMap = int( round( s1.g ) );
 		m.roughness = s1.b;
-		m.roughnessMap = floatBitsToInt( s1.a );
+		m.roughnessMap = int( round( s1.a ) );
 
 		m.ior = s2.r;
 		m.transmission = s2.g;
-		m.transmissionMap = floatBitsToInt( s2.b );
+		m.transmissionMap = int( round( s2.b ) );
 		m.emissiveIntensity = s2.a;
 
 		m.emissive = s3.rgb;
-		m.emissiveMap = floatBitsToInt( s3.a );
+		m.emissiveMap = int( round( s3.a ) );
 
-		m.normalMap = floatBitsToInt( s4.r );
+		m.normalMap = int( round( s4.r ) );
 		m.normalScale = s4.gb;
 
 		m.opacity = s5.r;

--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -111,18 +111,18 @@ export class MaterialsTexture extends DataTexture {
 			floatArray[ index ++ ] = m.color.r;
 			floatArray[ index ++ ] = m.color.g;
 			floatArray[ index ++ ] = m.color.b;
-			intArray[ index ++ ] = getTexture( m, 'map' );
+			floatArray[ index ++ ] = getTexture( m, 'map' );
 
 			// metalness & roughness
 			floatArray[ index ++ ] = getField( m, 'metalness', 0.0 );
-			intArray[ index ++ ] = textures.indexOf( m.metalnessMap );
+			floatArray[ index ++ ] = textures.indexOf( m.metalnessMap );
 			floatArray[ index ++ ] = getField( m, 'roughness', 0.0 );
-			intArray[ index ++ ] = textures.indexOf( m.roughnessMap );
+			floatArray[ index ++ ] = textures.indexOf( m.roughnessMap );
 
 			// transmission & emissiveIntensity
 			floatArray[ index ++ ] = getField( m, 'ior', 1.0 );
 			floatArray[ index ++ ] = getField( m, 'transmission', 0.0 );
-			intArray[ index ++ ] = getTexture( m, 'transmissionMap' );
+			floatArray[ index ++ ] = getTexture( m, 'transmissionMap' );
 			floatArray[ index ++ ] = getField( m, 'emissiveIntensity', 0.0 );
 
 			// emission
@@ -140,10 +140,10 @@ export class MaterialsTexture extends DataTexture {
 
 			}
 
-			intArray[ index ++ ] = getTexture( m, 'emissiveMap' );
+			floatArray[ index ++ ] = getTexture( m, 'emissiveMap' );
 
 			// normals
-			intArray[ index ++ ] = getTexture( m, 'normalMap' );
+			floatArray[ index ++ ] = getTexture( m, 'normalMap' );
 			if ( 'normalScale' in m ) {
 
 				floatArray[ index ++ ] = m.normalScale.x;


### PR DESCRIPTION
Changed material ints to floats to fix bug on android not being able to use floatBitsToInt()

We should submit a bug to the android chrome team to fix.