### PR TITLE
Add `alphaMap` support to `PhysicalPathTracingMaterial`

### DIFF
--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -187,6 +187,11 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							}
 
+							// alphaMap
+							if ( material.alphaMap != -1 ) {
+								albedo.a *= texture2D( textures, vec3( uv, material.alphaMap ) ).x;
+							}
+
 							// transmission
 							float transmission = material.transmission;
 							if ( material.transmissionMap != - 1 ) {
@@ -399,6 +404,11 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							albedo *= texture2D( textures, vec3( uv, material.map ) );
 
+						}
+
+						// alphaMap
+						if ( material.alphaMap != -1 ) {
+							albedo.a *= texture2D( textures, vec3( uv, material.alphaMap ) ).x;
 						}
 
 						// possibly skip this sample if it's transparent, alpha test is enabled, or we hit the wrong material side

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -189,7 +189,9 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							// alphaMap
 							if ( material.alphaMap != -1 ) {
+
 								albedo.a *= texture2D( textures, vec3( uv, material.alphaMap ) ).x;
+							
 							}
 
 							// transmission
@@ -408,7 +410,9 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 						// alphaMap
 						if ( material.alphaMap != -1 ) {
+
 							albedo.a *= texture2D( textures, vec3( uv, material.alphaMap ) ).x;
+						
 						}
 
 						// possibly skip this sample if it's transparent, alpha test is enabled, or we hit the wrong material side

--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -41,6 +41,8 @@ export const shaderMaterialStructs = /* glsl */ `
 		int normalMap;
 		vec2 normalScale;
 
+		int alphaMap;
+
 		float opacity;
 		float alphaTest;
 
@@ -79,6 +81,8 @@ export const shaderMaterialStructs = /* glsl */ `
 
 		m.normalMap = int( round( s4.r ) );
 		m.normalScale = s4.gb;
+
+		m.alphaMap = int( round( s4.a ) );
 
 		m.opacity = s5.r;
 		m.alphaTest = s5.g;

--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -101,7 +101,10 @@ export class MaterialsTexture extends DataTexture {
 		}
 
 		const floatArray = this.image.data;
-		const intArray = new Int32Array( floatArray.buffer );
+
+		// on some devices (Google Pixel 6) the "floatBitsToInt" function does not work correctly so we
+		// can't encode texture ids that way.
+		// const intArray = new Int32Array( floatArray.buffer );
 
 		for ( let i = 0, l = materials.length; i < l; i ++ ) {
 

--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -159,7 +159,7 @@ export class MaterialsTexture extends DataTexture {
 
  			}
 
-			index ++;
+			floatArray[ index ++ ] = getTexture( m, 'alphaMap' );
 
 			// side & matte
 			floatArray[ index ++ ] = m.opacity;


### PR DESCRIPTION
This PR adds `alphaMap` support to the renderer



![image](https://user-images.githubusercontent.com/55190601/170819273-e5d81db7-0c4f-442c-b98f-a51db51906ea.png)

The puddles in the above demo are via an alpha map'd circle.