### PR TITLE
Support for spot lights with IES profiles

### DIFF
--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -16,12 +16,14 @@ const params = {
 	controls: true,
 
 	areaLight1Enabled: true,
-	areaLight2Enabled: true,
+	areaLight1IsCircular: false,
 	areaLight1Intensity: 5,
 	areaLight1Color: '#ffffff',
 	areaLight1Width: 1,
 	areaLight1Height: 1,
 
+	areaLight2Enabled: true,
+	areaLight2IsCircular: false,
 	areaLight2Intensity: 20,
 	areaLight2Color: '#ff0000',
 	areaLight2Width: 1.25,
@@ -144,12 +146,14 @@ async function init() {
 	areaLight1.position.z = - 0.5;
 	areaLight1.rotateZ( - Math.PI / 4 );
 	areaLight1.rotateX( - Math.PI / 2 );
+	areaLight1.isCircular = false;
 	group.add( areaLight1 );
 
-	const areaLight2 = new THREE.RectAreaLight( new THREE.Color( 0xff0000 ), 15.0, 1.25, 2.75 );
+	const areaLight2 = new THREE.RectAreaLight( new THREE.Color( 0xFF0000 ), 15.0, 1.25, 2.75 );
 	areaLight2.position.y = 1.25;
 	areaLight2.position.z = - 1.5;
 	areaLight2.rotateX( Math.PI );
+	areaLight2.isCircular = false;
 	group.add( areaLight2 );
 
 	areaLights = [ areaLight1, areaLight2 ];
@@ -274,6 +278,7 @@ async function init() {
 
 	const areaLight1Folder = gui.addFolder( 'Area Light 1' );
 	areaLight1Folder.add( params, 'areaLight1Enabled' ).name( 'enable' ).onChange( updateLights );
+	areaLight1Folder.add( params, 'areaLight1IsCircular' ).name( 'isCircular' ).onChange( updateLights );
 	areaLight1Folder.add( params, 'areaLight1Intensity', 0, 200 ).name( 'intensity' ).onChange( updateLights );
 	areaLight1Folder.addColor( params, 'areaLight1Color' ).name( 'color' ).onChange( updateLights );
 	areaLight1Folder.add( params, 'areaLight1Width', 0, 5 ).name( 'width' ).onChange( updateLights );
@@ -281,6 +286,7 @@ async function init() {
 
 	const areaLight2Folder = gui.addFolder( 'Area Light 2' );
 	areaLight2Folder.add( params, 'areaLight2Enabled' ).name( 'enable' ).onChange( updateLights );
+	areaLight2Folder.add( params, 'areaLight2IsCircular' ).name( 'isCircular' ).onChange( updateLights );
 	areaLight2Folder.add( params, 'areaLight2Intensity', 0, 200 ).name( 'intensity' ).onChange( updateLights );
 	areaLight2Folder.addColor( params, 'areaLight2Color' ).name( 'color' ).onChange( updateLights );
 	areaLight2Folder.add( params, 'areaLight2Width', 0, 5 ).name( 'width' ).onChange( updateLights );
@@ -294,11 +300,13 @@ async function init() {
 
 function updateLights() {
 
+	areaLights[ 0 ].isCircular = params.areaLight1IsCircular;
 	areaLights[ 0 ].intensity = params.areaLight1Intensity;
 	areaLights[ 0 ].width = params.areaLight1Width;
 	areaLights[ 0 ].height = params.areaLight1Height;
 	areaLights[ 0 ].color.set( params.areaLight1Color ).convertSRGBToLinear();
 
+	areaLights[ 1 ].isCircular = params.areaLight2IsCircular;
 	areaLights[ 1 ].intensity = params.areaLight2Intensity;
 	areaLights[ 1 ].width = params.areaLight2Width;
 	areaLights[ 1 ].height = params.areaLight2Height;
@@ -335,6 +343,7 @@ function animate() {
 	requestAnimationFrame( animate );
 
 	ptRenderer.material.materials.updateFrom( sceneInfo.materials, sceneInfo.textures );
+	ptRenderer.material.lights.updateFrom( areaLights );
 
 	ptRenderer.material.filterGlossyFactor = params.filterGlossyFactor;
 	ptRenderer.material.environmentIntensity = params.environmentIntensity;
@@ -357,7 +366,3 @@ function animate() {
 	samplesEl.innerText = `Samples: ${ Math.floor( ptRenderer.samples ) }`;
 
 }
-
-
-
-

--- a/example/spotLights.html
+++ b/example/spotLights.html
@@ -1,0 +1,61 @@
+<html>
+	<head>
+		<title>Spot Lights Path Tracing</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+		<style>
+			html, body {
+				margin: 0;
+				padding: 0;
+				background-color: #111;
+			}
+
+			#info {
+				position: absolute;
+				bottom: 0;
+				left: 0;
+				font-family: 'Courier New', Courier, monospace;
+				color: white;
+				pointer-events: none;
+			}
+
+			#samples, #credits {
+
+				opacity: 0.5;
+				background-color: rgba( 0.0, 0.0, 0.0, 0.5 );
+				padding: 5px;
+				display: inline-block;
+
+			}
+
+			#loading {
+				position: absolute;
+				left: 50%;
+				top: 50%;
+				transform: translate(-50%, -50%);
+				color: white;
+				font-family: 'Courier New', Courier, monospace;
+			}
+
+			.checkerboard {
+				background-image:
+					linear-gradient(45deg, #222 25%, transparent 25%),
+					linear-gradient(-45deg, #222 25%, transparent 25%),
+					linear-gradient(45deg, transparent 75%, #222 75%),
+					linear-gradient(-45deg, transparent 75%, #222 75%);
+				background-size: 20px 20px;
+				background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+			}
+		</style>
+
+	</head>
+	<body>
+		<div id="loading">LOADING</div>
+		<div id="info">
+			<div>
+				<div id="samples">--</div>
+			</div>
+		</div>
+		<script src="./spotLights.js" type="module"></script>
+	</body>
+</html>

--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -9,7 +9,7 @@ import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.j
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
 
-let renderer, controls, transformControlsScene, spotLight1, lights, spotLightHelpers, sceneInfo, ptRenderer, activeCamera, fsQuad, materials;
+let renderer, controls, transformControlsScene, spotLight1, lights, spotLights, spotLightHelpers, sceneInfo, ptRenderer, activeCamera, fsQuad, materials;
 let perspectiveCamera, orthoCamera;
 let envMap, envMapGenerator, scene;
 let samplesEl;
@@ -272,6 +272,7 @@ async function init() {
 			// spot lights
 			spotLightHelpers = [ ];
 			lights = [ ];
+			spotLights = [ ];
 
 			const decays = [ 0, 1.5, 0, 0.25, 0 ];
 			for ( let i = 0; i < 5; ++ i ) {
@@ -283,8 +284,7 @@ async function init() {
 				spotLight.penumbra = 0.0;
 				spotLight.decay = decays[ i ];
 				spotLight.distance = 0.0;
-				spotLight.intensity = 50.0;
-				spotLight.lampIntensityScale = 0.0;
+				spotLight.intensity = 150.0;
 				spotLight.radius = 0.5;
 				spotLight.iesProfile = - 1 + i;
 
@@ -295,6 +295,7 @@ async function init() {
 				spotLight.shadow.focus = 1.0;
 				spotLight.castShadow = true;
 
+				spotLights.push( spotLight );
 				lights.push( spotLight );
 
 				const targetObject = new THREE.Object3D();
@@ -373,7 +374,7 @@ async function init() {
 
 			scene.add( result.scene );
 
-			const { bvh, textures, materials, lights } = result;
+			const { bvh, textures, materials, lights, spotLights } = result;
 			const geometry = bvh.geometry;
 			const material = ptRenderer.material;
 
@@ -387,6 +388,8 @@ async function init() {
 			material.iesProfiles.updateFrom( renderer, iesProfileURLs );
 			material.lights.updateFrom( lights );
 			material.lightCount = lights.length;
+			material.spotLights.updateFrom( spotLights );
+			material.spotLightCount = spotLights.length;
 
 			generator.dispose();
 
@@ -550,7 +553,7 @@ async function init() {
 	matFolder3.add( params.material3, 'castShadow' ).onChange( reset );
 	matFolder3.close();
 
-	const matFolder4 = gui.addFolder( 'Floor Material' );
+	const matFolder4 = gui.addFolder( 'Wall Material' );
 	matFolder4.addColor( params.material4, 'color' ).onChange( reset );
 	matFolder4.add( params.material4, 'roughness', 0, 1 ).onChange( reset );
 	matFolder4.add( params.material4, 'metalness', 0, 1 ).onChange( reset );
@@ -570,7 +573,6 @@ async function init() {
 	matFolder5.add( spotLight1, 'distance', 0.0, 20.0 ).onChange( reset );
 	matFolder5.add( spotLight1, 'angle', 0.0, Math.PI / 2.0 ).onChange( reset );
 	matFolder5.add( spotLight1, 'penumbra', 0.0, 1.0 ).onChange( reset );
-	matFolder5.add( spotLight1, 'lampIntensityScale', 0.0, 1.0 ).onChange( reset );
 	matFolder5.add( spotLight1, 'iesProfile', - 1, iesProfileURLs.length - 1, 1 ).onChange( reset );
 
 	animate();
@@ -706,6 +708,7 @@ function animate() {
 	ptRenderer.material.physicalCamera.updateFrom( activeCamera );
 
 	ptRenderer.material.lights.updateFrom( lights );
+	ptRenderer.material.spotLights.updateFrom( spotLights );
 
 	activeCamera.updateMatrixWorld();
 

--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -315,7 +315,7 @@ async function init() {
 					spotLight.add( spotLightHelper );
 					transformControlsScene.add( spotLightHelper );
 
-					spotLightHelpers.push ( spotLightHelper );
+					spotLightHelpers.push( spotLightHelper );
 
 					spotLight1 = spotLight;
 

--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -1,0 +1,753 @@
+import * as THREE from 'three';
+import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { PathTracingRenderer, PhysicalPathTracingMaterial, PhysicalCamera, BlurredEnvMapGenerator } from '../src/index.js';
+import { PathTracingSceneWorker } from '../src/workers/PathTracingSceneWorker.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
+
+let renderer, controls, transformControlsScene, spotLight1, lights, spotLightHelpers, sceneInfo, ptRenderer, activeCamera, fsQuad, materials;
+let perspectiveCamera, orthoCamera;
+let envMap, envMapGenerator, scene;
+let samplesEl;
+
+const orthoWidth = 5;
+
+const iesProfileURLs = [
+	'https://gist.githubusercontent.com/richardassar/0241a4c03091fc61d7d727d61480f1ed/raw/780409421bf8efe6cc828314d456aa2c8803976c/108b32f07d6d38a7a6528a6d307440df.ies',
+	'https://gist.githubusercontent.com/richardassar/80a5be46f3bf2e91c98cba093f60a443/raw/8650c0c019bfdb120ecc07917c97de9e86c0438d/1aec5958092c236d005093ca27ebe378.ies',
+	'https://gist.githubusercontent.com/richardassar/a5f4362935b59bb8c5ea822f17b178bc/raw/bd03ff9716a0217577d5b0f91c9ee06b363b87d0/02a7562c650498ebb301153dbbf59207.ies',
+	'https://gist.githubusercontent.com/richardassar/8a712f70b99da706a13f4e902b5508e9/raw/d0d469e128b5cdec23cfe1dd10854846f8a6a1c4/1a936937a49c63374e6d4fbed9252b29.ies',
+	'https://gist.githubusercontent.com/richardassar/6cbb7abf80f73a2ca10d39f7d7587556/raw/a459770128719d0af76eac8076376dd4b708e834/00c6ce79e1d2cdf3a1fb491aaaa47ae0.ies'
+];
+
+const params = {
+
+	material1: {
+		color: '#ffc766',
+		emissive: '#FFFFFF',
+		emissiveIntensity: 0.0,
+		roughness: 0.2,
+		metalness: 1.0,
+		ior: 1.495,
+		transmission: 0.0,
+		opacity: 1.0,
+		matte: false,
+		castShadow: true,
+	},
+	material2: {
+		color: '#db7157',
+		emissive: '#FFFFFF',
+		emissiveIntensity: 0,
+		roughness: 0.0,
+		metalness: 0.8,
+		transmission: 0.0,
+		ior: 1.495,
+		opacity: 1.0,
+		matte: false,
+		castShadow: true,
+	},
+	material3: {
+		color: '#3465a4',
+		roughness: 0.4,
+		metalness: 0.4,
+		matte: false,
+		castShadow: false,
+		receiveShadow: true
+	},
+	material4: {
+		color: '#FFFFFF',
+		emissive: '#FFFFFF',
+		emissiveIntensity: 0.0,
+		roughness: 0.4,
+		metalness: 0.1,
+		matte: false,
+		castShadow: false,
+		transmission: 0.0,
+		opacity: 1.0,
+	},
+
+	multipleImportanceSampling: true,
+	stableNoise: false,
+	environmentIntensity: 0.5,
+	environmentRotation: 0,
+	environmentBlur: 0.0,
+	backgroundBlur: 0.05,
+	bounces: 3,
+	samplesPerFrame: 1,
+	acesToneMapping: true,
+	resolutionScale: 1 / window.devicePixelRatio, // TODO: remove before commit
+	transparentTraversals: 20,
+	filterGlossyFactor: 0.5,
+	tiles: 1,
+	backgroundAlpha: 1,
+	checkerboardTransparency: true,
+	showTransformControls: true,
+	cameraProjection: 'Perspective',
+};
+
+if ( window.location.hash.includes( 'transmission' ) ) {
+
+	params.material1.metalness = 0.0;
+	params.material1.roughness = 0.05;
+	params.material1.transmission = 1.0;
+	params.material1.color = '#ffffff';
+	params.bounces = 10;
+
+}
+
+// adjust performance parameters for mobile
+const aspectRatio = window.innerWidth / window.innerHeight;
+if ( aspectRatio < 0.65 ) {
+
+	params.bounces = Math.max( params.bounces, 6 );
+	params.resolutionScale *= 0.5;
+	params.tiles = 2;
+	params.multipleImportanceSampling = false;
+	params.environmentBlur = 0.35;
+
+}
+
+init();
+
+async function init() {
+
+	renderer = new THREE.WebGLRenderer( { antialias: true } );
+	renderer.toneMapping = THREE.ACESFilmicToneMapping;
+	renderer.setClearColor( 0, 0 );
+	renderer.shadowMap.enabled = true;
+	//renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+	document.body.appendChild( renderer.domElement );
+
+	const aspect = window.innerWidth / window.innerHeight;
+	perspectiveCamera = new PhysicalCamera( 75, aspect, 0.025, 500 );
+	perspectiveCamera.position.set( 16, 2, 15 );
+
+	const orthoHeight = orthoWidth / aspect;
+	orthoCamera = new THREE.OrthographicCamera( orthoWidth / - 2, orthoWidth / 2, orthoHeight / 2, orthoHeight / - 2, 0, 100 );
+	orthoCamera.position.set( - 4, 2, 3 );
+
+	ptRenderer = new PathTracingRenderer( renderer );
+	ptRenderer.alpha = true;
+	ptRenderer.material = new PhysicalPathTracingMaterial();
+	ptRenderer.material.setDefine( 'TRANSPARENT_TRAVERSALS', params.transparentTraversals );
+	ptRenderer.material.setDefine( 'FEATURE_MIS', Number( params.multipleImportanceSampling ) );
+	ptRenderer.tiles.set( params.tiles, params.tiles );
+
+	fsQuad = new FullScreenQuad( new THREE.MeshBasicMaterial( {
+		map: ptRenderer.target.texture,
+		blending: THREE.CustomBlending,
+	} ) );
+
+	controls = new OrbitControls( perspectiveCamera, renderer.domElement );
+	controls.target.set( 16, 1, 1 );
+	controls.addEventListener( 'change', () => {
+
+		ptRenderer.reset();
+
+	} );
+
+	scene = new THREE.Scene();
+
+	samplesEl = document.getElementById( 'samples' );
+
+	envMapGenerator = new BlurredEnvMapGenerator( renderer );
+
+	const envMapPromise = new Promise( resolve => {
+
+		new RGBELoader()
+			.load( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr', texture => {
+
+				envMap = texture;
+
+				updateEnvBlur();
+				resolve();
+
+			} );
+
+	} );
+
+	transformControlsScene = new THREE.Scene();
+
+	const generator = new PathTracingSceneWorker();
+	const gltfPromise = new GLTFLoader()
+		.setMeshoptDecoder( MeshoptDecoder )
+		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/main/models/material-balls/material_ball_v2.glb' )
+		.then( gltf => {
+
+			const group = new THREE.Group();
+
+			const gltfScenes =  [ ];
+
+			// objects
+			gltf.scene.scale.setScalar( 0.01 );
+			gltf.scene.position.x = 0;
+			gltf.scene.updateMatrixWorld();
+			gltf.castShadow = true;
+			gltf.receiveShadow = true;
+			group.add( gltf.scene );
+			gltfScenes.push( gltf.scene )
+
+			const box = new THREE.Box3();
+			box.setFromObject( gltf.scene );
+
+			gltf.scene = gltf.scene.clone()
+			gltf.scene.position.x += 8;
+			gltf.scene.updateMatrixWorld();
+			group.add( gltf.scene );
+			gltfScenes.push( gltf.scene )
+
+			gltf.scene = gltf.scene.clone()
+			gltf.scene.position.x += 8;
+			gltf.scene.updateMatrixWorld();
+			group.add( gltf.scene );
+			gltfScenes.push( gltf.scene )
+
+			gltf.scene = gltf.scene.clone()
+			gltf.scene.position.x += 8;
+			gltf.scene.updateMatrixWorld();
+			group.add( gltf.scene );
+			gltfScenes.push( gltf.scene )
+
+			gltf.scene = gltf.scene.clone()
+			gltf.scene.position.x += 8;
+			gltf.scene.updateMatrixWorld();
+			group.add( gltf.scene );
+			gltfScenes.push( gltf.scene )
+
+			const floor = new THREE.Mesh(
+				new THREE.CylinderBufferGeometry( 100, 100, 0.05, 200 ),
+				new THREE.MeshStandardMaterial( { color: 0xffffff, roughness: 0.5, metalness: 0.2 } ),
+			);
+			floor.geometry = floor.geometry.toNonIndexed();
+			floor.geometry.clearGroups();
+			floor.position.y = box.min.y - 0.05;
+			floor.receiveShadow = true;
+			group.add( floor );
+
+			const wall = new THREE.Mesh(
+				new THREE.BoxGeometry( 100, 10, 1 ),
+				new THREE.MeshStandardMaterial( { color: 0xffffff, roughness: 0, metalness: 1.0 } ),
+			);
+			wall.castShadow = true;
+			wall.receiveShadow = true;
+			wall.geometry = wall.geometry.toNonIndexed();
+			wall.geometry.clearGroups();
+			wall.position.x = 0.0;
+			wall.position.y = box.min.y + 0.05 + 5;
+			wall.position.z = box.min.z - 0.5;
+			group.add( wall );
+
+			// transform controls
+			let draggingSpotLight = false;
+
+			function makeTransformControls( object ) {
+
+				const transformControls = new TransformControls( perspectiveCamera, renderer.domElement );
+				transformControls.addEventListener( 'change', () => {
+
+					if( draggingSpotLight ) {
+
+						ptRenderer.reset();
+
+					}
+
+				} );
+
+				transformControls.addEventListener( 'dragging-changed', ( e ) => {
+
+					draggingSpotLight = e.value;
+					return controls.enabled = ! e.value;
+
+				} );
+
+				transformControls.attach( object );
+				transformControlsScene.add( transformControls );
+
+			}
+
+			// spot lights
+			spotLightHelpers = [ ];
+			lights = [ ];
+
+			const decays = [ 0, 1.5, 0, 0.25, 0 ];
+			for( let i = 0; i < 5; ++ i) {
+
+				const spotLight = new THREE.SpotLight( 0xffffff );
+
+				spotLight.position.set( i * 8, 7.0, 0.005 );
+				spotLight.angle = Math.PI / 8.0;
+				spotLight.penumbra = 0.0;
+				spotLight.decay = decays [ i ];
+				spotLight.distance = 0.0;
+				spotLight.intensity = 50.0;
+				spotLight.lampIntensityScale = 0.0;
+				spotLight.radius = 0.5;
+				spotLight.iesProfile = -1 + i;
+
+				spotLight.shadow.mapSize.width = 512;
+				spotLight.shadow.mapSize.height = 512;
+				spotLight.shadow.camera.near = 0.1;
+				spotLight.shadow.camera.far = 10.0;
+				spotLight.shadow.focus = 1.0;
+				spotLight.castShadow = true;
+
+				lights.push( spotLight );
+
+				const targetObject = new THREE.Object3D();
+				targetObject.position.x = i * 8.0;
+				targetObject.position.y = floor.position.y + 0.05;
+				targetObject.position.z = 0.05;
+				targetObject.updateMatrixWorld();
+				spotLight.updateMatrixWorld();
+				group.add( targetObject );
+
+				spotLight.target = targetObject;
+
+				group.add( spotLight );
+
+				if ( i == 0 ) {
+
+					const spotLightHelper = new THREE.SpotLightHelper( spotLight );
+					spotLight.add( spotLightHelper );
+					transformControlsScene.add(spotLightHelper);
+
+					spotLightHelpers.push ( spotLightHelper );
+
+					spotLight1 = spotLight;
+
+					makeTransformControls( spotLight );
+					makeTransformControls( targetObject );
+
+				}
+
+			}
+
+			// materials
+			const material1 = new THREE.MeshStandardMaterial();
+			const material2 = new THREE.MeshStandardMaterial();
+
+			gltfScenes.forEach( gltfScene => {
+
+				gltfScene.traverse( c => {
+
+					// the vertex normals on the material ball are off...
+					// TODO: precompute the vertex normals so they are correct on load
+					if ( c.geometry ) {
+
+						c.geometry.computeVertexNormals();
+
+					}
+
+					if ( c.name === 'Sphere_1' ) {
+
+						c.material = material2;
+
+					} else {
+
+						c.material = material1;
+
+					}
+
+					if ( c.name === 'subsphere_1' ) {
+
+						c.material = material2;
+
+					}
+
+				} );
+
+			} );
+
+			materials = [ material1, material2, floor.material, wall.material ];
+
+			return generator.generate( group );
+
+		} )
+		.then( result => {
+
+			sceneInfo = result;
+
+			scene.add( result.scene );
+
+			const { bvh, textures, materials, lights } = result;
+			const geometry = bvh.geometry;
+			const material = ptRenderer.material;
+
+			material.bvh.updateFrom( bvh );
+			material.normalAttribute.updateFrom( geometry.attributes.normal );
+			material.tangentAttribute.updateFrom( geometry.attributes.tangent );
+			material.uvAttribute.updateFrom( geometry.attributes.uv );
+			material.materialIndexAttribute.updateFrom( geometry.attributes.materialIndex );
+			material.textures.setTextures( renderer, 2048, 2048, textures );
+			material.materials.updateFrom( materials, textures );
+			material.iesProfiles.updateFrom( renderer, iesProfileURLs );
+			material.lights.updateFrom( lights );
+			material.lightCount = lights.length;
+
+			generator.dispose();
+
+		} );
+
+	await Promise.all( [ gltfPromise, envMapPromise ] );
+
+	document.getElementById( 'loading' ).remove();
+	document.body.classList.add( 'checkerboard' );
+
+	onResize();
+	window.addEventListener( 'resize', onResize );
+	const gui = new GUI();
+
+	updateCamera( params.cameraProjection );
+
+	const ptFolder = gui.addFolder( 'Path Tracing' );
+	ptFolder.add( params, 'acesToneMapping' ).onChange( value => {
+
+		renderer.toneMapping = value ? THREE.ACESFilmicToneMapping : THREE.NoToneMapping;
+		fsQuad.material.needsUpdate = true;
+
+	} );
+	ptFolder.add( params, 'stableNoise' ).onChange( value => {
+
+		ptRenderer.stableNoise = value;
+
+	} );
+	ptFolder.add( params, 'multipleImportanceSampling' ).onChange( value => {
+
+		ptRenderer.material.setDefine( 'FEATURE_MIS', Number( value ) );
+		ptRenderer.reset();
+
+	} );
+	ptFolder.add( params, 'tiles', 1, 4, 1 ).onChange( value => {
+
+		ptRenderer.tiles.set( value, value );
+
+	} );
+	ptFolder.add( params, 'samplesPerFrame', 1, 10, 1 );
+	ptFolder.add( params, 'filterGlossyFactor', 0, 1 ).onChange( () => {
+
+		ptRenderer.reset();
+
+	} );
+	ptFolder.add( params, 'bounces', 1, 30, 1 ).onChange( () => {
+
+		ptRenderer.reset();
+
+	} );
+	ptFolder.add( params, 'transparentTraversals', 0, 40, 1 ).onChange( value => {
+
+		ptRenderer.material.setDefine( 'TRANSPARENT_TRAVERSALS', value );
+		ptRenderer.reset();
+
+	} );
+	ptFolder.add( params, 'resolutionScale', 0.1, 1 ).onChange( () => {
+
+		onResize();
+
+	} );
+
+	const envFolder = gui.addFolder( 'Environment' );
+	envFolder.add( params, 'environmentIntensity', 0, 10 ).onChange( () => {
+
+		ptRenderer.reset();
+
+	} );
+	envFolder.add( params, 'environmentRotation', 0, 2 * Math.PI ).onChange( v => {
+
+		ptRenderer.material.environmentRotation.setFromMatrix4( new THREE.Matrix4().makeRotationY( v ) );
+		ptRenderer.reset();
+
+	} );
+	envFolder.add( params, 'environmentBlur', 0, 1 ).onChange( () => {
+
+		updateEnvBlur();
+
+	} );
+	envFolder.add( params, 'backgroundBlur', 0, 1 ).onChange( () => {
+
+		ptRenderer.reset();
+
+	} );
+	envFolder.add( params, 'backgroundAlpha', 0, 1 ).onChange( () => {
+
+		ptRenderer.reset();
+
+	} );
+	envFolder.add( params, 'checkerboardTransparency' ).onChange( v => {
+
+		if ( v ) {
+
+			document.body.classList.add( 'checkerboard' );
+
+		} else {
+
+			document.body.classList.remove( 'checkerboard' );
+
+		}
+
+	} );
+	envFolder.add( params, 'showTransformControls' );
+
+	const cameraFolder = gui.addFolder( 'Camera' );
+	cameraFolder.add( params, 'cameraProjection', [ 'Perspective', 'Orthographic' ] ).onChange( v => {
+
+		updateCamera( v );
+
+	} );
+	cameraFolder.add( perspectiveCamera, 'focusDistance', 1, 100 ).onChange( reset );
+	cameraFolder.add( perspectiveCamera, 'apertureBlades', 0, 10, 1 ).onChange( function ( v ) {
+
+		perspectiveCamera.apertureBlades = v === 0 ? 0 : Math.max( v, 3 );
+		this.updateDisplay();
+		reset();
+
+	} );
+	cameraFolder.add( perspectiveCamera, 'apertureRotation', 0, 12.5 ).onChange( reset );
+	cameraFolder.add( perspectiveCamera, 'anamorphicRatio', 0.1, 10.0 ).onChange( reset );
+	cameraFolder.add( perspectiveCamera, 'bokehSize', 0, 50 ).onChange( reset ).listen();
+	cameraFolder.add( perspectiveCamera, 'fStop', 0.3, 20 ).onChange( reset ).listen();
+	cameraFolder.add( perspectiveCamera, 'fov', 25, 100 ).onChange( () => {
+
+		perspectiveCamera.updateProjectionMatrix();
+		reset();
+
+	} ).listen();
+
+	const matFolder1 = gui.addFolder( 'Shell Material' );
+	matFolder1.addColor( params.material1, 'color' ).onChange( reset );
+	matFolder1.addColor( params.material1, 'emissive' ).onChange( reset );
+	matFolder1.add( params.material1, 'emissiveIntensity', 0.0, 50.0, 0.01 ).onChange( reset );
+	matFolder1.add( params.material1, 'roughness', 0, 1 ).onChange( reset );
+	matFolder1.add( params.material1, 'metalness', 0, 1 ).onChange( reset );
+	matFolder1.add( params.material1, 'opacity', 0, 1 ).onChange( reset );
+	matFolder1.add( params.material1, 'transmission', 0, 1 ).onChange( reset );
+	matFolder1.add( params.material1, 'ior', 0.9, 3.0 ).onChange( reset );
+	matFolder1.add( params.material1, 'matte' ).onChange( reset );
+	matFolder1.add( params.material1, 'castShadow' ).onChange( reset );
+	matFolder1.close();
+
+	const matFolder2 = gui.addFolder( 'Ball Material' );
+	matFolder2.addColor( params.material2, 'color' ).onChange( reset );
+	matFolder2.addColor( params.material2, 'emissive' ).onChange( reset );
+	matFolder2.add( params.material2, 'emissiveIntensity', 0.0, 50.0, 0.01 ).onChange( reset );
+	matFolder2.add( params.material2, 'roughness', 0, 1 ).onChange( reset );
+	matFolder2.add( params.material2, 'metalness', 0, 1 ).onChange( reset );
+	matFolder2.add( params.material2, 'opacity', 0, 1 ).onChange( reset );
+	matFolder2.add( params.material2, 'transmission', 0, 1 ).onChange( reset );
+	matFolder2.add( params.material2, 'ior', 0.9, 3.0 ).onChange( reset );
+	matFolder2.add( params.material2, 'matte' ).onChange( reset );
+	matFolder2.add( params.material2, 'castShadow' ).onChange( reset );
+	matFolder2.close();
+
+	const matFolder3 = gui.addFolder( 'Floor Material' );
+	matFolder3.addColor( params.material3, 'color' ).onChange( reset );
+	matFolder3.add( params.material3, 'roughness', 0, 1 ).onChange( reset );
+	matFolder3.add( params.material3, 'metalness', 0, 1 ).onChange( reset );
+	matFolder3.add( params.material3, 'matte' ).onChange( reset );
+	matFolder3.add( params.material3, 'castShadow' ).onChange( reset );
+	matFolder3.close();
+
+	const matFolder4 = gui.addFolder( 'Floor Material' );
+	matFolder4.addColor( params.material4, 'color' ).onChange( reset );
+	matFolder4.add( params.material4, 'roughness', 0, 1 ).onChange( reset );
+	matFolder4.add( params.material4, 'metalness', 0, 1 ).onChange( reset );
+	matFolder4.add( params.material4, 'matte' ).onChange( reset );
+	matFolder4.add( params.material4, 'castShadow' ).onChange( reset );
+	matFolder4.addColor( params.material4, 'emissive' ).onChange( reset );
+	matFolder4.add( params.material4, 'emissiveIntensity', 0.0, 50.0, 0.01 ).onChange( reset );
+	matFolder4.add( params.material4, 'transmission', 0, 1 ).onChange( reset );
+	matFolder4.add( params.material4, 'opacity', 0, 1 ).onChange( reset );
+	matFolder4.close();
+
+	const matFolder5 = gui.addFolder( 'Spot Light' );
+	matFolder5.addColor( spotLight1, 'color' ).onChange( reset );
+	matFolder5.add( spotLight1, 'intensity', 0.0, 200.0, 0.01 ).onChange( reset );
+	matFolder5.add( spotLight1, 'radius', 0.0, 10.0 ).onChange( reset );
+	matFolder5.add( spotLight1, 'decay', 0.0, 2.0 ).onChange( reset );
+	matFolder5.add( spotLight1, 'distance', 0.0, 20.0 ).onChange( reset );
+	matFolder5.add( spotLight1, 'angle', 0.0, Math.PI / 2.0 ).onChange( reset );
+	matFolder5.add( spotLight1, 'penumbra', 0.0, 1.0 ).onChange( reset );
+	matFolder5.add( spotLight1, 'lampIntensityScale', 0.0, 1.0 ).onChange( reset );
+	matFolder5.add( spotLight1, 'iesProfile', -1, iesProfileURLs.length - 1, 1 ).onChange( reset );
+
+	animate();
+
+}
+
+function onResize() {
+
+	const w = window.innerWidth;
+	const h = window.innerHeight;
+	const scale = params.resolutionScale;
+	const dpr = window.devicePixelRatio;
+
+	ptRenderer.setSize( w * scale * dpr, h * scale * dpr );
+	ptRenderer.reset();
+
+	renderer.setSize( w, h );
+	renderer.setPixelRatio( window.devicePixelRatio * scale );
+
+	const aspect = w / h;
+
+	perspectiveCamera.aspect = aspect;
+	perspectiveCamera.updateProjectionMatrix();
+
+	const orthoHeight = orthoWidth / aspect;
+	orthoCamera.top = orthoHeight / 2;
+	orthoCamera.bottom = orthoHeight / - 2;
+	orthoCamera.updateProjectionMatrix();
+
+}
+
+function reset() {
+
+	ptRenderer.reset();
+
+}
+
+function updateEnvBlur() {
+
+	const blurredTex = envMapGenerator.generate( envMap, params.environmentBlur );
+	ptRenderer.material.envMapInfo.updateFrom( blurredTex );
+	scene.environment = blurredTex;
+	ptRenderer.reset();
+
+}
+
+function updateCamera( cameraProjection ) {
+
+	if ( cameraProjection === "Perspective" ) {
+
+		if ( activeCamera ) {
+
+			perspectiveCamera.position.copy( activeCamera.position );
+
+		}
+
+		activeCamera = perspectiveCamera;
+
+	} else {
+
+		if ( activeCamera ) {
+
+			orthoCamera.position.copy( activeCamera.position );
+
+		}
+
+		activeCamera = orthoCamera;
+
+	}
+
+	controls.object = activeCamera;
+	ptRenderer.camera = activeCamera;
+
+	controls.update();
+
+	reset();
+
+}
+
+function animate() {
+
+	requestAnimationFrame( animate );
+
+	const m1 = materials[ 0 ];
+	m1.color.set( params.material1.color ).convertSRGBToLinear();
+	m1.emissive.set( params.material1.emissive ).convertSRGBToLinear();
+	m1.emissiveIntensity = params.material1.emissiveIntensity;
+	m1.metalness = params.material1.metalness;
+	m1.roughness = params.material1.roughness;
+	m1.transmission = params.material1.transmission;
+	m1.ior = params.material1.ior;
+	m1.opacity = params.material1.opacity;
+
+	const m2 = materials[ 1 ];
+	m2.color.set( params.material2.color ).convertSRGBToLinear();
+	m2.emissive.set( params.material2.emissive ).convertSRGBToLinear();
+	m2.emissiveIntensity = params.material2.emissiveIntensity;
+	m2.metalness = params.material2.metalness;
+	m2.roughness = params.material2.roughness;
+	m2.transmission = params.material2.transmission;
+	m2.ior = params.material2.ior;
+	m2.opacity = params.material2.opacity;
+
+	const m3 = materials[ 2 ];
+	m3.color.set( params.material3.color ).convertSRGBToLinear();
+	m3.metalness = params.material3.metalness;
+	m3.roughness = params.material3.roughness;
+
+	const m4 = materials[ 3 ];
+	m4.color.set( params.material4.color ).convertSRGBToLinear();
+	m4.metalness = params.material4.metalness;
+	m4.roughness = params.material4.roughness;
+	m4.emissive.set( params.material4.emissive ).convertSRGBToLinear();
+	m4.emissiveIntensity = params.material4.emissiveIntensity;
+	m4.transmission = params.material4.transmission;
+	m4.opacity = params.material4.opacity;
+
+	ptRenderer.material.materials.updateFrom( sceneInfo.materials, sceneInfo.textures );
+	ptRenderer.material.materials.setMatte( 0, params.material1.matte );
+	ptRenderer.material.materials.setMatte( 1, params.material2.matte );
+	ptRenderer.material.materials.setMatte( 2, params.material3.matte );
+	ptRenderer.material.materials.setMatte( 3, params.material4.matte );
+	ptRenderer.material.materials.setCastShadow( 0, params.material1.castShadow );
+	ptRenderer.material.materials.setCastShadow( 1, params.material2.castShadow );
+	ptRenderer.material.materials.setCastShadow( 2, params.material3.castShadow );
+	ptRenderer.material.materials.setCastShadow( 3, params.material4.castShadow );
+
+	ptRenderer.material.filterGlossyFactor = params.filterGlossyFactor;
+	ptRenderer.material.environmentIntensity = params.environmentIntensity;
+	ptRenderer.material.backgroundBlur = params.backgroundBlur;
+	ptRenderer.material.bounces = params.bounces;
+	ptRenderer.material.backgroundAlpha = params.backgroundAlpha;
+	ptRenderer.material.physicalCamera.updateFrom( activeCamera );
+
+	ptRenderer.material.lights.updateFrom( lights );
+
+	activeCamera.updateMatrixWorld();
+
+	if ( params.backgroundAlpha < 1.0 ) {
+
+		scene.background = null;
+
+	} else {
+
+		scene.background = scene.environment;
+
+	}
+
+	spotLightHelpers.forEach(spotLightHelper => {
+
+		spotLightHelper.update();
+
+	});
+
+	for ( let i = 0, l = params.samplesPerFrame; i < l; i ++ ) {
+
+		ptRenderer.update();
+
+	}
+
+	if ( ptRenderer.samples < 1 ) {
+
+		renderer.render( scene, activeCamera );
+
+	}
+
+	renderer.autoClear = false;
+
+	fsQuad.material.map = ptRenderer.target.texture;
+	fsQuad.material.depthWrite = false;
+	fsQuad.render( renderer );
+
+	if( params.showTransformControls )
+		renderer.render( transformControlsScene, activeCamera );
+
+	renderer.autoClear = true;
+
+	samplesEl.innerText = `Samples: ${ Math.floor( ptRenderer.samples ) }`;
+
+}

--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -180,7 +180,7 @@ async function init() {
 
 			const group = new THREE.Group();
 
-			const gltfScenes =  [ ];
+			const gltfScenes = [ ];
 
 			// objects
 			gltf.scene.scale.setScalar( 0.01 );
@@ -189,34 +189,34 @@ async function init() {
 			gltf.castShadow = true;
 			gltf.receiveShadow = true;
 			group.add( gltf.scene );
-			gltfScenes.push( gltf.scene )
+			gltfScenes.push( gltf.scene );
 
 			const box = new THREE.Box3();
 			box.setFromObject( gltf.scene );
 
-			gltf.scene = gltf.scene.clone()
+			gltf.scene = gltf.scene.clone();
 			gltf.scene.position.x += 8;
 			gltf.scene.updateMatrixWorld();
 			group.add( gltf.scene );
-			gltfScenes.push( gltf.scene )
+			gltfScenes.push( gltf.scene );
 
-			gltf.scene = gltf.scene.clone()
+			gltf.scene = gltf.scene.clone();
 			gltf.scene.position.x += 8;
 			gltf.scene.updateMatrixWorld();
 			group.add( gltf.scene );
-			gltfScenes.push( gltf.scene )
+			gltfScenes.push( gltf.scene );
 
-			gltf.scene = gltf.scene.clone()
+			gltf.scene = gltf.scene.clone();
 			gltf.scene.position.x += 8;
 			gltf.scene.updateMatrixWorld();
 			group.add( gltf.scene );
-			gltfScenes.push( gltf.scene )
+			gltfScenes.push( gltf.scene );
 
-			gltf.scene = gltf.scene.clone()
+			gltf.scene = gltf.scene.clone();
 			gltf.scene.position.x += 8;
 			gltf.scene.updateMatrixWorld();
 			group.add( gltf.scene );
-			gltfScenes.push( gltf.scene )
+			gltfScenes.push( gltf.scene );
 
 			const floor = new THREE.Mesh(
 				new THREE.CylinderBufferGeometry( 100, 100, 0.05, 200 ),
@@ -249,7 +249,7 @@ async function init() {
 				const transformControls = new TransformControls( perspectiveCamera, renderer.domElement );
 				transformControls.addEventListener( 'change', () => {
 
-					if( draggingSpotLight ) {
+					if ( draggingSpotLight ) {
 
 						ptRenderer.reset();
 
@@ -274,19 +274,19 @@ async function init() {
 			lights = [ ];
 
 			const decays = [ 0, 1.5, 0, 0.25, 0 ];
-			for( let i = 0; i < 5; ++ i) {
+			for ( let i = 0; i < 5; ++ i ) {
 
 				const spotLight = new THREE.SpotLight( 0xffffff );
 
 				spotLight.position.set( i * 8, 7.0, 0.005 );
 				spotLight.angle = Math.PI / 8.0;
 				spotLight.penumbra = 0.0;
-				spotLight.decay = decays [ i ];
+				spotLight.decay = decays[ i ];
 				spotLight.distance = 0.0;
 				spotLight.intensity = 50.0;
 				spotLight.lampIntensityScale = 0.0;
 				spotLight.radius = 0.5;
-				spotLight.iesProfile = -1 + i;
+				spotLight.iesProfile = - 1 + i;
 
 				spotLight.shadow.mapSize.width = 512;
 				spotLight.shadow.mapSize.height = 512;
@@ -313,7 +313,7 @@ async function init() {
 
 					const spotLightHelper = new THREE.SpotLightHelper( spotLight );
 					spotLight.add( spotLightHelper );
-					transformControlsScene.add(spotLightHelper);
+					transformControlsScene.add( spotLightHelper );
 
 					spotLightHelpers.push ( spotLightHelper );
 
@@ -571,7 +571,7 @@ async function init() {
 	matFolder5.add( spotLight1, 'angle', 0.0, Math.PI / 2.0 ).onChange( reset );
 	matFolder5.add( spotLight1, 'penumbra', 0.0, 1.0 ).onChange( reset );
 	matFolder5.add( spotLight1, 'lampIntensityScale', 0.0, 1.0 ).onChange( reset );
-	matFolder5.add( spotLight1, 'iesProfile', -1, iesProfileURLs.length - 1, 1 ).onChange( reset );
+	matFolder5.add( spotLight1, 'iesProfile', - 1, iesProfileURLs.length - 1, 1 ).onChange( reset );
 
 	animate();
 
@@ -619,7 +619,7 @@ function updateEnvBlur() {
 
 function updateCamera( cameraProjection ) {
 
-	if ( cameraProjection === "Perspective" ) {
+	if ( cameraProjection === 'Perspective' ) {
 
 		if ( activeCamera ) {
 
@@ -719,11 +719,11 @@ function animate() {
 
 	}
 
-	spotLightHelpers.forEach(spotLightHelper => {
+	spotLightHelpers.forEach( spotLightHelper => {
 
 		spotLightHelper.update();
 
-	});
+	} );
 
 	for ( let i = 0, l = params.samplesPerFrame; i < l; i ++ ) {
 
@@ -743,7 +743,7 @@ function animate() {
 	fsQuad.material.depthWrite = false;
 	fsQuad.render( renderer );
 
-	if( params.showTransformControls )
+	if ( params.showTransformControls )
 		renderer.render( transformControlsScene, activeCamera );
 
 	renderer.autoClear = true;

--- a/src/core/PathTracingSceneGenerator.js
+++ b/src/core/PathTracingSceneGenerator.js
@@ -32,7 +32,7 @@ export class PathTracingSceneGenerator {
 
 					meshes.push( c );
 
-				} else if ( c.isRectAreaLight ) {
+				} else if ( c.isRectAreaLight || c.isSpotLight ) {
 
 					lights.push( c );
 

--- a/src/core/PathTracingSceneGenerator.js
+++ b/src/core/PathTracingSceneGenerator.js
@@ -10,6 +10,7 @@ export class PathTracingSceneGenerator {
 
 		const meshes = [];
 		const lights = [];
+		const spotLights = [];
 
 		for ( let i = 0, l = scene.length; i < l; i ++ ) {
 
@@ -32,9 +33,13 @@ export class PathTracingSceneGenerator {
 
 					meshes.push( c );
 
-				} else if ( c.isRectAreaLight || c.isSpotLight ) {
+				} else if ( c.isRectAreaLight ) {
 
 					lights.push( c );
+
+				} else if ( c.isSpotLight ) {
+
+					spotLights.push( c );
 
 				}
 
@@ -46,20 +51,22 @@ export class PathTracingSceneGenerator {
 			...mergeMeshes( meshes, {
 				attributes: [ 'position', 'normal', 'tangent', 'uv' ],
 			} ),
-			lights
+			lights,
+			spotLights
 		};
 
 	}
 
 	generate( scene, options = {} ) {
 
-		const { materials, textures, geometry, lights } = this.prepScene( scene );
+		const { materials, textures, geometry, lights, spotLights } = this.prepScene( scene );
 		const bvhOptions = { strategy: SAH, ...options, maxLeafTris: 1 };
 		return {
 			scene,
 			materials,
 			textures,
 			lights,
+			spotLights,
 			bvh: new MeshBVH( geometry, bvhOptions ),
 		};
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ export * from './uniforms/RenderTarget2DArray.js';
 export * from './uniforms/EquirectHdrInfoUniform.js';
 export * from './uniforms/PhysicalCameraUniform.js';
 export * from './uniforms/LightsTexture.js';
+export * from './uniforms/SpotLightsTexture.js';
 export * from './uniforms/IESProfilesTexture.js';
 
 // utils

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,13 @@ export * from './uniforms/MaterialsTexture.js';
 export * from './uniforms/RenderTarget2DArray.js';
 export * from './uniforms/EquirectHdrInfoUniform.js';
 export * from './uniforms/PhysicalCameraUniform.js';
+export * from './uniforms/LightsTexture.js';
+export * from './uniforms/IESProfilesTexture.js';
 
 // utils
 export * from './utils/GeometryPreparationUtils.js';
 export * from './utils/BlurredEnvMapGenerator.js';
+export * from './utils/IESLoader.js';
 
 // materials
 export * from './materials/MaterialBase.js';

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -14,6 +14,7 @@ import { shaderUtils } from '../shader/shaderUtils.js';
 import { PhysicalCameraUniform } from '../uniforms/PhysicalCameraUniform.js';
 import { EquirectHdrInfoUniform } from '../uniforms/EquirectHdrInfoUniform.js';
 import { LightsTexture } from '../uniforms/LightsTexture.js';
+import { IESProfilesTexture } from '../uniforms/IESProfilesTexture.js';
 
 export class PhysicalPathTracingMaterial extends MaterialBase {
 
@@ -56,6 +57,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				textures: { value: new RenderTarget2DArray().texture },
 				lights: { value: new LightsTexture() },
 				lightCount: { value: 0 },
+				iesProfiles: { value: new IESProfilesTexture().texture },
 				cameraWorldMatrix: { value: new Matrix4() },
 				invProjectionMatrix: { value: new Matrix4() },
 				backgroundBlur: { value: 0.0 },
@@ -104,7 +106,6 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				${ shaderUtils }
 				${ shaderMaterialSampling }
 				${ shaderEnvMapSampling }
-				${ shaderLightSampling }
 
 				uniform mat3 environmentRotation;
 				uniform float backgroundBlur;
@@ -139,6 +140,9 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				uniform sampler2D materials;
 				uniform sampler2D lights;
 				uniform uint lightCount;
+				uniform sampler2DArray iesProfiles;
+
+				${ shaderLightSampling }
 
 				uniform EquirectHdrInfo envMapInfo;
 

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -14,6 +14,7 @@ import { shaderUtils } from '../shader/shaderUtils.js';
 import { PhysicalCameraUniform } from '../uniforms/PhysicalCameraUniform.js';
 import { EquirectHdrInfoUniform } from '../uniforms/EquirectHdrInfoUniform.js';
 import { LightsTexture } from '../uniforms/LightsTexture.js';
+import { SpotLightsTexture } from '../uniforms/SpotLightsTexture.js';
 import { IESProfilesTexture } from '../uniforms/IESProfilesTexture.js';
 
 export class PhysicalPathTracingMaterial extends MaterialBase {
@@ -57,6 +58,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				textures: { value: new RenderTarget2DArray().texture },
 				lights: { value: new LightsTexture() },
 				lightCount: { value: 0 },
+				spotLights: { value: new SpotLightsTexture() },
+				spotLightCount: { value: 0 },
 				iesProfiles: { value: new IESProfilesTexture().texture },
 				cameraWorldMatrix: { value: new Matrix4() },
 				invProjectionMatrix: { value: new Matrix4() },
@@ -140,6 +143,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				uniform sampler2D materials;
 				uniform sampler2D lights;
 				uniform uint lightCount;
+				uniform sampler2D spotLights;
+				uniform uint spotLightCount;
 				uniform sampler2DArray iesProfiles;
 
 				${ shaderLightSampling }
@@ -763,6 +768,49 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 						bool isBelowSurface = dot( rayDirection, faceNormal ) < 0.0;
 						rayOrigin = point + faceNormal * ( maxPoint + 1.0 ) * ( isBelowSurface ? - RAY_OFFSET : RAY_OFFSET );
+
+						// spot light sampling
+						LightSampleRec lightSampleRec = randomSpotLightSample( spotLights, iesProfiles, spotLightCount, rayOrigin );
+
+						bool isSampleBelowSurface = dot( faceNormal, lightSampleRec.direction ) < 0.0;
+						if ( isSampleBelowSurface ) {
+
+							lightSampleRec.pdf = 0.0;
+
+						}
+
+						// check if a ray could even reach the light area
+						if (
+							lightSampleRec.pdf > 0.0 &&
+							isDirectionValid( lightSampleRec.direction, normal, faceNormal ) &&
+							! anyCloserHit( bvh, rayOrigin, lightSampleRec.direction, lightSampleRec.dist )
+						) {
+
+							// get the material pdf
+							vec3 sampleColor;
+							float lightMaterialPdf = bsdfResult( outgoing, clearcoatOutgoing, normalize( invBasis * lightSampleRec.direction ), normalize( clearcoatInvBasis * lightSampleRec.direction ), surfaceRec, sampleColor );
+							bool isValidSampleColor = any( greaterThanEqual( sampleColor, vec3( 0.0 ) ) );
+							if ( lightMaterialPdf > 0.0 && isValidSampleColor ) {
+
+								#if FEATURE_MIS
+
+								// weight the direct light contribution
+								float lightPdf = lightSampleRec.pdf;// / float( spotLightCount );
+								float misWeight = misHeuristic( lightPdf, lightMaterialPdf );
+								gl_FragColor.rgb += lightSampleRec.emission * throughputColor * sampleColor * misWeight / lightPdf;
+
+								#else
+
+								gl_FragColor.rgb +=
+									lightSampleRec.emission *
+									throughputColor *
+									sampleColor;
+
+								#endif
+
+							}
+
+						}
 
 						// direct env map sampling
 						#if FEATURE_MIS

--- a/src/shader/shaderEnvMapSampling.js
+++ b/src/shader/shaderEnvMapSampling.js
@@ -26,7 +26,7 @@ float envMapSample( vec3 direction, EquirectHdrInfo info, out vec3 color ) {
 	vec2 uv = equirectDirectionToUv( direction );
 	color = texture2D( info.map, uv ).rgb;
 
-	float totalSum = texture2D( info.totalSum, vec2( 0.0 ) ).r;
+	float totalSum = info.totalSumWhole + info.totalSumDecimal;
 	float lum = colorToLuminance( color );
 	ivec2 resolution = textureSize( info.map, 0 );
 	float pdf = lum / totalSum;
@@ -47,7 +47,7 @@ float randomEnvMapSample( EquirectHdrInfo info, out vec3 color, out vec3 directi
 	direction = derivedDirection;
 	color = texture2D( info.map, uv ).rgb;
 
-	float totalSum = texture2D( info.totalSum, vec2( 0.0 ) ).r;
+	float totalSum = info.totalSumWhole + info.totalSumDecimal;
 	float lum = colorToLuminance( color );
 	ivec2 resolution = textureSize( info.map, 0 );
 	float pdf = lum / totalSum;

--- a/src/shader/shaderLightSampling.js
+++ b/src/shader/shaderLightSampling.js
@@ -1,11 +1,51 @@
 export const shaderLightSampling = /* glsl */`
 
+float getSpotAttenuation( const in float coneCosine, const in float penumbraCosine, const in float angleCosine ) {
+
+	return smoothstep( coneCosine, penumbraCosine, angleCosine );
+
+}
+
+float getDistanceAttenuation( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {
+
+		// based upon Frostbite 3 Moving to Physically-based Rendering
+		// page 32, equation 26: E[window1]
+		// https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
+		float distanceFalloff = 1.0 / max( pow( lightDistance, decayExponent ), EPSILON );
+
+		if ( cutoffDistance > 0.0 ) {
+			distanceFalloff *= pow2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) );
+		}
+
+		return distanceFalloff;
+}
+
+// float atan2(float y, float x) {
+
+//     bool s = ( abs( x ) > abs( y ) );
+//     return mix( PI / 2.0 - atan( x, y ), atan( y, x ), s );
+
+// }
+
+float getPhotometricAttenuation(int iesProfile, vec3 posToLight, vec3 lightDir, vec3 u, vec3 v) {
+    float cosTheta = dot(-posToLight, lightDir);
+    float angle = acos(cosTheta) * (1.0 / PI);
+
+	//float y = dot( posToLight, u ); // TODO: use azimuth if any IES profiles require this
+	//float x = dot( posToLight, v );
+	//float a2 = atan2( y, x );
+
+    return texture2D( iesProfiles, vec3( 0.0, angle, iesProfile ) ).r;
+}
+
 struct LightSampleRec {
+
 	bool hit;
 	float dist;
 	vec3 direction;
 	float pdf;
 	vec3 emission;
+
 };
 
 LightSampleRec lightsClosestHit( sampler2D lights, uint lightCount, vec3 rayOrigin, vec3 rayDirection ) {
@@ -14,7 +54,7 @@ LightSampleRec lightsClosestHit( sampler2D lights, uint lightCount, vec3 rayOrig
 	lightSampleRec.hit = false;
 
 	uint l;
-	for ( l = 0u; l < lightCount; l++ ) {
+	for ( l = 0u; l < lightCount; l ++ ) {
 
 		Light light = readLightInfo( lights, l );
 
@@ -27,20 +67,50 @@ LightSampleRec lightsClosestHit( sampler2D lights, uint lightCount, vec3 rayOrig
 			continue;
 		}
 
-		u *= 1.0 / dot(u, u);
-		v *= 1.0 / dot(v, v);
+		u *= 1.0 / dot( u, u );
+		v *= 1.0 / dot( v, v );
 
 		float dist;
-		if ( intersectsRectangle( light.position, normal, u, v, rayOrigin, rayDirection, dist ) ) {
 
-			if ( dist < lightSampleRec.dist || !lightSampleRec.hit ) {
+		if( light.type == 0 ) {
 
-				lightSampleRec.hit = true;
-				lightSampleRec.dist = dist;
-				float cosTheta = dot( rayDirection, normal );
-				lightSampleRec.pdf = ( dist * dist ) / ( light.area * cosTheta );
-				lightSampleRec.emission = light.color * light.intensity;
-				lightSampleRec.direction = rayDirection;
+			if ( intersectsRectangle( light.position, normal, u, v, rayOrigin, rayDirection, dist ) ) {
+
+				if ( dist < lightSampleRec.dist || !lightSampleRec.hit ) {
+
+					lightSampleRec.hit = true;
+					lightSampleRec.dist = dist;
+					float cosTheta = dot( rayDirection, normal );
+					lightSampleRec.pdf = ( dist * dist ) / ( light.area * cosTheta );
+					lightSampleRec.emission = light.color * light.intensity;
+					lightSampleRec.direction = rayDirection;
+
+				}
+
+			}
+
+		} else {
+
+			SpotLight spotLight = readSpotLightInfo( lights, l );
+
+			float angle = acos( spotLight.coneCos );
+			float angleTan = tan( angle );
+			float startDistance = spotLight.radius / angleTan;
+
+			vec3 lightPosition = light.position - normal * startDistance;
+			if ( spotLight.lampIntensityScale > 0.0 && spotLight.radius > 0.0 && intersectsCircle( lightPosition, normal, u, v, spotLight.radius * 2.0, rayOrigin, rayDirection, dist ) ) {
+
+				if ( dist < lightSampleRec.dist || !lightSampleRec.hit ) {
+
+					lightSampleRec.hit = true;
+					lightSampleRec.dist = dist;
+					float cosTheta = dot( rayDirection, normal );
+					lightSampleRec.pdf = ( dist * dist ) / ( light.area * cosTheta );
+					lightSampleRec.emission = light.color * light.intensity * spotLight.lampIntensityScale;
+					lightSampleRec.direction = rayDirection;
+
+				}
+
 			}
 
 		}
@@ -61,13 +131,55 @@ LightSampleRec randomRectAreaLightSample( Light light, vec3 rayOrigin ) {
 	vec3 randomPos = light.position + light.u * ( rand() - 0.5 ) + light.v * ( rand() - 0.5 );
 	vec3 toLight = randomPos - rayOrigin;
 	float lightDistSq = dot( toLight, toLight );
-	lightSampleRec.dist = length( toLight );
+	lightSampleRec.dist = sqrt( lightDistSq );
 
-	vec3 direction = normalize( toLight );
+	vec3 direction = toLight / lightSampleRec.dist;
 	lightSampleRec.direction = direction;
 
 	vec3 lightNormal = normalize( cross( light.u, light.v ) );
 	lightSampleRec.pdf = lightDistSq / ( light.area * dot( direction, lightNormal ) );
+
+	return lightSampleRec;
+
+}
+
+LightSampleRec randomSpotLightSample( Light light, SpotLight spotLight, vec3 rayOrigin ) {
+
+	LightSampleRec lightSampleRec;
+	lightSampleRec.hit = true;
+
+	float r = 2.0 * spotLight.radius * sqrt( rand() );
+	float theta = rand() * 2.0 * PI;
+	float x = r * cos( theta );
+	float y = r * sin( theta );
+
+	vec3 u = light.u;
+	vec3 v = light.v;
+	vec3 lightNormal = normalize( cross( u, v ) );
+
+	float angle = acos( spotLight.coneCos );
+	float angleTan = tan( angle );
+	float startDistance = spotLight.radius / angleTan;
+
+	vec3 randomPos = light.position - lightNormal * startDistance + u * x + v * y;
+	vec3 toLight = randomPos - rayOrigin;
+	float lightDistSq = dot( toLight, toLight );
+	lightSampleRec.dist = sqrt( lightDistSq );
+
+	vec3 direction = toLight / max( lightSampleRec.dist, EPSILON );
+	lightSampleRec.direction = direction;
+
+	float cosTheta = dot( direction, lightNormal );
+
+	float spotAttenuation = spotLight.iesProfile != -1 ?
+		  getPhotometricAttenuation( spotLight.iesProfile, direction, -lightNormal, u, v )
+		: getSpotAttenuation( spotLight.coneCos, spotLight.penumbraCos, cosTheta );
+
+	float distanceAttenuation = getDistanceAttenuation( lightSampleRec.dist, spotLight.distance, spotLight.decay );
+
+	lightSampleRec.emission = light.color * light.intensity;
+
+	lightSampleRec.pdf = 1.0 / max( distanceAttenuation * spotAttenuation, EPSILON );
 
 	return lightSampleRec;
 
@@ -80,7 +192,18 @@ LightSampleRec randomLightSample( sampler2D lights, uint lightCount, vec3 rayOri
 	Light light = readLightInfo( lights, l );
 
 	// sample the light
-	return randomRectAreaLightSample( light, rayOrigin );
+	if( light.type == 0 )
+
+		// rectangular area light
+		return randomRectAreaLightSample( light, rayOrigin );
+
+	else {
+
+		// spot light
+		SpotLight spotLight = readSpotLightInfo( lights, l );
+		return randomSpotLightSample( light, spotLight, rayOrigin );
+
+	}
 
 }
 

--- a/src/shader/shaderLightSampling.js
+++ b/src/shader/shaderLightSampling.js
@@ -117,7 +117,7 @@ LightSampleRec randomCircularAreaLightSample( Light light, vec3 rayOrigin ) {
 
 	lightSampleRec.emission = light.color * light.intensity;
 
-	float r = 2.0 * sqrt( rand() );
+	float r = 0.5 * sqrt( rand() );
 	float theta = rand() * 2.0 * PI;
 	float x = r * cos( theta );
 	float y = r * sin( theta );
@@ -142,7 +142,7 @@ LightSampleRec randomSpotLightSample( SpotLight spotLight, sampler2DArray iesPro
 	LightSampleRec lightSampleRec;
 	lightSampleRec.hit = true;
 
-	float r = 2.0 * spotLight.radius * sqrt( rand() );
+	float r = spotLight.radius * sqrt( rand() );
 	float theta = rand() * 2.0 * PI;
 	float x = r * cos( theta );
 	float y = r * sin( theta );

--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -15,7 +15,9 @@ export const shaderMaterialStructs = /* glsl */ `
 		sampler2D marginalWeights;
 		sampler2D conditionalWeights;
 		sampler2D map;
-		sampler2D totalSum;
+
+		float totalSumWhole;
+		float totalSumDecimal;
 
 	};
 

--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -204,7 +204,7 @@ export const shaderLightStruct = /* glsl */ `
 
 	Light readLightInfo( sampler2D tex, uint index ) {
 
-		uint i = index * 6u;
+		uint i = index * 4u;
 
 		vec4 s0 = texelFetch1D( tex, i + 0u );
 		vec4 s1 = texelFetch1D( tex, i + 1u );
@@ -228,13 +228,22 @@ export const shaderLightStruct = /* glsl */ `
 
 	struct SpotLight {
 
+		vec3 position;
+		int type;
+
+		vec3 color;
+		float intensity;
+
+		vec3 u;
+		vec3 v;
+		float area;
+
 		float radius;
 		float near;
 		float decay;
 		float distance;
 		float coneCos;
 		float penumbraCos;
-		float lampIntensityScale;
 		int iesProfile;
 
 	};
@@ -243,19 +252,32 @@ export const shaderLightStruct = /* glsl */ `
 
 		uint i = index * 6u;
 
-		vec4 s0 = texelFetch1D( tex, i + 4u );
-		vec4 s1 = texelFetch1D( tex, i + 5u );
+		vec4 s0 = texelFetch1D( tex, i + 0u );
+		vec4 s1 = texelFetch1D( tex, i + 1u );
+		vec4 s2 = texelFetch1D( tex, i + 2u );
+		vec4 s3 = texelFetch1D( tex, i + 3u );
+		vec4 s4 = texelFetch1D( tex, i + 4u );
+		vec4 s5 = texelFetch1D( tex, i + 5u );
 
 		SpotLight sl;
-		sl.radius = s0.r;
-		sl.near = s0.g;
-		sl.decay = s0.b;
-		sl.distance = s0.a;
+		sl.position = s0.rgb;
+		sl.type = int( round( s0.a ) );
 
-		sl.coneCos = s1.r;
-		sl.penumbraCos = s1.g;
-		sl.lampIntensityScale = s1.b;
-		sl.iesProfile = int( round ( s1.a ) );
+		sl.color = s1.rgb;
+		sl.intensity = s1.a;
+
+		sl.u = s2.rgb;
+		sl.v = s3.rgb;
+		sl.area = s3.a;
+
+		sl.radius = s4.r;
+		sl.near = s4.g;
+		sl.decay = s4.b;
+		sl.distance = s4.a;
+
+		sl.coneCos = s5.r;
+		sl.penumbraCos = s5.g;
+		sl.iesProfile = int( round ( s5.b ) );
 
 		return sl;
 

--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -191,6 +191,7 @@ export const shaderLightStruct = /* glsl */ `
 	struct Light {
 
 		vec3 position;
+		int type;
 
 		vec3 color;
 		float intensity;
@@ -203,7 +204,7 @@ export const shaderLightStruct = /* glsl */ `
 
 	Light readLightInfo( sampler2D tex, uint index ) {
 
-		uint i = index * 4u;
+		uint i = index * 6u;
 
 		vec4 s0 = texelFetch1D( tex, i + 0u );
 		vec4 s1 = texelFetch1D( tex, i + 1u );
@@ -212,6 +213,7 @@ export const shaderLightStruct = /* glsl */ `
 
 		Light l;
 		l.position = s0.rgb;
+		l.type = int( round( s0.a ) );
 
 		l.color = s1.rgb;
 		l.intensity = s1.a;
@@ -221,6 +223,41 @@ export const shaderLightStruct = /* glsl */ `
 		l.area = s3.a;
 
 		return l;
+
+	}
+
+	struct SpotLight {
+
+		float radius;
+		float near;
+		float decay;
+		float distance;
+		float coneCos;
+		float penumbraCos;
+		float lampIntensityScale;
+		int iesProfile;
+
+	};
+
+	SpotLight readSpotLightInfo( sampler2D tex, uint index ) {
+
+		uint i = index * 6u;
+
+		vec4 s0 = texelFetch1D( tex, i + 4u );
+		vec4 s1 = texelFetch1D( tex, i + 5u );
+
+		SpotLight sl;
+		sl.radius = s0.r;
+		sl.near = s0.g;
+		sl.decay = s0.b;
+		sl.distance = s0.a;
+
+		sl.coneCos = s1.r;
+		sl.penumbraCos = s1.g;
+		sl.lampIntensityScale = s1.b;
+		sl.iesProfile = int( round ( s1.a ) );
+
+		return sl;
 
 	}
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -352,6 +352,32 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	bool intersectsCircle( vec3 position, vec3 normal, vec3 u, vec3 v, float radius, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
+
+		float dt = dot( rayDirection, normal );
+		float t = ( dot( normal, position ) - dot( normal, rayOrigin ) ) / dt;
+
+		if ( t > EPSILON ) {
+
+			vec3 hit = rayOrigin + rayDirection * t;
+			vec3 vi = hit - position;
+
+			float a1 = dot( u, vi );
+			float a2 = dot( v, vi );
+
+			if( length( vec2( a1, a2 ) ) <= radius ) {
+
+				dist = t;
+				return true;
+
+			}
+
+		}
+
+		return false;
+
+	}
+
 	// power heuristic for multiple importance sampling
 	float misHeuristic( float a, float b ) {
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -313,7 +313,7 @@ export const shaderUtils = /* glsl */`
 
 	// Finds the point where the ray intersects the plane defined by u and v and checks if this point
 	// falls in the bounds of the circle on that same plane. See above URL for a description of the plane intersection algorithm.
-	bool intersectsCircle( vec3 position, vec3 normal, vec3 u, vec3 v, float radius, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
+	bool intersectsCircle( vec3 position, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
 
 		float t = dot( position - rayOrigin, normal ) / dot( rayDirection, normal );
 
@@ -325,7 +325,7 @@ export const shaderUtils = /* glsl */`
 			float a1 = dot( u, vi );
 			float a2 = dot( v, vi );
 
-			if( length( vec2( a1, a2 ) ) <= radius ) {
+			if( length( vec2( a1, a2 ) ) <= 0.5 ) {
 
 				dist = t;
 				return true;

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -320,20 +320,24 @@ export const shaderUtils = /* glsl */`
 
 	}
 
-	bool intersectsRectangle( vec3 position, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
+	// Finds the point where the ray intersects the plane defined by u and v and checks if this point
+	// falls in the bounds of the rectangle on that same plane.
+	// Plane intersection: https://lousodrome.net/blog/light/2020/07/03/intersection-of-a-ray-and-a-plane/
+	bool intersectsRectangle( vec3 center, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
 
-		float dt = dot( rayDirection, normal );
-		float t = ( dot( normal, position ) - dot( normal, rayOrigin ) ) / dt;
+		float t = dot( center - rayOrigin, normal ) / dot( rayDirection, normal );
 
 		if ( t > EPSILON ) {
 
-			vec3 hit = rayOrigin + rayDirection * t;
-			vec3 vi = hit - position;
+			vec3 p = rayOrigin + rayDirection * t;
+			vec3 vi = p - center;
+
+			// check if p falls inside the rectangle
 			float a1 = dot( u, vi );
-			if ( a1 >= - 0.5 && a1 <= 0.5 ) {
+			if ( abs( a1 ) <= 0.5 ) {
 
 				float a2 = dot( v, vi );
-				if ( a2 >= - 0.5 && a2 <= 0.5 ) {
+				if ( abs( a2 ) <= 0.5 ) {
 
 					dist = t;
 					return true;

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -361,4 +361,41 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	bool intersectsRectangle( vec3 position, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
+
+		float dt = dot( rayDirection, normal );
+		float t = ( dot( normal, position ) - dot( normal, rayOrigin ) ) / dt;
+
+		if ( t > EPSILON ) {
+
+			vec3 hit = rayOrigin + rayDirection * t;
+			vec3 vi = hit - position;
+			float a1 = dot( u, vi );
+			if ( a1 >= - 0.5 && a1 <= 0.5 ) {
+
+				float a2 = dot( v, vi );
+				if ( a2 >= - 0.5 && a2 <= 0.5 ) {
+
+					dist = t;
+					return true;
+
+				}
+
+			}
+
+		}
+
+		return false;
+
+	}
+
+	// power heuristic for multiple importance sampling
+	float misHeuristic( float a, float b ) {
+
+		float aa = a * a;
+		float bb = b * b;
+		return aa / ( aa + bb );
+
+	}
+
 `;

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -242,47 +242,6 @@ export const shaderUtils = /* glsl */`
 
 	}
 
-	// Finds the point where the ray intersects the plane defined by u and v and checks if this point
-	// falls in the bounds of the rectangle on that same plane.
-	// Plane intersection: https://lousodrome.net/blog/light/2020/07/03/intersection-of-a-ray-and-a-plane/
-	bool intersectsRectangle( vec3 center, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
-
-		float t = dot( center - rayOrigin, normal ) / dot( rayDirection, normal );
-
-		if ( t > EPSILON ) {
-
-			vec3 p = rayOrigin + rayDirection * t;
-			vec3 vi = p - center;
-
-			// check if p falls inside the rectangle
-			float a1 = dot( u, vi );
-			if ( abs( a1 ) <= 0.5 ) {
-
-				float a2 = dot( v, vi );
-				if ( abs( a2 ) <= 0.5 ) {
-
-					dist = t;
-					return true;
-
-				}
-
-			}
-
-		}
-
-		return false;
-
-	}
-
-	// power heuristic for multiple importance sampling
-	float misHeuristic( float a, float b ) {
-
-		float aa = a * a;
-		float bb = b * b;
-		return aa / ( aa + bb );
-
-	}
-
 	// An acos with input values bound to the range [-1, 1].
 	float acosSafe( float x ) {
 
@@ -354,7 +313,7 @@ export const shaderUtils = /* glsl */`
 
 	bool intersectsCircle( vec3 position, vec3 normal, vec3 u, vec3 v, float radius, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
 
-		float t = dot(position - rayOrigin, normal) / dot(rayDirection, normal);
+		float t = dot( position - rayOrigin, normal ) / dot( rayDirection, normal );
 
 		if ( t > EPSILON ) {
 
@@ -368,42 +327,6 @@ export const shaderUtils = /* glsl */`
 
 				dist = t;
 				return true;
-
-			}
-
-		}
-
-		return false;
-
-	}
-
-	// power heuristic for multiple importance sampling
-	float misHeuristic( float a, float b ) {
-
-		float aa = a * a;
-		float bb = b * b;
-		return aa / ( aa + bb );
-
-	}
-
-	bool intersectsRectangle( vec3 position, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
-
-		float t = dot(position - rayOrigin, normal) / dot(rayDirection, normal);
-
-		if ( t > EPSILON ) {
-
-			vec3 hit = rayOrigin + rayDirection * t;
-			vec3 vi = hit - position;
-			float a1 = dot( u, vi );
-			if ( a1 >= - 0.5 && a1 <= 0.5 ) {
-
-				float a2 = dot( v, vi );
-				if ( a2 >= - 0.5 && a2 <= 0.5 ) {
-
-					dist = t;
-					return true;
-
-				}
 
 			}
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -320,4 +320,41 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	bool intersectsRectangle( vec3 position, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
+
+		float dt = dot( rayDirection, normal );
+		float t = ( dot( normal, position ) - dot( normal, rayOrigin ) ) / dt;
+
+		if ( t > EPSILON ) {
+
+			vec3 hit = rayOrigin + rayDirection * t;
+			vec3 vi = hit - position;
+			float a1 = dot( u, vi );
+			if ( a1 >= - 0.5 && a1 <= 0.5 ) {
+
+				float a2 = dot( v, vi );
+				if ( a2 >= - 0.5 && a2 <= 0.5 ) {
+
+					dist = t;
+					return true;
+
+				}
+
+			}
+
+		}
+
+		return false;
+
+	}
+
+	// power heuristic for multiple importance sampling
+	float misHeuristic( float a, float b ) {
+
+		float aa = a * a;
+		float bb = b * b;
+		return aa / ( aa + bb );
+
+	}
+
 `;

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -311,6 +311,8 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	// Finds the point where the ray intersects the plane defined by u and v and checks if this point
+	// falls in the bounds of the circle on that same plane. See above URL for a description of the plane intersection algorithm.
 	bool intersectsCircle( vec3 position, vec3 normal, vec3 u, vec3 v, float radius, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
 
 		float t = dot( position - rayOrigin, normal ) / dot( rayDirection, normal );

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -354,8 +354,7 @@ export const shaderUtils = /* glsl */`
 
 	bool intersectsCircle( vec3 position, vec3 normal, vec3 u, vec3 v, float radius, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
 
-		float dt = dot( rayDirection, normal );
-		float t = ( dot( normal, position ) - dot( normal, rayOrigin ) ) / dt;
+		float t = dot(position - rayOrigin, normal) / dot(rayDirection, normal);
 
 		if ( t > EPSILON ) {
 
@@ -389,8 +388,7 @@ export const shaderUtils = /* glsl */`
 
 	bool intersectsRectangle( vec3 position, vec3 normal, vec3 u, vec3 v, vec3 rayOrigin, vec3 rayDirection, out float dist ) {
 
-		float dt = dot( rayDirection, normal );
-		float t = ( dot( normal, position ) - dot( normal, rayOrigin ) ) / dt;
+		float t = dot(position - rayOrigin, normal) / dot(rayDirection, normal);
 
 		if ( t > EPSILON ) {
 

--- a/src/uniforms/IESProfilesTexture.js
+++ b/src/uniforms/IESProfilesTexture.js
@@ -1,0 +1,126 @@
+import {
+	ClampToEdgeWrapping,
+	Color,
+	FloatType,
+	LinearFilter,
+	MeshBasicMaterial,
+	NoToneMapping,
+	RGBAFormat,
+	WebGLArrayRenderTarget,
+} from 'three';
+import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
+import { IESLoader } from '../utils/IESLoader.js'
+
+const prevColor = new Color();
+export class IESProfilesTexture extends WebGLArrayRenderTarget {
+
+	constructor( ...args ) {
+
+		super( ...args );
+
+		const tex = this.texture;
+		tex.format = RGBAFormat;
+		tex.type = FloatType;
+		tex.minFilter = LinearFilter;
+		tex.magFilter = LinearFilter;
+		tex.wrapS = ClampToEdgeWrapping;
+		tex.wrapT = ClampToEdgeWrapping;
+		tex.generateMipmaps = false;
+
+		tex.updateFrom = ( ...args ) => {
+
+			this.updateFrom( ...args );
+
+		};
+
+		const fsQuad = new FullScreenQuad( new MeshBasicMaterial() );
+		this.fsQuad = fsQuad;
+
+		this.iesLoader = new IESLoader();
+
+	}
+
+	async updateFrom( renderer, iesProfiles ) {
+
+		const textures = [ ];
+		const promises = [ ];
+
+		iesProfiles.forEach( iesProfileURL => {
+
+			promises.push( new Promise( resolve => {
+
+				this.iesLoader
+					.load( iesProfileURL, texture => {
+
+						textures.push( texture );
+						resolve();
+
+					} );
+
+			} ) );
+
+		} );
+
+		await Promise.all( promises );
+
+		this._setTextures( renderer, textures );
+	}
+
+	_setTextures( renderer, textures ) {
+
+		// save previous renderer state
+		const prevRenderTarget = renderer.getRenderTarget();
+		const prevToneMapping = renderer.toneMapping;
+		const prevAlpha = renderer.getClearAlpha();
+		renderer.getClearColor( prevColor );
+
+		// resize the render target and ensure we don't have an empty texture
+		// render target depth must be >= 1 to avoid unbound texture error on android devices
+		const depth = textures.length || 1;
+		this.setSize( 360, 180, depth );
+		renderer.setClearColor( 0, 0 );
+		renderer.toneMapping = NoToneMapping;
+
+		// render each texture into each layer of the target
+		const fsQuad = this.fsQuad;
+		for ( let i = 0, l = depth; i < l; i ++ ) {
+
+			const texture = textures[ i ];
+			if ( texture ) {
+
+				// revert to default texture transform before rendering
+				texture.matrixAutoUpdate = false;
+				texture.matrix.identity();
+
+				fsQuad.material.map = texture;
+				fsQuad.material.transparent = true;
+
+				renderer.setRenderTarget( this, i );
+				fsQuad.render( renderer );
+
+				// restore custom texture transform
+				texture.updateMatrix();
+				texture.matrixAutoUpdate = true;
+
+			}
+
+		}
+
+		// reset the renderer
+		fsQuad.material.map = null;
+		renderer.setClearColor( prevColor, prevAlpha );
+		renderer.setRenderTarget( prevRenderTarget );
+		renderer.toneMapping = prevToneMapping;
+
+		fsQuad.dispose();
+
+	}
+
+	dispose() {
+
+		super.dispose();
+		this.fsQuad.dispose();
+
+	}
+
+}

--- a/src/uniforms/IESProfilesTexture.js
+++ b/src/uniforms/IESProfilesTexture.js
@@ -9,7 +9,7 @@ import {
 	WebGLArrayRenderTarget,
 } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
-import { IESLoader } from '../utils/IESLoader.js'
+import { IESLoader } from '../utils/IESLoader.js';
 
 const prevColor = new Color();
 export class IESProfilesTexture extends WebGLArrayRenderTarget {
@@ -64,6 +64,7 @@ export class IESProfilesTexture extends WebGLArrayRenderTarget {
 		await Promise.all( promises );
 
 		this._setTextures( renderer, textures );
+
 	}
 
 	_setTextures( renderer, textures ) {

--- a/src/uniforms/LightsTexture.js
+++ b/src/uniforms/LightsTexture.js
@@ -51,7 +51,7 @@ export class LightsTexture extends DataTexture {
 			floatArray[ baseIndex + ( index ++ ) ] = v.z;
 
 			// type
-			floatArray[ baseIndex + ( index ++ ) ] = l.isRectAreaLight ? 0 : ( l.isSpotLight ? 1 : -1 );
+			floatArray[ baseIndex + ( index ++ ) ] = l.isRectAreaLight ? 0 : ( l.isSpotLight ? 1 : - 1 );
 
 			// color
 			floatArray[ baseIndex + ( index ++ ) ] = l.color.r;
@@ -61,7 +61,7 @@ export class LightsTexture extends DataTexture {
 			// intensity
 			floatArray[ baseIndex + ( index ++ ) ] = l.intensity;
 
-			if( l.isRectAreaLight ) {
+			if ( l.isRectAreaLight ) {
 
 				l.getWorldQuaternion( worldQuaternion );
 
@@ -83,7 +83,7 @@ export class LightsTexture extends DataTexture {
 				// area
 				floatArray[ baseIndex + ( index ++ ) ] = u.cross( v ).length();
 
-			} else if( l.isSpotLight ) {
+			} else if ( l.isSpotLight ) {
 
 				const eye = new Vector3();
 				eye.setFromMatrixPosition( l.matrixWorld );
@@ -141,6 +141,7 @@ export class LightsTexture extends DataTexture {
 
 				// iesProfile
 				floatArray[ baseIndex + ( index ++ ) ] = l.iesProfile;
+
 			}
 
 		}

--- a/src/uniforms/LightsTexture.js
+++ b/src/uniforms/LightsTexture.js
@@ -1,6 +1,6 @@
-import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, Vector3, Quaternion } from 'three';
+import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, Vector3, Matrix4, Quaternion } from 'three';
 
-const LIGHT_PIXELS = 4;
+const LIGHT_PIXELS = 6;
 
 export class LightsTexture extends DataTexture {
 
@@ -18,7 +18,6 @@ export class LightsTexture extends DataTexture {
 
 	updateFrom( lights ) {
 
-		let index = 0;
 		const pixelCount = lights.length * LIGHT_PIXELS;
 		const dimension = Math.ceil( Math.sqrt( pixelCount ) );
 
@@ -42,37 +41,107 @@ export class LightsTexture extends DataTexture {
 
 			const l = lights[ i ];
 
-			// position
+			const baseIndex = i * LIGHT_PIXELS * 4;
+			let index = 0;
+
+		    // position
 			l.getWorldPosition( v );
-			floatArray[ index ++ ] = v.x;
-			floatArray[ index ++ ] = v.y;
-			floatArray[ index ++ ] = v.z;
-			index ++;
+			floatArray[ baseIndex + ( index ++ ) ] = v.x;
+			floatArray[ baseIndex + ( index ++ ) ] = v.y;
+			floatArray[ baseIndex + ( index ++ ) ] = v.z;
+
+			// type
+			floatArray[ baseIndex + ( index ++ ) ] = l.isRectAreaLight ? 0 : ( l.isSpotLight ? 1 : -1 );
 
 			// color
-			floatArray[ index ++ ] = l.color.r;
-			floatArray[ index ++ ] = l.color.g;
-			floatArray[ index ++ ] = l.color.b;
+			floatArray[ baseIndex + ( index ++ ) ] = l.color.r;
+			floatArray[ baseIndex + ( index ++ ) ] = l.color.g;
+			floatArray[ baseIndex + ( index ++ ) ] = l.color.b;
 
 			// intensity
-			floatArray[ index ++ ] = l.intensity;
+			floatArray[ baseIndex + ( index ++ ) ] = l.intensity;
 
-			// u vector
-			l.getWorldQuaternion( worldQuaternion );
-			u.set( l.width, 0, 0 ).applyQuaternion( worldQuaternion );
-			floatArray[ index ++ ] = u.x;
-			floatArray[ index ++ ] = u.y;
-			floatArray[ index ++ ] = u.z;
-			index ++;
+			if( l.isRectAreaLight ) {
 
-			// v vector
-			v.set( 0, l.height, 0 ).applyQuaternion( worldQuaternion );
-			floatArray[ index ++ ] = v.x;
-			floatArray[ index ++ ] = v.y;
-			floatArray[ index ++ ] = v.z;
+				l.getWorldQuaternion( worldQuaternion );
 
-			// area
-			floatArray[ index ++ ] = u.cross( v ).length();
+				// u vector
+				u.set( l.width, 0, 0 ).applyQuaternion( worldQuaternion );
+
+				floatArray[ baseIndex + ( index ++ ) ] = u.x;
+				floatArray[ baseIndex + ( index ++ ) ] = u.y;
+				floatArray[ baseIndex + ( index ++ ) ] = u.z;
+				index ++;
+
+				// v vector
+				v.set( 0, l.height, 0 ).applyQuaternion( worldQuaternion );
+
+				floatArray[ baseIndex + ( index ++ ) ] = v.x;
+				floatArray[ baseIndex + ( index ++ ) ] = v.y;
+				floatArray[ baseIndex + ( index ++ ) ] = v.z;
+
+				// area
+				floatArray[ baseIndex + ( index ++ ) ] = u.cross( v ).length();
+
+			} else if( l.isSpotLight ) {
+
+				const eye = new Vector3();
+				eye.setFromMatrixPosition( l.matrixWorld );
+
+				const target = new Vector3();
+				target.setFromMatrixPosition( l.target.matrixWorld );
+
+				const up = new Vector3();
+
+				var m = new Matrix4();
+				m.lookAt( eye, target, up );
+
+				worldQuaternion.setFromRotationMatrix( m );
+
+				// u vector
+				u.set( 1, 0, 0 ).applyQuaternion( worldQuaternion );
+
+				floatArray[ baseIndex + ( index ++ ) ] = u.x;
+				floatArray[ baseIndex + ( index ++ ) ] = u.y;
+				floatArray[ baseIndex + ( index ++ ) ] = u.z;
+				index ++;
+
+				// v vector
+				v.set( 0, 1, 0 ).applyQuaternion( worldQuaternion );
+
+				floatArray[ baseIndex + ( index ++ ) ] = v.x;
+				floatArray[ baseIndex + ( index ++ ) ] = v.y;
+				floatArray[ baseIndex + ( index ++ ) ] = v.z;
+
+				const radius = l.radius;
+
+				// area
+				floatArray[ baseIndex + ( index ++ ) ] = Math.PI * radius * radius;
+
+				// radius
+				floatArray[ baseIndex + ( index ++ ) ] = radius;
+
+				// near
+				floatArray[ baseIndex + ( index ++ ) ] = l.shadow.camera.near;
+
+				// decay
+				floatArray[ baseIndex + ( index ++ ) ] = l.decay;
+
+				// distance
+				floatArray[ baseIndex + ( index ++ ) ] = l.distance;
+
+				// coneCos
+				floatArray[ baseIndex + ( index ++ ) ] = Math.cos( l.angle );
+
+				// penumbraCos
+				floatArray[ baseIndex + ( index ++ ) ] = Math.cos( l.angle * ( 1 - l.penumbra ) );
+
+				// lampIntensityScale
+				floatArray[ baseIndex + ( index ++ ) ] = l.lampIntensityScale;
+
+				// iesProfile
+				floatArray[ baseIndex + ( index ++ ) ] = l.iesProfile;
+			}
 
 		}
 

--- a/src/uniforms/LightsTexture.js
+++ b/src/uniforms/LightsTexture.js
@@ -1,6 +1,6 @@
-import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, Vector3, Matrix4, Quaternion } from 'three';
+import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, Vector3, Quaternion } from 'three';
 
-const LIGHT_PIXELS = 6;
+const LIGHT_PIXELS = 4;
 
 export class LightsTexture extends DataTexture {
 
@@ -51,7 +51,7 @@ export class LightsTexture extends DataTexture {
 			floatArray[ baseIndex + ( index ++ ) ] = v.z;
 
 			// type
-			floatArray[ baseIndex + ( index ++ ) ] = l.isRectAreaLight ? 0 : ( l.isSpotLight ? 1 : - 1 );
+			floatArray[ baseIndex + ( index ++ ) ] = l.isCircular ? 1 : 0;
 
 			// color
 			floatArray[ baseIndex + ( index ++ ) ] = l.color.r;
@@ -61,88 +61,25 @@ export class LightsTexture extends DataTexture {
 			// intensity
 			floatArray[ baseIndex + ( index ++ ) ] = l.intensity;
 
-			if ( l.isRectAreaLight ) {
+			l.getWorldQuaternion( worldQuaternion );
 
-				l.getWorldQuaternion( worldQuaternion );
+			// u vector
+			u.set( l.width, 0, 0 ).applyQuaternion( worldQuaternion );
 
-				// u vector
-				u.set( l.width, 0, 0 ).applyQuaternion( worldQuaternion );
+			floatArray[ baseIndex + ( index ++ ) ] = u.x;
+			floatArray[ baseIndex + ( index ++ ) ] = u.y;
+			floatArray[ baseIndex + ( index ++ ) ] = u.z;
+			index ++;
 
-				floatArray[ baseIndex + ( index ++ ) ] = u.x;
-				floatArray[ baseIndex + ( index ++ ) ] = u.y;
-				floatArray[ baseIndex + ( index ++ ) ] = u.z;
-				index ++;
+			// v vector
+			v.set( 0, l.height, 0 ).applyQuaternion( worldQuaternion );
 
-				// v vector
-				v.set( 0, l.height, 0 ).applyQuaternion( worldQuaternion );
+			floatArray[ baseIndex + ( index ++ ) ] = v.x;
+			floatArray[ baseIndex + ( index ++ ) ] = v.y;
+			floatArray[ baseIndex + ( index ++ ) ] = v.z;
 
-				floatArray[ baseIndex + ( index ++ ) ] = v.x;
-				floatArray[ baseIndex + ( index ++ ) ] = v.y;
-				floatArray[ baseIndex + ( index ++ ) ] = v.z;
-
-				// area
-				floatArray[ baseIndex + ( index ++ ) ] = u.cross( v ).length();
-
-			} else if ( l.isSpotLight ) {
-
-				const eye = new Vector3();
-				eye.setFromMatrixPosition( l.matrixWorld );
-
-				const target = new Vector3();
-				target.setFromMatrixPosition( l.target.matrixWorld );
-
-				const up = new Vector3();
-
-				var m = new Matrix4();
-				m.lookAt( eye, target, up );
-
-				worldQuaternion.setFromRotationMatrix( m );
-
-				// u vector
-				u.set( 1, 0, 0 ).applyQuaternion( worldQuaternion );
-
-				floatArray[ baseIndex + ( index ++ ) ] = u.x;
-				floatArray[ baseIndex + ( index ++ ) ] = u.y;
-				floatArray[ baseIndex + ( index ++ ) ] = u.z;
-				index ++;
-
-				// v vector
-				v.set( 0, 1, 0 ).applyQuaternion( worldQuaternion );
-
-				floatArray[ baseIndex + ( index ++ ) ] = v.x;
-				floatArray[ baseIndex + ( index ++ ) ] = v.y;
-				floatArray[ baseIndex + ( index ++ ) ] = v.z;
-
-				const radius = l.radius;
-
-				// area
-				floatArray[ baseIndex + ( index ++ ) ] = Math.PI * radius * radius;
-
-				// radius
-				floatArray[ baseIndex + ( index ++ ) ] = radius;
-
-				// near
-				floatArray[ baseIndex + ( index ++ ) ] = l.shadow.camera.near;
-
-				// decay
-				floatArray[ baseIndex + ( index ++ ) ] = l.decay;
-
-				// distance
-				floatArray[ baseIndex + ( index ++ ) ] = l.distance;
-
-				// coneCos
-				floatArray[ baseIndex + ( index ++ ) ] = Math.cos( l.angle );
-
-				// penumbraCos
-				floatArray[ baseIndex + ( index ++ ) ] = Math.cos( l.angle * ( 1 - l.penumbra ) );
-
-				// lampIntensityScale
-				floatArray[ baseIndex + ( index ++ ) ] = l.lampIntensityScale;
-
-				// iesProfile
-				floatArray[ baseIndex + ( index ++ ) ] = l.iesProfile;
-
-			}
+			// area
+			floatArray[ baseIndex + ( index ++ ) ] = u.cross( v ).length() * ( l.isCircular ? ( Math.PI / 4.0 ) : 1.0 );
 
 		}
 

--- a/src/uniforms/SpotLightsTexture.js
+++ b/src/uniforms/SpotLightsTexture.js
@@ -1,0 +1,124 @@
+import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, Vector3, Matrix4, Quaternion } from 'three';
+
+const SPOT_LIGHT_PIXELS = 6;
+
+export class SpotLightsTexture extends DataTexture {
+
+	constructor() {
+
+		super( new Float32Array( 4 ), 1, 1 );
+
+		this.format = RGBAFormat;
+		this.type = FloatType;
+		this.wrapS = ClampToEdgeWrapping;
+		this.wrapT = ClampToEdgeWrapping;
+		this.generateMipmaps = false;
+
+	}
+
+	updateFrom( spotLights ) {
+
+		const pixelCount = spotLights.length * SPOT_LIGHT_PIXELS;
+		const dimension = Math.ceil( Math.sqrt( pixelCount ) );
+
+		if ( this.image.width !== dimension ) {
+
+			this.dispose();
+
+			this.image.data = new Float32Array( dimension * dimension * 4 );
+			this.image.width = dimension;
+			this.image.height = dimension;
+
+		}
+
+		const floatArray = this.image.data;
+
+		const u = new Vector3();
+		const v = new Vector3();
+		const worldQuaternion = new Quaternion();
+
+		for ( let i = 0, l = spotLights.length; i < l; i ++ ) {
+
+			const sl = spotLights[ i ];
+
+			const baseIndex = i * SPOT_LIGHT_PIXELS * 4;
+			let index = 0;
+
+		    // position
+			sl.getWorldPosition( v );
+			floatArray[ baseIndex + ( index ++ ) ] = v.x;
+			floatArray[ baseIndex + ( index ++ ) ] = v.y;
+			floatArray[ baseIndex + ( index ++ ) ] = v.z;
+
+			// type
+			floatArray[ baseIndex + ( index ++ ) ] = - 1;
+
+			// color
+			floatArray[ baseIndex + ( index ++ ) ] = sl.color.r;
+			floatArray[ baseIndex + ( index ++ ) ] = sl.color.g;
+			floatArray[ baseIndex + ( index ++ ) ] = sl.color.b;
+
+			// intensity
+			floatArray[ baseIndex + ( index ++ ) ] = sl.intensity;
+
+			const eye = new Vector3();
+			eye.setFromMatrixPosition( sl.matrixWorld );
+
+			const target = new Vector3();
+			target.setFromMatrixPosition( sl.target.matrixWorld );
+
+			const up = new Vector3();
+
+			var m = new Matrix4();
+			m.lookAt( eye, target, up );
+
+			worldQuaternion.setFromRotationMatrix( m );
+
+			// u vector
+			u.set( 1, 0, 0 ).applyQuaternion( worldQuaternion );
+
+			floatArray[ baseIndex + ( index ++ ) ] = u.x;
+			floatArray[ baseIndex + ( index ++ ) ] = u.y;
+			floatArray[ baseIndex + ( index ++ ) ] = u.z;
+			index ++;
+
+			// v vector
+			v.set( 0, 1, 0 ).applyQuaternion( worldQuaternion );
+
+			floatArray[ baseIndex + ( index ++ ) ] = v.x;
+			floatArray[ baseIndex + ( index ++ ) ] = v.y;
+			floatArray[ baseIndex + ( index ++ ) ] = v.z;
+
+			const radius = sl.radius;
+
+			// area
+			floatArray[ baseIndex + ( index ++ ) ] = Math.PI * radius * radius;
+
+			// radius
+			floatArray[ baseIndex + ( index ++ ) ] = radius;
+
+			// near
+			floatArray[ baseIndex + ( index ++ ) ] = sl.shadow.camera.near;
+
+			// decay
+			floatArray[ baseIndex + ( index ++ ) ] = sl.decay;
+
+			// distance
+			floatArray[ baseIndex + ( index ++ ) ] = sl.distance;
+
+			// coneCos
+			floatArray[ baseIndex + ( index ++ ) ] = Math.cos( sl.angle );
+
+			// penumbraCos
+			floatArray[ baseIndex + ( index ++ ) ] = Math.cos( sl.angle * ( 1 - sl.penumbra ) );
+
+			// iesProfile
+			floatArray[ baseIndex + ( index ++ ) ] = sl.iesProfile;
+
+		}
+
+		this.needsUpdate = true;
+
+	}
+
+}

--- a/src/utils/IESLoader.js
+++ b/src/utils/IESLoader.js
@@ -112,7 +112,7 @@ function IESLamp( text ) {
 
 	while ( true ) {
 
-		var line = textArray[ lineNumber ++ ];
+		line = textArray[ lineNumber ++ ];
 
 		if ( line.includes( 'TILT' ) ) {
 
@@ -122,7 +122,7 @@ function IESLamp( text ) {
 
 	}
 
-	if ( !line.includes( 'NONE' ) ) {
+	if ( ! line.includes( 'NONE' ) ) {
 
 		if ( line.includes( 'INCLUDE' ) ) {
 
@@ -167,9 +167,10 @@ function IESLamp( text ) {
 				* _self.ballFactor * _self.blpFactor;
 
 		}
+
 	}
 
-	var maxVal = -1;
+	var maxVal = - 1;
 	for ( var i = 0; i < _self.numHorAngles; ++ i ) {
 
 		for ( var j = 0; j < _self.numVerAngles; ++ j ) {
@@ -188,7 +189,7 @@ function IESLamp( text ) {
 
 			for ( var j = 0; j < _self.numVerAngles; ++ j ) {
 
-				_self.candelaValues[ i ] [ j ] /= maxVal;
+				_self.candelaValues[ i ][ j ] /= maxVal;
 
 			}
 

--- a/src/utils/IESLoader.js
+++ b/src/utils/IESLoader.js
@@ -1,0 +1,325 @@
+import {
+	DataTexture,
+	DefaultLoadingManager,
+	FileLoader,
+	FloatType,
+	LinearFilter,
+	RedFormat,
+	MathUtils
+} from 'three';
+
+function IESLoader( manager ) {
+
+	this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+
+}
+
+function IESLamp( text ) {
+
+	var _self = this;
+
+	var textArray = text.split( '\n' );
+
+	var lineNumber = 0;
+	var line;
+
+	_self.verAngles = [ ];
+	_self.horAngles = [ ];
+
+	_self.candelaValues = [ ];
+
+	_self.tiltData = { };
+	_self.tiltData.angles = [ ];
+	_self.tiltData.mulFactors = [ ];
+
+	function textToArray( text ) {
+
+		text = text.replace( /^\s+|\s+$/g, '' ); // remove leading or trailing spaces
+		text = text.replace( /,/g, ' ' ); // replace commas with spaces
+		text = text.replace( /\s\s+/g, ' ' ); // Replcae white space/tabs etc by single whitespace
+
+		var array = text.split( ' ' );
+
+		return array;
+
+	}
+
+	function readArray( count, array ) {
+
+		while ( true ) {
+
+			var line = textArray[ lineNumber ++ ];
+			var lineData = textToArray( line );
+
+			for ( var i = 0; i < lineData.length; ++ i ) {
+
+				array.push( Number( lineData[ i ] ) );
+
+			}
+
+			if ( array.length === count )
+				break;
+
+		}
+
+	}
+
+	function readTilt() {
+
+		var line = textArray[ lineNumber ++ ];
+		var lineData = textToArray( line );
+
+		_self.tiltData.lampToLumGeometry = Number( lineData[ 0 ] );
+
+		line = textArray[ lineNumber ++ ];
+		lineData = textToArray( line );
+
+		_self.tiltData.numAngles = Number( lineData[ 0 ] );
+
+		readArray( _self.tiltData.numAngles, _self.tiltData.angles );
+		readArray( _self.tiltData.numAngles, _self.tiltData.mulFactors );
+
+	}
+
+	function readLampValues() {
+
+		var values = [ ];
+		readArray( 10, values );
+
+		_self.count = Number( values[ 0 ] );
+		_self.lumens = Number( values[ 1 ] );
+		_self.multiplier = Number( values[ 2 ] );
+		_self.numVerAngles = Number( values[ 3 ] );
+		_self.numHorAngles = Number( values[ 4 ] );
+		_self.gonioType = Number( values[ 5 ] );
+		_self.units = Number( values[ 6 ] );
+		_self.width = Number( values[ 7 ] );
+		_self.length = Number( values[ 8 ] );
+		_self.height = Number( values[ 9 ] );
+
+	}
+
+	function readLampFactors() {
+
+		var values = [ ];
+		readArray( 3, values );
+
+		_self.ballFactor = Number( values[ 0 ] );
+		_self.blpFactor = Number( values[ 1 ] );
+		_self.inputWatts = Number( values[ 2 ] );
+
+	}
+
+	while ( true ) {
+
+		var line = textArray[ lineNumber ++ ];
+
+		if ( line.includes( 'TILT' ) ) {
+
+			break;
+
+		}
+
+	}
+
+	if ( !line.includes( 'NONE' ) ) {
+
+		if ( line.includes( 'INCLUDE' ) ) {
+
+			readTilt();
+
+		} else {
+
+			// TODO:: Read tilt data from a file
+
+		}
+
+	}
+
+	readLampValues();
+
+	readLampFactors();
+
+	// Initialize candela value array
+	for ( var i = 0; i < _self.numHorAngles; ++ i ) {
+
+		_self.candelaValues.push( [ ] );
+
+	}
+
+	// Parse Angles
+	readArray( _self.numVerAngles, _self.verAngles );
+	readArray( _self.numHorAngles, _self.horAngles );
+
+	// Parse Candela values
+	for ( var i = 0; i < _self.numHorAngles; ++ i ) {
+
+		readArray( _self.numVerAngles, _self.candelaValues[ i ] );
+
+	}
+
+	// Calculate actual candela values, and normalize.
+	for ( var i = 0; i < _self.numHorAngles; ++ i ) {
+
+		for ( var j = 0; j < _self.numVerAngles; ++ j ) {
+
+			_self.candelaValues[ i ][ j ] *= _self.candelaValues[ i ][ j ] * _self.multiplier
+				* _self.ballFactor * _self.blpFactor;
+
+		}
+	}
+
+	var maxVal = -1;
+	for ( var i = 0; i < _self.numHorAngles; ++ i ) {
+
+		for ( var j = 0; j < _self.numVerAngles; ++ j ) {
+
+			var value = _self.candelaValues[ i ][ j ];
+			maxVal = maxVal < value ? value : maxVal;
+
+		}
+
+	}
+
+	var bNormalize = true;
+	if ( bNormalize && maxVal > 0 ) {
+
+		for ( var i = 0; i < _self.numHorAngles; ++ i ) {
+
+			for ( var j = 0; j < _self.numVerAngles; ++ j ) {
+
+				_self.candelaValues[ i ] [ j ] /= maxVal;
+
+			}
+
+		}
+
+	}
+
+}
+
+Object.assign( IESLoader.prototype, {
+
+	_parseIESData: function ( text ) {
+
+		var iesLamp = new IESLamp( text );
+
+		return iesLamp;
+
+	},
+
+	_getIESValues: function ( iesLamp ) {
+
+		var width = 360;
+		var height = 180;
+		var size = width * height;
+
+		var data = new Float32Array( size );
+
+		function interpolateCandelaValues( phi, theta ) {
+
+			var phiIndex = 0, thetaIndex = 0;
+			var startTheta = 0, endTheta = 0, startPhi = 0, endPhi = 0;
+
+			for ( var i = 0; i < iesLamp.numHorAngles - 1; ++ i ) { // numHorAngles = horAngles.length-1 because of extra padding, so this wont cause an out of bounds error
+
+				if ( theta < iesLamp.horAngles[ i + 1 ] || i == iesLamp.numHorAngles - 2 ) {
+
+					thetaIndex = i;
+					startTheta = iesLamp.horAngles[ i ];
+					endTheta = iesLamp.horAngles[ i + 1 ];
+
+					break;
+
+				}
+
+			}
+
+			for ( var i = 0; i < iesLamp.numVerAngles - 1; ++ i ) {
+
+				if ( phi < iesLamp.verAngles[ i + 1 ] || i == iesLamp.numVerAngles - 2 ) {
+
+					phiIndex = i;
+					startPhi = iesLamp.verAngles[ i ];
+					endPhi = iesLamp.verAngles[ i + 1 ];
+
+					break;
+
+				}
+
+			}
+
+			var deltaTheta = endTheta - startTheta;
+			var deltaPhi = endPhi - startPhi;
+
+			if ( deltaPhi === 0 ) // Outside range
+				return 0;
+
+			var t1 = deltaTheta === 0 ? 0 : ( theta - startTheta ) / deltaTheta;
+			var t2 = ( phi - startPhi ) / deltaPhi;
+
+			var nextThetaIndex = deltaTheta === 0 ? thetaIndex : thetaIndex + 1;
+
+			var v1 = MathUtils.lerp( iesLamp.candelaValues[ thetaIndex ][ phiIndex ], iesLamp.candelaValues[ nextThetaIndex ][ phiIndex ], t1 );
+			var v2 = MathUtils.lerp( iesLamp.candelaValues[ thetaIndex ][ phiIndex + 1 ], iesLamp.candelaValues[ nextThetaIndex ][ phiIndex + 1 ], t1 );
+			var v = MathUtils.lerp( v1, v2, t2 );
+
+			return v;
+
+		}
+
+		var startTheta = iesLamp.horAngles[ 0 ], endTheta = iesLamp.horAngles[ iesLamp.numHorAngles - 1 ];
+		for ( var i = 0; i < size; ++ i ) {
+
+			var theta = i % width;
+			var phi = Math.floor( i / width );
+
+			if ( endTheta - startTheta !== 0 && ( theta < startTheta || theta >= endTheta ) ) { // Handle symmetry for hor angles
+
+				theta %= endTheta * 2;
+				if ( theta > endTheta )
+					theta = endTheta * 2 - theta;
+
+			}
+
+			data[ i ] = interpolateCandelaValues( phi, theta );
+
+		}
+
+		return data;
+
+	},
+
+	load: function ( url, onLoad, onProgress, onError ) {
+
+		var loader = new FileLoader( this.manager );
+		loader.setResponseType( 'text' );
+
+		var _self = this;
+
+		var texture = new DataTexture( null, 360, 180, RedFormat, FloatType );
+		texture.minFilter = LinearFilter;
+		texture.magFilter = LinearFilter;
+
+		loader.load( url, function ( text ) {
+
+			var iesLamp = _self._parseIESData( text );
+
+			texture.image.data = _self._getIESValues( iesLamp );
+			texture.needsUpdate = true;
+
+			if ( onLoad !== undefined ) {
+
+				onLoad( texture );
+
+			}
+
+		}, onProgress, onError );
+
+		return texture;
+
+	}
+
+} );
+
+export { IESLoader };

--- a/src/workers/PathTracingSceneWorker.js
+++ b/src/workers/PathTracingSceneWorker.js
@@ -14,7 +14,7 @@ export class PathTracingSceneWorker extends PathTracingSceneGenerator {
 	generate( scene, options = {} ) {
 
 		const { bvhGenerator } = this;
-		const { geometry, materials, textures, lights } = this.prepScene( scene );
+		const { geometry, materials, textures, lights, spotLights } = this.prepScene( scene );
 
 		const bvhOptions = { strategy: SAH, ...options, maxLeafTris: 1 };
 		const bvhPromise = bvhGenerator.generate( geometry, bvhOptions );
@@ -25,6 +25,7 @@ export class PathTracingSceneWorker extends PathTracingSceneGenerator {
 				materials,
 				textures,
 				lights,
+				spotLights,
 				bvh,
 			};
 


### PR DESCRIPTION
Implements the features requested in https://github.com/gkjohnson/three-gpu-pathtracer/issues/113 and https://github.com/gkjohnson/three-gpu-pathtracer/issues/181

![Screenshot 2022-06-15 at 00-10-53 Spot Lights Path Tracing](https://user-images.githubusercontent.com/868396/173705320-570f5493-96a2-4993-9e59-4c11d759f0a5.png)

Builds on top of the area lights feature added by @mrxz. Merge after https://github.com/gkjohnson/three-gpu-pathtracer/pull/174 has been merged.

- Adds a `type` field to lights, allowing the use of `RectAreaLight` and `SpotLight`
- The non-IES spot light `angle`, `distance`, `decay` and `penumbra` parameters match the behaviour of THREE.js spotlights in physically accurate mode
- When using IES profiles `angle` and `penumbra` are ignored
- The `radius` parameter offsets the spotlight's position to match that of the cone angle and provides a means for soft shadows
- The `lampIntensityScale` parameter, when not 0, displays a circular area light with an intensity that is scaled by the spot light's main `intensity` parameter, otherwise this is invisible (light counts used in computations elsewhere might need to consider this but it seems fine without)

In `getPhotometricAttenuation` I've left some commented lines for if/when the azimuth angle is to be used, as `IESLoader` provides a 360 x 180 texture. If we don't need this then a 1 x 180 or 180 x 1 texture array can be used instead for the main `IESProfilesTexture`.

**Outstanding issues**

This change also further highlights some issues between the MIS and non-MIS branches, with the spot lights not working at all in the non-MIS branch. 

The final `FEATURE_MIS` block in `PhysicalPathTracingMaterial.js` seems to be lacking a non-MIS counterpart but I could be wrong in thinking this is the case. 

When many lights are present there's also a "warm up" time where pixels affected by the IES lights seem to receive their contributions slowly. This doesn't affect the "lamp" or any rectangular area lights, only the contributions from `randomLightSample`. (edit: this seems to only happen on load, and goes away after any `reset()`, looking into it)

I'd like to add some more IES profiles and improve the demo scene, will submit this for review now and get to that separately.

🔦