### PR TITLE
Fix enabling perfect specular reflections.

### DIFF
--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -568,16 +568,11 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						// then we can just always assume this is a front face.
 						surfaceRec.frontFace = side == 1.0 || transmission == 0.0;
 
-						// Compute the filtered roughness value to use during specular reflection computations. A minimum
-						// value of 1e-6 is needed because the GGX functions do not work with a roughness value of 0 and
-						// the accumulated roughness value is scaled by a user setting and a "magic value" of 5.0.
+						// Compute the filtered roughness value to use during specular reflection computations.
+						// The accumulated roughness value is scaled by a user setting and a "magic value" of 5.0.
 						// If we're exiting something transmissive then scale the factor down significantly so we can retain
 						// sharp internal reflections
-						surfaceRec.filteredRoughness = clamp(
-							max( surfaceRec.roughness, accumulatedRoughness * filterGlossyFactor * 5.0 ),
-							1e-3,
-							1.0
-						);
+						surfaceRec.filteredRoughness = clamp( max( surfaceRec.roughness, accumulatedRoughness * filterGlossyFactor * 5.0 ), 0.0, 1.0 );
 
 						mat3 normalBasis = getBasisFromNormal( surfaceRec.normal );
 						mat3 invBasis = inverse( normalBasis );
@@ -648,7 +643,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							// determine if this is a rough normal or not by checking how far off straight up it is
 							vec3 halfVector = normalize( outgoing + sampleRec.direction );
-							accumulatedRoughness += sin( acos( halfVector.z ) );
+							accumulatedRoughness += sin( acosApprox( halfVector.z ) );
 							transmissiveRay = false;
 
 						}

--- a/src/shader/shaderGGXFunctions.js
+++ b/src/shader/shaderGGXFunctions.js
@@ -77,7 +77,7 @@ float ggxDistribution( vec3 halfVector, float roughness ) {
 
 	if ( cosTheta == 0.0 ) return 0.0;
 
-	float theta = acos( halfVector.z );
+	float theta = acosApprox( halfVector.z );
 	float tanTheta = tan( theta );
 	float tanTheta2 = pow( tanTheta, 2.0 );
 

--- a/src/shader/shaderGGXFunctions.js
+++ b/src/shader/shaderGGXFunctions.js
@@ -82,7 +82,7 @@ float ggxDistribution( vec3 halfVector, float roughness ) {
 	float tanTheta2 = pow( tanTheta, 2.0 );
 
 	float denom = PI * cosTheta4 * pow( a2 + tanTheta2, 2.0 );
-	return a2 / denom;
+	return denom < 1e-6 ? 1.0 : a2 / denom;
 
 	// See equation (1) from reference [2]
 	// const { x, y, z } = halfVector;

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -67,11 +67,11 @@ float specularPDF( vec3 wo, vec3 wi, SurfaceRec surf ) {
 vec3 specularDirection( vec3 wo, SurfaceRec surf ) {
 
 	// sample ggx vndf distribution which gives a new normal
-	float roughness = surf.roughness;
+	float filteredRoughness = surf.filteredRoughness;
 	vec3 halfVector = ggxDirection(
 		wo,
-		roughness,
-		roughness,
+		filteredRoughness,
+		filteredRoughness,
 		rand(),
 		rand()
 	);

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -67,11 +67,11 @@ float specularPDF( vec3 wo, vec3 wi, SurfaceRec surf ) {
 vec3 specularDirection( vec3 wo, SurfaceRec surf ) {
 
 	// sample ggx vndf distribution which gives a new normal
-	float filteredRoughness = surf.filteredRoughness;
+	float roughness = surf.roughness;
 	vec3 halfVector = ggxDirection(
 		wo,
-		filteredRoughness,
-		filteredRoughness,
+		roughness,
+		roughness,
 		rand(),
 		rand()
 	);

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -226,6 +226,9 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	// Fast arccos approximation used to remove banding artifacts caused by numerical errors in acos.
+	// This is a cubic Lagrange interpolating polynomial for x = [-1, -1/2, 0, 1/2, 1].	
+	// Source: https://stackoverflow.com/questions/3380628/fast-arc-cos-algorithm/answer#3380723	
 	float acosApprox(float x) {
 		return ( -0.69813170079773212 * x * x - 0.87266462599716477 ) * x + 1.5707963267948966;
 	}

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -225,4 +225,8 @@ export const shaderUtils = /* glsl */`
 		return vec3( sinPhi * cos( theta ), cos( phi ), sinPhi * sin( theta ) );
 
 	}
+
+	float acosApprox(float x) {
+		return ( -0.69813170079773212 * x * x - 0.87266462599716477 ) * x + 1.5707963267948966;
+	}
 `;


### PR DESCRIPTION
Fix for https://github.com/gkjohnson/three-gpu-pathtracer/issues/161

- shaderUtils.js/acosApprox(...): added small-order polynomial approximation of `acos`, removing banding artifacts
- shaderGGXFunctions.js/ggxDistribution(...): `theta` calculated with `acos` approximation
- shaderMaterialSampling.js/specularDirection(...): switched from `filteredRoughness` to `rougness`

Reproduced the issue (having scene.js files for a repro in such cases would be helpful). The issue is caused by `filteredRoughness` being used in the `specularDirection` function.

![Screenshot from 2022-06-09 00-37-34](https://user-images.githubusercontent.com/868396/172744906-6a4030ab-e71c-4108-92f9-9fb57224d44b.png)

Switching to `roughness` reveals the precision issues of the PDF function.

![Screenshot from 2022-06-09 00-40-09](https://user-images.githubusercontent.com/868396/172744961-fb5124f0-cdc7-4ea7-aa27-85679a3b5691.png)

Replacing `theta` in `ggxDistribution` with an approximation resolves this. Shown here is a mirror-box with no emissive component and a higher number of bounces demonstrates perfect specular reflections.

![Screenshot from 2022-06-09 01-59-08](https://user-images.githubusercontent.com/868396/172745190-76f0dee7-7fff-4988-8d26-91574776b7b5.png)

I took a look at the other example scenes and they appeared unchanged.