### PR TITLE
Fix for artifacts introduced by Perfect Specular Reflections feature

### DIFF
--- a/src/shader/shaderGGXFunctions.js
+++ b/src/shader/shaderGGXFunctions.js
@@ -72,17 +72,18 @@ float ggxDistribution( vec3 halfVector, float roughness ) {
 
 	// See equation (33) from reference [0]
 	float a2 = roughness * roughness;
+	a2 = max( EPSILON, a2 );
 	float cosTheta = halfVector.z;
 	float cosTheta4 = pow( cosTheta, 4.0 );
 
 	if ( cosTheta == 0.0 ) return 0.0;
 
-	float theta = ( roughness == 0.0 ) ? acosApprox( halfVector.z ) : acosSafe( halfVector.z );
+	float theta = acosSafe( halfVector.z );
 	float tanTheta = tan( theta );
 	float tanTheta2 = pow( tanTheta, 2.0 );
 
 	float denom = PI * cosTheta4 * pow( a2 + tanTheta2, 2.0 );
-	return ( denom < 1e-12 ) ? PI : ( a2 / denom );
+	return ( a2 / denom );
 
 	// See equation (1) from reference [2]
 	// const { x, y, z } = halfVector;

--- a/src/shader/shaderGGXFunctions.js
+++ b/src/shader/shaderGGXFunctions.js
@@ -77,12 +77,12 @@ float ggxDistribution( vec3 halfVector, float roughness ) {
 
 	if ( cosTheta == 0.0 ) return 0.0;
 
-	float theta = acosApprox( halfVector.z );
+	float theta = ( roughness == 0.0 ) ? acosApprox( halfVector.z ) : acosSafe( halfVector.z );
 	float tanTheta = tan( theta );
 	float tanTheta2 = pow( tanTheta, 2.0 );
 
 	float denom = PI * cosTheta4 * pow( a2 + tanTheta2, 2.0 );
-	return denom < 1e-6 ? 1.0 : a2 / denom;
+	return ( denom < 1e-12 ) ? PI : ( a2 / denom );
 
 	// See equation (1) from reference [2]
 	// const { x, y, z } = halfVector;

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -227,11 +227,20 @@ export const shaderUtils = /* glsl */`
 	}
 
 	// Fast arccos approximation used to remove banding artifacts caused by numerical errors in acos.
-	// This is a cubic Lagrange interpolating polynomial for x = [-1, -1/2, 0, 1/2, 1].	
-	// Source: https://stackoverflow.com/questions/3380628/fast-arc-cos-algorithm/answer#3380723	
+	// This is a cubic Lagrange interpolating polynomial for x = [-1, -1/2, 0, 1/2, 1].
+	// For more information see: https://github.com/gkjohnson/three-gpu-pathtracer/pull/171#issuecomment-1152275248
 	float acosApprox( float x ) {
 
+		x = clamp( x, -1.0, 1.0 );
 		return ( - 0.69813170079773212 * x * x - 0.87266462599716477 ) * x + 1.5707963267948966;
 
 	}
+
+	// An acos with input values bound to the range [-1, 1].
+	float acosSafe( float x ) {
+
+		return acos( clamp( x, -1.0, 1.0 ) );
+
+	}
+
 `;


### PR DESCRIPTION
Problem reported in https://github.com/gkjohnson/three-gpu-pathtracer/pull/171#issuecomment-1152805532

`ggxDistribution` now uses `acosApprox` only when `roughness` is zero, otherwise uses the introduced `acosSafe` which is clamped to the input range [-1, 1]. Lowered the epsilon check for `denom`, returning Pi as a suitably large value in this case.

**Before the fix:**
![Screenshot 2022-06-11 at 08-57-21 Material Orb Path Tracing](https://user-images.githubusercontent.com/868396/173179604-654c3ee1-c68b-47a4-bd2f-a188ab0b7fe9.png)

**After the fix:**
![Screenshot 2022-06-11 at 08-59-05 Material Orb Path Tracing](https://user-images.githubusercontent.com/868396/173179611-92e8227b-da1d-42b6-8e83-12126d7b767a.png)

**Banding artifacts remain solved in the roughness = 0 case:**
![Screenshot 2022-06-11 at 09-08-10 Material Orb Path Tracing](https://user-images.githubusercontent.com/868396/173179641-3e10e039-ac31-41e6-bfac-6281815b4595.png)

**The mirror box scene still shows perfect reflections for each bounce:**
![Screenshot 2022-06-11 at 09-01-41 Material Orb Path Tracing](https://user-images.githubusercontent.com/868396/173179682-cbe98d7e-6f29-4c0d-b49d-d8d033774fe7.png)

**No noticeable artifacts in the other example scenes:**
![Screenshot 2022-06-11 at 09-06-30 PBR Path Tracing](https://user-images.githubusercontent.com/868396/173179720-5604b40d-d8df-42bd-88d6-fe5983b33308.png)
![Screenshot 2022-06-11 at 09-04-15 Interior Scene Path Tracing](https://user-images.githubusercontent.com/868396/173179731-37e56459-23b7-453c-8f9e-b71a8b400449.png)

