### PR TITLE
Add support for disabling shadow casting per material

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ptRenderer.alpha = true;
 // init quad for rendering to the canvas
 const fsQuad = new FullScreenQuad( new THREE.MeshBasicMaterial( {
 	map: ptRenderer.target.texture,
-	
+
 	// if rendering transparent background
 	blending: THREE.CustomBlending,
 } ) );
@@ -544,6 +544,14 @@ setMatte( index : Number, matte : Boolean ) : void
 ```
 
 Sets whether or not the material of the given index is matte or not. When "true" the background is rendered in place of the material.
+
+### .setCastShadow
+
+```js
+setCastShadow( index : Number, enabled : Boolean ) : void
+```
+
+Sets whether or not the material of the given index will cast shadows. When "false" materials will not cast shadows on diffuse surfaces but will still be reflected. This is a good setting for lighting enclosed interiors with environment lighting.
 
 ### .updateFrom
 

--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -23,6 +23,7 @@ const params = {
 		transmission: 0.0,
 		opacity: 1.0,
 		matte: false,
+		castShadow: true,
 	},
 	material2: {
 		color: '#db7157',
@@ -34,12 +35,14 @@ const params = {
 		ior: 1.495,
 		opacity: 1.0,
 		matte: false,
+		castShadow: true,
 	},
 	material3: {
 		color: '#000000',
 		roughness: 0.01,
 		metalness: 0.05,
 		matte: false,
+		castShadow: true,
 	},
 
 	multipleImportanceSampling: true,
@@ -337,6 +340,7 @@ async function init() {
 	matFolder1.add( params.material1, 'transmission', 0, 1 ).onChange( reset );
 	matFolder1.add( params.material1, 'ior', 0.9, 3.0 ).onChange( reset );
 	matFolder1.add( params.material1, 'matte' ).onChange( reset );
+	matFolder1.add( params.material1, 'castShadow' ).onChange( reset );
 	matFolder1.close();
 
 	const matFolder2 = gui.addFolder( 'Ball Material' );
@@ -349,6 +353,7 @@ async function init() {
 	matFolder2.add( params.material2, 'transmission', 0, 1 ).onChange( reset );
 	matFolder2.add( params.material2, 'ior', 0.9, 3.0 ).onChange( reset );
 	matFolder2.add( params.material2, 'matte' ).onChange( reset );
+	matFolder2.add( params.material2, 'castShadow' ).onChange( reset );
 	matFolder2.close();
 
 	const matFolder3 = gui.addFolder( 'Floor Material' );
@@ -356,6 +361,7 @@ async function init() {
 	matFolder3.add( params.material3, 'roughness', 0, 1 ).onChange( reset );
 	matFolder3.add( params.material3, 'metalness', 0, 1 ).onChange( reset );
 	matFolder3.add( params.material3, 'matte' ).onChange( reset );
+	matFolder3.add( params.material3, 'castShadow' ).onChange( reset );
 	matFolder3.close();
 
 	animate();
@@ -426,6 +432,9 @@ function animate() {
 	ptRenderer.material.materials.setMatte( 0, params.material1.matte );
 	ptRenderer.material.materials.setMatte( 1, params.material2.matte );
 	ptRenderer.material.materials.setMatte( 2, params.material3.matte );
+	ptRenderer.material.materials.setCastShadow( 0, params.material1.castShadow );
+	ptRenderer.material.materials.setCastShadow( 1, params.material2.castShadow );
+	ptRenderer.material.materials.setCastShadow( 2, params.material3.castShadow );
 
 	ptRenderer.material.filterGlossyFactor = params.filterGlossyFactor;
 	ptRenderer.material.environmentIntensity = params.environmentIntensity;

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -398,6 +398,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 						}
 
+						// if we've determined that this is a shadow ray and we've hit an item with no shadow casting
+						// then skip it
 						if ( ! material.castShadow && isShadowRay ) {
 
 							vec3 point = rayOrigin + rayDirection * dist;

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -207,6 +207,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 							bool useAlphaTest = alphaTest != 0.0;
 							float transmissionFactor = ( 1.0 - metalness ) * transmission;
 							if (
+								material.castShadow &&
 								transmissionFactor < rand() && ! (
 									// material sidedness
 									material.side != 0.0 && side == material.side

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -16,6 +16,7 @@ struct SurfaceRec {
 };
 
 struct SampleRec {
+	float specularPdf;
 	float pdf;
 	vec3 direction;
 	vec3 color;
@@ -213,7 +214,7 @@ vec3 transmissionColor( vec3 wo, vec3 wi, SurfaceRec surf ) {
 
 }
 
-float bsdfPdf( vec3 wo, vec3 wi, SurfaceRec surf ) {
+float bsdfPdf( vec3 wo, vec3 wi, SurfaceRec surf, out float specularPdf ) {
 
 	float ior = surf.ior;
 	float metalness = surf.metalness;
@@ -254,6 +255,9 @@ float bsdfPdf( vec3 wo, vec3 wi, SurfaceRec surf ) {
 		+ spdf * ( 1.0 - transmission ) * diffSpecularProb
 		+ dpdf * ( 1.0 - transmission ) * ( 1.0 - diffSpecularProb );
 
+	// retrieve specular rays for the shadows flag
+	specularPdf = spdf * transmission * transSpecularProb + spdf * ( 1.0 - transmission ) * diffSpecularProb;
+
 	return pdf;
 
 }
@@ -280,8 +284,9 @@ vec3 bsdfColor( vec3 wo, vec3 wi, SurfaceRec surf ) {
 
 float bsdfResult( vec3 wo, vec3 wi, SurfaceRec surf, out vec3 color ) {
 
+	float specularPdf;
 	color = bsdfColor( wo, wi, surf );
-	return bsdfPdf( wo, wi, surf );
+	return bsdfPdf( wo, wi, surf, specularPdf );
 
 }
 
@@ -332,7 +337,7 @@ SampleRec bsdfSample( vec3 wo, SurfaceRec surf ) {
 
 	}
 
-	result.pdf = bsdfPdf( wo, result.direction, surf );
+	result.pdf = bsdfPdf( wo, result.direction, surf, result.specularPdf );
 	result.color = bsdfColor( wo, result.direction, surf );
 	return result;
 

--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -52,7 +52,7 @@ export const shaderMaterialStructs = /* glsl */ `
 
 	Material readMaterialInfo( sampler2D tex, uint index ) {
 
-		uint i = index * 6u;
+		uint i = index * 7u;
 
 		vec4 s0 = texelFetch1D( tex, i + 0u );
 		vec4 s1 = texelFetch1D( tex, i + 1u );
@@ -60,6 +60,7 @@ export const shaderMaterialStructs = /* glsl */ `
 		vec4 s3 = texelFetch1D( tex, i + 3u );
 		vec4 s4 = texelFetch1D( tex, i + 4u );
 		vec4 s5 = texelFetch1D( tex, i + 5u );
+		vec4 s6 = texelFetch1D( tex, i + 6u );
 
 		Material m;
 		m.color = s0.rgb;
@@ -80,12 +81,13 @@ export const shaderMaterialStructs = /* glsl */ `
 
 		m.normalMap = int( round( s4.r ) );
 		m.normalScale = s4.gb;
-		m.castShadow = ! bool( s4.a );
 
 		m.opacity = s5.r;
 		m.alphaTest = s5.g;
 		m.side = s5.b;
 		m.matte = bool( s5.a );
+
+		m.castShadow = ! bool( s6.r );
 
 		return m;
 

--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -41,6 +41,7 @@ export const shaderMaterialStructs = /* glsl */ `
 		int normalMap;
 		vec2 normalScale;
 
+		bool castShadow;
 		float opacity;
 		float alphaTest;
 
@@ -79,6 +80,7 @@ export const shaderMaterialStructs = /* glsl */ `
 
 		m.normalMap = int( round( s4.r ) );
 		m.normalScale = s4.gb;
+		m.castShadow = ! bool( s4.a );
 
 		m.opacity = s5.r;
 		m.alphaTest = s5.g;

--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -1,7 +1,7 @@
 import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, FrontSide, BackSide, DoubleSide } from 'three';
 
-const MATERIAL_PIXELS = 6;
-const MATERIAL_STRIDE = 6 * 4;
+const MATERIAL_PIXELS = 7;
+const MATERIAL_STRIDE = MATERIAL_PIXELS * 4;
 
 export class MaterialsTexture extends DataTexture {
 
@@ -21,7 +21,7 @@ export class MaterialsTexture extends DataTexture {
 
 		// invert the shadow value so we default to "true" when initializing a material
 		const array = this.image.data;
-		const index = materialIndex * MATERIAL_STRIDE + 4 * 4 + 3;
+		const index = materialIndex * MATERIAL_STRIDE + 6 * 4 + 0;
 		array[ index ] = ! cast ? 1 : 0;
 
 	}
@@ -29,7 +29,7 @@ export class MaterialsTexture extends DataTexture {
 	getCastShadow( materialIndex ) {
 
 		const array = this.image.data;
-		const index = materialIndex * MATERIAL_STRIDE + 4 * 4 + 3;
+		const index = materialIndex * MATERIAL_STRIDE + 6 * 4 + 0;
 		return ! Boolean( array[ index ] );
 
 	}
@@ -176,13 +176,18 @@ export class MaterialsTexture extends DataTexture {
 
  			}
 
-			index ++; // shadow
+			index ++;
 
 			// side & matte
 			floatArray[ index ++ ] = m.opacity;
 			floatArray[ index ++ ] = m.alphaTest;
 			index ++; // side
 			index ++; // matte
+
+			index ++; // shadow
+			index ++;
+			index ++;
+			index ++;
 
 		}
 

--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -17,6 +17,23 @@ export class MaterialsTexture extends DataTexture {
 
 	}
 
+	setCastShadow( materialIndex, cast ) {
+
+		// invert the shadow value so we default to "true" when initializing a material
+		const array = this.image.data;
+		const index = materialIndex * MATERIAL_STRIDE + 4 * 4 + 3;
+		array[ index ] = ! cast ? 1 : 0;
+
+	}
+
+	getCastShadow( materialIndex ) {
+
+		const array = this.image.data;
+		const index = materialIndex * MATERIAL_STRIDE + 4 * 4 + 3;
+		return ! Boolean( array[ index ] );
+
+	}
+
 	setSide( materialIndex, side ) {
 
 		const array = this.image.data;
@@ -159,7 +176,7 @@ export class MaterialsTexture extends DataTexture {
 
  			}
 
-			index ++;
+			index ++; // shadow
 
 			// side & matte
 			floatArray[ index ++ ] = m.opacity;


### PR DESCRIPTION
Related to #82
Related to #161

Adds a flag for disabling the casting of shadows from certain materials. Works by disabling hits for materials only when the direct light sampling is used which primarily contributes lighting to diffuse surfaces. How can we determine a specular ray from a diffuse ray? From the sampling? From the probability? From how far off from a perfectly specular reflection it is?

```js
ptMaterial.materials.setCastShadow( index, value );
```

**TODO**

- [x] Update Docs
- [x] Add demo flag
- [x] Get this working without MIS
  - determine whether a ray is "specular" without MIS
  - add surface skipping if not MIS ray
  - check specular ray probability and use to randomly pass through the surface or not (or use a fixed threshold?)
  - OR check how far off of the ideal specular direction the ray is.

Images of the orb in an entirely enclosed box lit by an environment map:

![K6aCHFjO](https://user-images.githubusercontent.com/734200/170802001-5f5b9123-1122-435c-8898-cc85f95af141.jpg)

![7Ss5iNXK](https://user-images.githubusercontent.com/734200/170802002-e62ec745-ca7b-4f7b-97b5-89386f178963.jpg)
 
cc @setpixel 