### PR TITLE
Improve precision of initial rayDirection for perspective camera #178

### DIFF
--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -343,8 +343,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							// Perspective projection
 
-							vec3 cameraOrigin = ( cameraWorldMatrix * vec4( 0.0, 0.0, 0.0, 1.0 ) ).xyz;
-							rayDirection = normalize( rayOrigin - cameraOrigin );
+							rayDirection = normalize( mat3(cameraWorldMatrix) * ( invProjectionMatrix * vec4( ndc, 0.0, 1.0 ) ).xyz );
 
 						#endif
 


### PR DESCRIPTION
The computation of the `rayDirection` was done by computing the world position of the camera. Since only the direction is relevant, it can instead be computed from the normalized device coordinates and transformed accordingly. This seems to resolve the precision issues observed in #178 