### PR TITLE
Add support for rectangular area lights (RectAreaLight) #47

### DIFF
--- a/example/areaLight.html
+++ b/example/areaLight.html
@@ -1,0 +1,55 @@
+<html>
+	<head>
+		<title>Area Light Path Tracing</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+		<style>
+			html, body {
+				margin: 0;
+				padding: 0;
+				background-color: #111;
+			}
+
+			#info {
+				position: absolute;
+				bottom: 0;
+				left: 0;
+				font-family: 'Courier New', Courier, monospace;
+				color: white;
+				pointer-events: none;
+			}
+
+			#samples {
+
+				opacity: 0.5;
+				background-color: rgba( 0.0, 0.0, 0.0, 0.5 );
+				padding: 5px;
+				display: inline-block;
+
+			}
+
+			a {
+				color: white;
+			}
+
+			#loading {
+				position: absolute;
+				left: 50%;
+				top: 50%;
+				transform: translate(-50%, -50%);
+				color: white;
+				font-family: 'Courier New', Courier, monospace;
+			}
+		</style>
+
+	</head>
+	<body>
+		<div id="loading">LOADING</div>
+		<div id="info">
+			<div>
+				<div id="samples">--</div>
+			</div>
+		</div>
+		<script src="./areaLight.js" type="module"></script>
+	</body>
+</html>

--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -12,8 +12,9 @@ let renderer, controls, transformControls, transformControlsScene, areaLights, s
 let samplesEl;
 const params = {
 
-	environmentIntensity: 0.5,
+	environmentIntensity: 0.2,
 	environmentRotation: 0,
+	areaLightIntensity: 20.0,
 	bounces: 20,
 	samplesPerFrame: 1,
 	resolutionScale: 1 / window.devicePixelRatio,
@@ -96,7 +97,7 @@ async function init() {
 
 	group.updateMatrixWorld();
 
-	const areaLight1 = new THREE.RectAreaLight( new THREE.Color( 0xFFFFFF ), 50.0, 1.0, 1.0 );
+	const areaLight1 = new THREE.RectAreaLight( new THREE.Color( 0xFFFFFF ), 20.0, 1.0, 1.0 );
 	areaLight1.position.x = 1.5;
 	areaLight1.position.y = 1.0;
 	areaLight1.position.z = - 0.5;
@@ -104,7 +105,7 @@ async function init() {
 	areaLight1.rotateX( - Math.PI / 2 );
 	group.add( areaLight1 );
 
-	const areaLight2 = new THREE.RectAreaLight( new THREE.Color( 0x00FF00 ), 20.0, 5.0, 1.0 );
+	const areaLight2 = new THREE.RectAreaLight( new THREE.Color( 0x00FF00 ), 10.0, 5.0, 1.0 );
 	areaLight2.position.x = - 2.5;
 	areaLight2.position.y = 0.5;
 	areaLight2.position.z = - 3.0;
@@ -198,6 +199,7 @@ async function init() {
 		ptRenderer.reset();
 
 	} );
+	gui.add( params, 'areaLightIntensity', 0, 50 ).onChange( updateIntensity );
 	gui.add( params, 'bounces', 1, 30, 1 ).onChange( () => {
 
 		ptRenderer.reset();
@@ -216,7 +218,17 @@ async function init() {
 
 	} );
 
+	updateIntensity();
+
 	animate();
+
+}
+
+function updateIntensity() {
+
+	areaLights[ 0 ].intensity = params.areaLightIntensity;
+	ptRenderer.material.lights.updateFrom( areaLights );
+	ptRenderer.reset();
 
 }
 

--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -1,0 +1,268 @@
+import * as THREE from 'three';
+import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { PathTracingRenderer, PhysicalPathTracingMaterial } from '../src/index.js';
+import { PathTracingSceneWorker } from '../src/workers/PathTracingSceneWorker.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
+import { Scene } from 'three';
+
+let renderer, controls, transformControls, transformControlsScene, areaLights, sceneInfo, ptRenderer, camera, fsQuad;
+let samplesEl;
+const params = {
+
+	environmentIntensity: 0.5,
+	environmentRotation: 0,
+	emissiveIntensity: 100,
+	bounces: 20,
+	samplesPerFrame: 1,
+	resolutionScale: 1 / window.devicePixelRatio,
+	filterGlossyFactor: 0.25,
+	tiles: 1,
+	multipleImportanceSampling: true
+
+};
+
+// clamp value for mobile
+const aspectRatio = window.innerWidth / window.innerHeight;
+if ( aspectRatio < 0.65 ) {
+
+	params.bounces = Math.min( params.bounces, 10 );
+	params.resolutionScale *= 0.5;
+	params.tiles = 3;
+
+}
+
+init();
+
+async function init() {
+
+	renderer = new THREE.WebGLRenderer( { antialias: true } );
+	renderer.toneMapping = THREE.ACESFilmicToneMapping;
+	document.body.appendChild( renderer.domElement );
+
+	camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.025, 500 );
+	camera.position.set( 0.4, 0.6, 2.65 );
+
+	ptRenderer = new PathTracingRenderer( renderer );
+	ptRenderer.camera = camera;
+	ptRenderer.material = new PhysicalPathTracingMaterial();
+	ptRenderer.tiles.set( params.tiles, params.tiles );
+
+	fsQuad = new FullScreenQuad( new THREE.MeshBasicMaterial( {
+		map: ptRenderer.target.texture,
+	} ) );
+
+	controls = new OrbitControls( camera, renderer.domElement );
+	controls.target.set( - 0.15, 0.33, - 0.08 );
+	camera.lookAt( controls.target );
+	controls.addEventListener( 'change', () => {
+
+		ptRenderer.reset();
+
+	} );
+	controls.update();
+
+	camera.lookAt( - 0.15, 0.33, - 0.08 );
+
+	samplesEl = document.getElementById( 'samples' );
+
+	const envMapPromise = new Promise( resolve => {
+
+		new RGBELoader()
+			.load( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr', texture => {
+
+				ptRenderer.material.envMapInfo.updateFrom( texture );
+				resolve();
+
+			} );
+
+	} );
+
+	const group = new THREE.Group();
+
+	const floorGeom = new THREE.PlaneBufferGeometry( 10, 10 );
+	const floorMat = new THREE.MeshPhysicalMaterial( { color: new THREE.Color( 0x999999 ), roughness: 0.1 } );
+	const floor = new THREE.Mesh( floorGeom, floorMat );
+	floor.rotateX( Math.PI / 2 );
+	group.add( floor );
+
+	const redBoxGeom = new THREE.BoxBufferGeometry( 0.5, 2, 2 );
+	const redBoxMat = new THREE.MeshPhysicalMaterial( { color: new THREE.Color( 0xAA0000 ) } );
+	const redBox = new THREE.Mesh( redBoxGeom, redBoxMat );
+	redBox.position.set( - 1.5, 1.0, 0.0 );
+	group.add( redBox );
+
+	group.updateMatrixWorld();
+
+	const areaLight1 = new THREE.RectAreaLight( new THREE.Color( 0xFFFFFF ), 50.0, 1.0, 1.0 );
+	areaLight1.position.x = 1.5;
+	areaLight1.position.y = 1.0;
+	areaLight1.position.z = - 0.5;
+	areaLight1.rotateZ( - Math.PI / 4 );
+	areaLight1.rotateX( - Math.PI / 2 );
+	group.add( areaLight1 );
+
+	const areaLight2 = new THREE.RectAreaLight( new THREE.Color( 0x00FF00 ), 20.0, 5.0, 1.0 );
+	areaLight2.position.x = - 2.5;
+	areaLight2.position.y = 0.5;
+	areaLight2.position.z = - 3.0;
+	areaLight2.rotateX( Math.PI );
+	group.add( areaLight2 );
+
+	areaLights = [ areaLight1, areaLight2 ];
+
+	transformControls = new TransformControls( camera, renderer.domElement );
+	transformControls.addEventListener( 'change', () => {
+
+		ptRenderer.material.lights.updateFrom( areaLights );
+		ptRenderer.reset();
+
+	} );
+	transformControls.addEventListener( 'dragging-changed', ( e ) => controls.enabled = ! e.value );
+	transformControls.attach( areaLight1 );
+
+	transformControlsScene = new Scene();
+	transformControlsScene.add( transformControls );
+
+	const generator = new PathTracingSceneWorker();
+	const generatorPromise = generator.generate( group ).then( result => {
+
+		sceneInfo = result;
+
+		const { bvh, textures, materials, lights } = result;
+		const geometry = bvh.geometry;
+		const material = ptRenderer.material;
+
+		material.bvh.updateFrom( bvh );
+		material.normalAttribute.updateFrom( geometry.attributes.normal );
+		material.tangentAttribute.updateFrom( geometry.attributes.tangent );
+		material.uvAttribute.updateFrom( geometry.attributes.uv );
+		material.materialIndexAttribute.updateFrom( geometry.attributes.materialIndex );
+		material.textures.setTextures( renderer, 2048, 2048, textures );
+		material.materials.updateFrom( materials, textures );
+		material.lights.updateFrom( lights );
+		material.lightCount = lights.length;
+
+		generator.dispose();
+
+	} );
+
+	await Promise.all( [ generatorPromise, envMapPromise ] );
+
+	window.CAMERA = camera;
+	window.CONTROLS = controls;
+
+	document.getElementById( 'loading' ).remove();
+
+	onResize();
+	window.addEventListener( 'resize', onResize );
+
+	const gui = new GUI();
+	gui.add( params, 'tiles', 1, 4, 1 ).onChange( value => {
+
+		ptRenderer.tiles.set( value, value );
+
+	} );
+	gui.add( params, 'samplesPerFrame', 1, 10, 1 );
+	gui.add( params, 'filterGlossyFactor', 0, 1 ).onChange( () => {
+
+		ptRenderer.reset();
+
+	} );
+	gui.add( params, 'environmentIntensity', 0, 25 ).onChange( () => {
+
+		ptRenderer.reset();
+
+	} );
+	gui.add( params, 'environmentRotation', 0, 40 ).onChange( v => {
+
+		ptRenderer.material.environmentRotation.setFromMatrix4( new THREE.Matrix4().makeRotationY( v ) );
+		ptRenderer.reset();
+
+	} );
+	gui.add( params, 'emissiveIntensity', 0, 300 ).onChange( updateIntensity );
+	gui.add( params, 'bounces', 1, 30, 1 ).onChange( () => {
+
+		ptRenderer.reset();
+
+	} );
+	gui.add( params, 'resolutionScale', 0.1, 1 ).onChange( () => {
+
+		onResize();
+
+	} );
+	gui.add( params, 'multipleImportanceSampling' ).onChange( () => {
+
+		ptRenderer.material.defines.FEATURE_MIS = params.multipleImportanceSampling ? 1 : 0;
+		ptRenderer.material.needsUpdate = true;
+		ptRenderer.reset();
+
+	} );
+
+	updateIntensity();
+
+	animate();
+
+}
+
+function onResize() {
+
+	const w = window.innerWidth;
+	const h = window.innerHeight;
+	const scale = params.resolutionScale;
+	const dpr = window.devicePixelRatio;
+
+	ptRenderer.setSize( w * scale * dpr, h * scale * dpr );
+	ptRenderer.reset();
+
+	renderer.setSize( w, h );
+	renderer.setPixelRatio( window.devicePixelRatio * scale );
+	camera.aspect = w / h;
+	camera.updateProjectionMatrix();
+
+}
+
+function updateIntensity() {
+
+	sceneInfo.materials.forEach( material => {
+
+		material.emissiveIntensity = params.emissiveIntensity;
+
+	} );
+	ptRenderer.reset();
+
+}
+
+function animate() {
+
+	requestAnimationFrame( animate );
+
+	ptRenderer.material.materials.updateFrom( sceneInfo.materials, sceneInfo.textures );
+
+	ptRenderer.material.filterGlossyFactor = params.filterGlossyFactor;
+	ptRenderer.material.environmentIntensity = params.environmentIntensity;
+	ptRenderer.material.environmentBlur = 0.35;
+	ptRenderer.material.bounces = params.bounces;
+
+	camera.updateMatrixWorld();
+
+	for ( let i = 0, l = params.samplesPerFrame; i < l; i ++ ) {
+
+		ptRenderer.update();
+
+	}
+
+	renderer.autoClear = false;
+	fsQuad.render( renderer );
+	renderer.render( transformControlsScene, camera );
+	renderer.autoClear = true;
+
+	samplesEl.innerText = `Samples: ${ Math.floor( ptRenderer.samples ) }`;
+
+}
+
+
+
+

--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -14,7 +14,6 @@ const params = {
 
 	environmentIntensity: 0.5,
 	environmentRotation: 0,
-	emissiveIntensity: 100,
 	bounces: 20,
 	samplesPerFrame: 1,
 	resolutionScale: 1 / window.devicePixelRatio,
@@ -39,6 +38,7 @@ init();
 async function init() {
 
 	renderer = new THREE.WebGLRenderer( { antialias: true } );
+	renderer.outputEncoding = THREE.sRGBEncoding;
 	renderer.toneMapping = THREE.ACESFilmicToneMapping;
 	document.body.appendChild( renderer.domElement );
 
@@ -114,7 +114,7 @@ async function init() {
 	areaLights = [ areaLight1, areaLight2 ];
 
 	transformControls = new TransformControls( camera, renderer.domElement );
-	transformControls.addEventListener( 'change', () => {
+	transformControls.addEventListener( 'objectChange', () => {
 
 		ptRenderer.material.lights.updateFrom( areaLights );
 		ptRenderer.reset();
@@ -122,6 +122,22 @@ async function init() {
 	} );
 	transformControls.addEventListener( 'dragging-changed', ( e ) => controls.enabled = ! e.value );
 	transformControls.attach( areaLight1 );
+
+	window.addEventListener( 'keydown', function ( event ) {
+
+		switch ( event.key ) {
+
+		case 'w':
+			transformControls.setMode( 'translate' );
+			break;
+
+		case 'e':
+			transformControls.setMode( 'rotate' );
+			break;
+
+		}
+
+	} );
 
 	transformControlsScene = new Scene();
 	transformControlsScene.add( transformControls );
@@ -182,7 +198,6 @@ async function init() {
 		ptRenderer.reset();
 
 	} );
-	gui.add( params, 'emissiveIntensity', 0, 300 ).onChange( updateIntensity );
 	gui.add( params, 'bounces', 1, 30, 1 ).onChange( () => {
 
 		ptRenderer.reset();
@@ -200,8 +215,6 @@ async function init() {
 		ptRenderer.reset();
 
 	} );
-
-	updateIntensity();
 
 	animate();
 
@@ -221,17 +234,6 @@ function onResize() {
 	renderer.setPixelRatio( window.devicePixelRatio * scale );
 	camera.aspect = w / h;
 	camera.updateProjectionMatrix();
-
-}
-
-function updateIntensity() {
-
-	sceneInfo.materials.forEach( material => {
-
-		material.emissiveIntensity = params.emissiveIntensity;
-
-	} );
-	ptRenderer.reset();
 
 }
 

--- a/src/core/PathTracingSceneGenerator.js
+++ b/src/core/PathTracingSceneGenerator.js
@@ -7,6 +7,7 @@ export class PathTracingSceneGenerator {
 	prepScene( scene ) {
 
 		const meshes = [];
+		const lights = [];
 		scene.traverse( c => {
 
 			if ( c.isSkinnedMesh || c.isMesh && c.morphTargetInfluences ) {
@@ -26,24 +27,32 @@ export class PathTracingSceneGenerator {
 
 				meshes.push( c );
 
+			} else if ( c.isRectAreaLight ) {
+
+				lights.push( c );
+
 			}
 
 		} );
 
-		return mergeMeshes( meshes, {
-			attributes: [ 'position', 'normal', 'tangent', 'uv' ],
-		} );
+		return {
+			...mergeMeshes( meshes, {
+				attributes: [ 'position', 'normal', 'tangent', 'uv' ],
+			} ),
+			lights
+		};
 
 	}
 
 	generate( scene, options = {} ) {
 
-		const { materials, textures, geometry } = this.prepScene( scene );
+		const { materials, textures, geometry, lights } = this.prepScene( scene );
 		const bvhOptions = { strategy: SAH, ...options, maxLeafTris: 1 };
 		return {
 			scene,
 			materials,
 			textures,
+			lights,
 			bvh: new MeshBVH( geometry, bvhOptions ),
 		};
 

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -660,7 +660,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								// get the material pdf
 								vec3 sampleColor;
 								float lightMaterialPdf = bsdfResult( outgoing, normalize( invBasis * lightSampleRec.direction ), surfaceRec, sampleColor );
-								if ( lightMaterialPdf > 0.0 ) {
+								if ( lightMaterialPdf > 0.0 && ! any( isnan( sampleColor ) ) ) {
 
 									// weight the direct light contribution
 									float lightPdf = lightSampleRec.pdf / float( lightCount + 1u );
@@ -699,7 +699,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								// get the material pdf
 								vec3 sampleColor;
 								float envMaterialPdf = bsdfResult( outgoing, normalize( invBasis * envDirection ), surfaceRec, sampleColor );
-								if ( envMaterialPdf > 0.0 ) {
+								if ( envMaterialPdf > 0.0 && ! any( isnan( sampleColor ) ) ) {
 
 									// weight the direct light contribution
 									envPdf /= float( lightCount + 1u );

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -660,7 +660,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								// get the material pdf
 								vec3 sampleColor;
 								float lightMaterialPdf = bsdfResult( outgoing, normalize( invBasis * lightSampleRec.direction ), surfaceRec, sampleColor );
-								if ( lightMaterialPdf > 0.0 && ! any( isnan( sampleColor ) ) ) {
+								bool isValidSampleColor = all( greaterThanEqual( sampleColor, vec3( 0.0 ) ) );
+								if ( lightMaterialPdf > 0.0 && isValidSampleColor ) {
 
 									// weight the direct light contribution
 									float lightPdf = lightSampleRec.pdf / float( lightCount + 1u );
@@ -699,7 +700,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								// get the material pdf
 								vec3 sampleColor;
 								float envMaterialPdf = bsdfResult( outgoing, normalize( invBasis * envDirection ), surfaceRec, sampleColor );
-								if ( envMaterialPdf > 0.0 && ! any( isnan( sampleColor ) ) ) {
+								bool isValidSampleColor = all( greaterThanEqual( sampleColor, vec3( 0.0 ) ) );
+								if ( envMaterialPdf > 0.0 && isValidSampleColor ) {
 
 									// weight the direct light contribution
 									envPdf /= float( lightCount + 1u );

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -402,7 +402,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								#if FEATURE_MIS
 
 								// weight the contribution
-								float misWeight = misHeuristic( sampleRec.pdf, lightHit.pdf );
+								float misWeight = misHeuristic( sampleRec.pdf, lightHit.pdf / float( lightCount + 1u ) );
 								gl_FragColor.rgb += lightHit.emission * throughputColor * misWeight;
 
 								#else
@@ -432,6 +432,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								// get the PDF of the hit envmap point
 								vec3 envColor;
 								float envPdf = envMapSample( environmentRotation * rayDirection, envMapInfo, envColor );
+								envPdf /= float( lightCount + 1u );
 
 								// and weight the contribution
 								float misWeight = misHeuristic( sampleRec.pdf, envPdf );

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -4,14 +4,16 @@ import {
 	MeshBVHUniformStruct, FloatVertexAttributeTexture, UIntVertexAttributeTexture,
 	shaderStructs, shaderIntersectFunction,
 } from 'three-mesh-bvh';
-import { shaderMaterialStructs } from '../shader/shaderStructs.js';
+import { shaderMaterialStructs, shaderLightStruct } from '../shader/shaderStructs.js';
 import { MaterialsTexture } from '../uniforms/MaterialsTexture.js';
 import { RenderTarget2DArray } from '../uniforms/RenderTarget2DArray.js';
 import { shaderMaterialSampling } from '../shader/shaderMaterialSampling.js';
 import { shaderEnvMapSampling } from '../shader/shaderEnvMapSampling.js';
+import { shaderLightSampling } from '../shader/shaderLightSampling.js';
 import { shaderUtils } from '../shader/shaderUtils.js';
 import { PhysicalCameraUniform } from '../uniforms/PhysicalCameraUniform.js';
 import { EquirectHdrInfoUniform } from '../uniforms/EquirectHdrInfoUniform.js';
+import { LightsTexture } from '../uniforms/LightsTexture.js';
 
 export class PhysicalPathTracingMaterial extends MaterialBase {
 
@@ -48,6 +50,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				materialIndexAttribute: { value: new UIntVertexAttributeTexture() },
 				materials: { value: new MaterialsTexture() },
 				textures: { value: new RenderTarget2DArray().texture },
+				lights: { value: new LightsTexture() },
+				lightCount: { value: 0 },
 				cameraWorldMatrix: { value: new Matrix4() },
 				invProjectionMatrix: { value: new Matrix4() },
 				isOrthographicCamera: { value: true },
@@ -92,10 +96,12 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				${ shaderStructs }
 				${ shaderIntersectFunction }
 				${ shaderMaterialStructs }
+				${ shaderLightStruct }
 
 				${ shaderUtils }
 				${ shaderMaterialSampling }
 				${ shaderEnvMapSampling }
+				${ shaderLightSampling }
 
 				uniform mat3 environmentRotation;
 				uniform float backgroundBlur;
@@ -129,6 +135,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				uniform int seed;
 				uniform float opacity;
 				uniform sampler2D materials;
+				uniform sampler2D lights;
+				uniform uint lightCount;
 
 				uniform EquirectHdrInfo envMapInfo;
 
@@ -267,15 +275,16 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 				}
 
-				// returns whether the ray hit anything, not just the first surface. Could be optimized to not check the full hierarchy.
-				bool anyHit( BVH bvh, vec3 rayOrigin, vec3 rayDirection ) {
+				// returns whether the ray hit anything before a certain distance, not just the first surface. Could be optimized to not check the full hierarchy.
+				bool anyCloserHit( BVH bvh, vec3 rayOrigin, vec3 rayDirection, float maxDist ) {
 
 					uvec4 faceIndices = uvec4( 0u );
 					vec3 faceNormal = vec3( 0.0, 0.0, 1.0 );
 					vec3 barycoord = vec3( 0.0 );
 					float side = 1.0;
 					float dist = 0.0;
-					return bvhIntersectFirstHit( bvh, rayOrigin, rayDirection, faceIndices, faceNormal, barycoord, side, dist );
+					bool hit = bvhIntersectFirstHit( bvh, rayOrigin, rayDirection, faceIndices, faceNormal, barycoord, side, dist );
+					return hit && dist < maxDist;
 
 				}
 
@@ -378,7 +387,38 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 					for ( i = 0; i < bounces; i ++ ) {
 
-						if ( ! bvhIntersectFirstHit( bvh, rayOrigin, rayDirection, faceIndices, faceNormal, barycoord, side, dist ) ) {
+						bool hit = bvhIntersectFirstHit( bvh, rayOrigin, rayDirection, faceIndices, faceNormal, barycoord, side, dist );
+
+						LightSampleRec lightHit = lightsClosestHit( lights, lightCount, rayOrigin, rayDirection );
+
+						if ( lightHit.hit && ( lightHit.dist < dist || !hit ) ) {
+
+							if ( i == 0 || transmissiveRay ) {
+
+								gl_FragColor.rgb += lightHit.emission * throughputColor;
+
+							} else {
+
+								#if FEATURE_MIS
+
+								// weight the contribution
+								float misWeight = misHeuristic( sampleRec.pdf, lightHit.pdf );
+								gl_FragColor.rgb += lightHit.emission * throughputColor * misWeight;
+
+								#else
+
+								gl_FragColor.rgb +=
+									lightHit.emission *
+									throughputColor;
+
+								#endif
+
+							}
+							break;
+
+						}
+
+						if ( ! hit ) {
 
 							if ( i == 0 || transmissiveRay ) {
 
@@ -580,7 +620,6 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						vec3 outgoing = - normalize( invBasis * rayDirection );
 						sampleRec = bsdfSample( outgoing, surfaceRec );
 
-						float specRayPdf = specularPDF( outgoing, sampleRec.direction, surfaceRec );
 						isShadowRay = sampleRec.specularPdf < rand();
 
 						// adjust the hit point by the surface normal by a factor of some offset and the
@@ -596,7 +635,9 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 						// direct env map sampling
 						#if FEATURE_MIS
-						{
+
+						// uniformly pick a light or environment map
+						if( rand() < 1.0 / float( lightCount + 1u ) ) {
 
 							// find a sample in the environment map to include in the contribution
 							vec3 envColor, envDirection;
@@ -627,8 +668,42 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								if ( envMaterialPdf > 0.0 ) {
 
 									// weight the direct light contribution
+									envPdf /= float( lightCount + 1u );
 									float misWeight = misHeuristic( envPdf, envMaterialPdf );
 									gl_FragColor.rgb += attenuatedColor * environmentIntensity * envColor * throughputColor * sampleColor * misWeight / envPdf;
+
+								}
+
+							}
+
+						} else {
+
+							// sample a light or environment
+							LightSampleRec lightSampleRec = randomLightSample( lights, lightCount, rayOrigin );
+
+							bool isSampleBelowSurface = dot( faceNormal, lightSampleRec.direction ) < 0.0;
+							if ( isSampleBelowSurface ) {
+
+								lightSampleRec.pdf = 0.0;
+
+							}
+
+							// check if a ray could even reach the light area
+							if (
+								lightSampleRec.pdf > 0.0 &&
+								isDirectionValid( lightSampleRec.direction, normal, faceNormal ) &&
+								! anyCloserHit( bvh, rayOrigin, lightSampleRec.direction, lightSampleRec.dist )
+							) {
+
+								// get the material pdf
+								vec3 sampleColor;
+								float lightMaterialPdf = bsdfResult( outgoing, normalize( invBasis * lightSampleRec.direction ), surfaceRec, sampleColor );
+								if ( lightMaterialPdf > 0.0 ) {
+
+									// weight the direct light contribution
+									float lightPdf = lightSampleRec.pdf / float( lightCount + 1u );
+									float misWeight = misHeuristic( lightPdf, lightMaterialPdf );
+									gl_FragColor.rgb += lightSampleRec.emission * throughputColor * sampleColor * misWeight / lightPdf;
 
 								}
 

--- a/src/shader/shaderEnvMapSampling.js
+++ b/src/shader/shaderEnvMapSampling.js
@@ -56,12 +56,4 @@ float randomEnvMapSample( EquirectHdrInfo info, out vec3 color, out vec3 directi
 
 }
 
-float misHeuristic( float a, float b ) {
-
-	float aa = a * a;
-	float bb = a * b;
-	return aa / ( bb + aa );
-
-}
-
 `;

--- a/src/shader/shaderLightSampling.js
+++ b/src/shader/shaderLightSampling.js
@@ -1,0 +1,87 @@
+export const shaderLightSampling = /* glsl */`
+
+struct LightSampleRec {
+	bool hit;
+	float dist;
+	vec3 direction;
+	float pdf;
+	vec3 emission;
+};
+
+LightSampleRec lightsClosestHit( sampler2D lights, uint lightCount, vec3 rayOrigin, vec3 rayDirection ) {
+
+	LightSampleRec lightSampleRec;
+	lightSampleRec.hit = false;
+
+	uint l;
+	for ( l = 0u; l < lightCount; l++ ) {
+
+		Light light = readLightInfo( lights, l );
+
+		vec3 u = light.u;
+		vec3 v = light.v;
+
+		// check for backface
+		vec3 normal = normalize( cross( u, v ) );
+		if ( dot( normal, rayDirection ) < 0.0 ) {
+			continue;
+		}
+
+		u *= 1.0 / dot(u, u);
+		v *= 1.0 / dot(v, v);
+
+		float dist;
+		if ( intersectsRectangle( light.position, normal, u, v, rayOrigin, rayDirection, dist ) ) {
+
+			if ( dist < lightSampleRec.dist || !lightSampleRec.hit ) {
+
+				lightSampleRec.hit = true;
+				lightSampleRec.dist = dist;
+				float cosTheta = dot( rayDirection, normal );
+				lightSampleRec.pdf = ( dist * dist ) / ( light.area * cosTheta );
+				lightSampleRec.emission = light.color * light.intensity;
+				lightSampleRec.direction = rayDirection;
+			}
+
+		}
+
+	}
+
+	return lightSampleRec;
+
+}
+
+LightSampleRec randomRectAreaLightSample( Light light, vec3 rayOrigin ) {
+
+	LightSampleRec lightSampleRec;
+	lightSampleRec.hit = true;
+
+	lightSampleRec.emission = light.color * light.intensity;
+
+	vec3 randomPos = light.position + light.u * ( rand() - 0.5 ) + light.v * ( rand() - 0.5 );
+	vec3 toLight = randomPos - rayOrigin;
+	float lightDistSq = dot( toLight, toLight );
+	lightSampleRec.dist = length( toLight );
+
+	vec3 direction = normalize( toLight );
+	lightSampleRec.direction = direction;
+
+	vec3 lightNormal = normalize( cross( light.u, light.v ) );
+	lightSampleRec.pdf = lightDistSq / ( light.area * dot( direction, lightNormal ) );
+
+	return lightSampleRec;
+
+}
+
+LightSampleRec randomLightSample( sampler2D lights, uint lightCount, vec3 rayOrigin ) {
+
+	// pick a random light
+	uint l = uint( rand() * float( lightCount ) );
+	Light light = readLightInfo( lights, l );
+
+	// sample the light
+	return randomRectAreaLightSample( light, rayOrigin );
+
+}
+
+`;

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -57,10 +57,10 @@ vec3 diffuseColor( vec3 wo, vec3 wi, SurfaceRec surf ) {
 // specular
 float specularPDF( vec3 wo, vec3 wi, SurfaceRec surf ) {
 
-	// See equation (17) in http://jcgt.org/published/0003/02/03/
+	// See equation (27) in http://jcgt.org/published/0003/02/03/
 	float filteredRoughness = surf.filteredRoughness;
 	vec3 halfVector = getHalfVector( wi, wo );
-	return ggxPDF( wi, halfVector, filteredRoughness ) / ( 4.0 * dot( wi, halfVector ) );
+	return ggxPDF( wo, halfVector, filteredRoughness ) / ( 4.0 * dot( wi, halfVector ) );
 
 }
 

--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -129,3 +129,42 @@ export const shaderMaterialStructs = /* glsl */ `
 	}
 
 `;
+
+export const shaderLightStruct = /* glsl */ `
+	struct Light {
+
+		vec3 position;
+
+		vec3 color;
+		float intensity;
+
+		vec3 u;
+		vec3 v;
+		float area;
+
+	};
+
+	Light readLightInfo( sampler2D tex, uint index ) {
+
+		uint i = index * 4u;
+
+		vec4 s0 = texelFetch1D( tex, i + 0u );
+		vec4 s1 = texelFetch1D( tex, i + 1u );
+		vec4 s2 = texelFetch1D( tex, i + 2u );
+		vec4 s3 = texelFetch1D( tex, i + 3u );
+
+		Light l;
+		l.position = s0.rgb;
+
+		l.color = s1.rgb;
+		l.intensity = s1.a;
+
+		l.u = s2.rgb;
+		l.v = s3.rgb;
+		l.area = s3.a;
+
+		return l;
+
+	}
+
+`;

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -234,4 +234,42 @@ export const shaderUtils = /* glsl */`
 		return ( - 0.69813170079773212 * x * x - 0.87266462599716477 ) * x + 1.5707963267948966;
 
 	}
+
+	bool intersectsRectangle( vec3 position, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
+
+		float dt = dot( rayDirection, normal );
+		float t = ( dot( normal, position ) - dot( normal, rayOrigin ) ) / dt;
+
+		if ( t > EPSILON ) {
+
+			vec3 hit = rayOrigin + rayDirection * t;
+			vec3 vi = hit - position;
+			float a1 = dot( u, vi );
+			if ( a1 >= - 0.5 && a1 <= 0.5 ) {
+
+				float a2 = dot( v, vi );
+				if ( a2 >= - 0.5 && a2 <= 0.5 ) {
+
+					dist = t;
+					return true;
+
+				}
+
+			}
+
+		}
+
+		return false;
+
+	}
+
+	// power heuristic for multiple importance sampling
+	float misHeuristic( float a, float b ) {
+
+		float aa = a * a;
+		float bb = b * b;
+		return aa / ( aa + bb );
+
+	}
+
 `;

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -236,20 +236,24 @@ export const shaderUtils = /* glsl */`
 
 	}
 
-	bool intersectsRectangle( vec3 position, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
+	// Finds the point where the ray intersects the plane defined by u and v and checks if this point
+	// falls in the bounds of the rectangle on that same plane.
+	// Plane intersection: https://lousodrome.net/blog/light/2020/07/03/intersection-of-a-ray-and-a-plane/
+	bool intersectsRectangle( vec3 center, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
 
-		float dt = dot( rayDirection, normal );
-		float t = ( dot( normal, position ) - dot( normal, rayOrigin ) ) / dt;
+		float t = dot( center - rayOrigin, normal ) / dot( rayDirection, normal );
 
 		if ( t > EPSILON ) {
 
-			vec3 hit = rayOrigin + rayDirection * t;
-			vec3 vi = hit - position;
+			vec3 p = rayOrigin + rayDirection * t;
+			vec3 vi = p - center;
+
+			// check if p falls inside the rectangle
 			float a1 = dot( u, vi );
-			if ( a1 >= - 0.5 && a1 <= 0.5 ) {
+			if ( abs( a1 ) <= 0.5 ) {
 
 				float a2 = dot( v, vi );
-				if ( a2 >= - 0.5 && a2 <= 0.5 ) {
+				if ( abs( a2 ) <= 0.5 ) {
 
 					dist = t;
 					return true;
@@ -270,7 +274,7 @@ export const shaderUtils = /* glsl */`
 		float aa = a * a;
 		float bb = b * b;
 		return aa / ( aa + bb );
-  
+
 	}
 
 	// An acos with input values bound to the range [-1, 1].

--- a/src/uniforms/LightsTexture.js
+++ b/src/uniforms/LightsTexture.js
@@ -1,0 +1,83 @@
+import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, Vector3, Quaternion } from 'three';
+
+const LIGHT_PIXELS = 4;
+
+export class LightsTexture extends DataTexture {
+
+	constructor() {
+
+		super( new Float32Array( 4 ), 1, 1 );
+
+		this.format = RGBAFormat;
+		this.type = FloatType;
+		this.wrapS = ClampToEdgeWrapping;
+		this.wrapT = ClampToEdgeWrapping;
+		this.generateMipmaps = false;
+
+	}
+
+	updateFrom( lights ) {
+
+		let index = 0;
+		const pixelCount = lights.length * LIGHT_PIXELS;
+		const dimension = Math.ceil( Math.sqrt( pixelCount ) );
+
+		if ( this.image.width !== dimension ) {
+
+			this.dispose();
+
+			this.image.data = new Float32Array( dimension * dimension * 4 );
+			this.image.width = dimension;
+			this.image.height = dimension;
+
+		}
+
+		const floatArray = this.image.data;
+
+		const u = new Vector3();
+		const v = new Vector3();
+		const worldQuaternion = new Quaternion();
+
+		for ( let i = 0, l = lights.length; i < l; i ++ ) {
+
+			const l = lights[ i ];
+
+		    // position
+			l.getWorldPosition( v );
+			floatArray[ index ++ ] = v.x;
+			floatArray[ index ++ ] = v.y;
+			floatArray[ index ++ ] = v.z;
+			index ++;
+
+			// color
+			floatArray[ index ++ ] = l.color.r;
+			floatArray[ index ++ ] = l.color.g;
+			floatArray[ index ++ ] = l.color.b;
+
+			// intensity
+			floatArray[ index ++ ] = l.intensity;
+
+		    // u vector
+		    l.getWorldQuaternion( worldQuaternion );
+		    u.set( l.width, 0, 0 ).applyQuaternion( worldQuaternion );
+			floatArray[ index ++ ] = u.x;
+			floatArray[ index ++ ] = u.y;
+			floatArray[ index ++ ] = u.z;
+			index ++;
+
+		    // v vector
+		    v.set( 0, l.height, 0 ).applyQuaternion( worldQuaternion );
+			floatArray[ index ++ ] = v.x;
+			floatArray[ index ++ ] = v.y;
+			floatArray[ index ++ ] = v.z;
+
+			// area
+			floatArray[ index ++ ] = u.cross( v ).length();
+
+		}
+
+		this.needsUpdate = true;
+
+	}
+
+}

--- a/src/uniforms/LightsTexture.js
+++ b/src/uniforms/LightsTexture.js
@@ -42,7 +42,7 @@ export class LightsTexture extends DataTexture {
 
 			const l = lights[ i ];
 
-		    // position
+			// position
 			l.getWorldPosition( v );
 			floatArray[ index ++ ] = v.x;
 			floatArray[ index ++ ] = v.y;
@@ -57,16 +57,16 @@ export class LightsTexture extends DataTexture {
 			// intensity
 			floatArray[ index ++ ] = l.intensity;
 
-		    // u vector
-		    l.getWorldQuaternion( worldQuaternion );
-		    u.set( l.width, 0, 0 ).applyQuaternion( worldQuaternion );
+			// u vector
+			l.getWorldQuaternion( worldQuaternion );
+			u.set( l.width, 0, 0 ).applyQuaternion( worldQuaternion );
 			floatArray[ index ++ ] = u.x;
 			floatArray[ index ++ ] = u.y;
 			floatArray[ index ++ ] = u.z;
 			index ++;
 
-		    // v vector
-		    v.set( 0, l.height, 0 ).applyQuaternion( worldQuaternion );
+			// v vector
+			v.set( 0, l.height, 0 ).applyQuaternion( worldQuaternion );
 			floatArray[ index ++ ] = v.x;
 			floatArray[ index ++ ] = v.y;
 			floatArray[ index ++ ] = v.z;

--- a/src/workers/PathTracingSceneWorker.js
+++ b/src/workers/PathTracingSceneWorker.js
@@ -14,7 +14,7 @@ export class PathTracingSceneWorker extends PathTracingSceneGenerator {
 	generate( scene, options = {} ) {
 
 		const { bvhGenerator } = this;
-		const { geometry, materials, textures } = this.prepScene( scene );
+		const { geometry, materials, textures, lights } = this.prepScene( scene );
 
 		const bvhOptions = { strategy: SAH, ...options, maxLeafTris: 1 };
 		const bvhPromise = bvhGenerator.generate( geometry, bvhOptions );
@@ -24,6 +24,7 @@ export class PathTracingSceneWorker extends PathTracingSceneGenerator {
 				scene,
 				materials,
 				textures,
+				lights,
 				bvh,
 			};
 


### PR DESCRIPTION
Initial version of supporting (rectangular) area lights. I tried to keep the changes straightforward and clear. I've also added an example. Apologies for it being a bit lacklustre, but it does demonstrate how much quicker the image converges due to NEE and MIS. Though, the benefit of MIS on top of NEE does appear to be limited in this scene. 

Not sure about the naming of some of the methods and variables, so any comments or suggestions are appreciated. The handling of the environment map can be further improved. It's now half-way in between being a light type (uniformly picked along with the area lights for NEE), yet at the same time still distinct. 

Couple of remarks (in no particular order):
- The `THREE.RectAreaLight` emits light from the back face. I've implemented it this way in the shader as well.
- The existing `misHeuristic` contained a bug and didn't actually implement the power heuristic, but accidentally the balance heuristic (`a^2 / (a^2 + b^2)` was accidentially `a^2 / (a^2 + ab)` which simplifies to just `a / (a + b)` :slightly_smiling_face: 
- Next-event estimation picks uniformly between any of the lights or the env map.

**Area lights (with MIS and NEE 293 samples)**
![image](https://user-images.githubusercontent.com/8823461/173152178-35f797c4-2db5-4623-a20c-95da67cd3fc3.png)
**Area lights (without MIS and NEE 1400 samples)**
![image](https://user-images.githubusercontent.com/8823461/173152143-f508be43-85e5-4d55-bcb4-2789d248a8cf.png)
**Area lights (without MIS and NEE 50k samples)**
![image](https://user-images.githubusercontent.com/8823461/173152693-2bfe3faa-fe11-417b-b72f-b0995d38fe3a.png)
