### PR TITLE
Added denoiser https://github.com/BrutPitt/glslSmartDeNoise #85

### DIFF
--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -51,6 +51,12 @@ const params = {
 
 	multipleImportanceSampling: true,
 	stableNoise: false,
+	denoiseEnabled: true,
+	denoiseSliderEnabled: true,
+	denoiseSlider: 0.0,
+	denoiseSigma: 2.5,
+	denoiseThreshold: 0.1,
+	denoiseKSigma: 1.0,
 	environmentIntensity: 1,
 	environmentRotation: 0,
 	environmentBlur: 0.0,
@@ -116,6 +122,8 @@ async function init() {
 	ptRenderer.material.setDefine( 'TRANSPARENT_TRAVERSALS', params.transparentTraversals );
 	ptRenderer.material.setDefine( 'FEATURE_MIS', Number( params.multipleImportanceSampling ) );
 	ptRenderer.tiles.set( params.tiles, params.tiles );
+	ptRenderer.denoise = params.denoiseEnabled;
+	ptRenderer.denoiser.setDefine( 'USE_SLIDER', Number( params.denoiseSliderEnabled ) );
 
 	fsQuad = new FullScreenQuad( new THREE.MeshBasicMaterial( {
 		map: ptRenderer.target.texture,
@@ -285,6 +293,38 @@ async function init() {
 	ptFolder.add( params, 'resolutionScale', 0.1, 1 ).onChange( () => {
 
 		onResize();
+
+	} );
+
+	const denoiseFolder = gui.addFolder( 'Denoising' );
+	denoiseFolder.add( params, 'denoiseEnabled' ).onChange( value => {
+
+		ptRenderer.denoise = value;
+
+	} );
+	denoiseFolder.add( params, 'denoiseSliderEnabled' ).onChange( value => {
+
+		ptRenderer.denoiser.setDefine( 'USE_SLIDER', Number( value ) );
+
+	} );
+	denoiseFolder.add( params, 'denoiseSlider', - 1.0, 1.0 ).onChange( value => {
+
+		ptRenderer.denoiser.slider = value;
+
+	} );
+	denoiseFolder.add( params, 'denoiseSigma', 0.01, 12.0 ).onChange( value => {
+
+		ptRenderer.denoiser.sigma = value;
+
+	} );
+	denoiseFolder.add( params, 'denoiseThreshold', 0.01, 1.0 ).onChange( value => {
+
+		ptRenderer.denoiser.threshold = value;
+
+	} );
+	denoiseFolder.add( params, 'denoiseKSigma', 0.0, 12.0 ).onChange( value => {
+
+		ptRenderer.denoiser.kSigma = value;
 
 	} );
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ export * from './utils/GeometryPreparationUtils.js';
 export * from './utils/BlurredEnvMapGenerator.js';
 
 // materials
+export * from './materials/DenoiseMaterial';
 export * from './materials/MaterialBase.js';
 export * from './materials/PhysicalPathTracingMaterial.js';
 

--- a/src/materials/DenoiseMaterial.js
+++ b/src/materials/DenoiseMaterial.js
@@ -94,6 +94,7 @@ export class DenoiseMaterial extends MaterialBase {
 					float invThresholdSqrt2PI = INV_SQRT_OF_2PI / threshold;
 
 					vec4 centrPx = texture2D( tex, uv );
+					centrPx.rgb *= centrPx.a;
 
 					float zBuff = 0.0;
 					vec4 aBuff = vec4( 0.0 );
@@ -109,6 +110,7 @@ export class DenoiseMaterial extends MaterialBase {
 							float blurFactor = exp( - dot( d, d ) * invSigmaQx2 ) * invSigmaQx2PI;
 
 							vec4 walkPx = texture2D( tex, uv + d / size );
+							walkPx.rgb *= walkPx.a;
 
 							vec4 dC = walkPx - centrPx;
 							float deltaFactor = exp( - dot( dC.rgba, dC.rgba ) * invThresholdSqx2 ) * invThresholdSqrt2PI * blurFactor;

--- a/src/materials/DenoiseMaterial.js
+++ b/src/materials/DenoiseMaterial.js
@@ -1,0 +1,154 @@
+import { NoBlending } from 'three';
+import { MaterialBase } from './MaterialBase.js';
+
+export class DenoiseMaterial extends MaterialBase {
+
+	constructor( parameters ) {
+
+		super( {
+
+			blending: NoBlending,
+
+			transparent: false,
+
+			depthWrite: false,
+
+			depthTest: false,
+
+			defines: {
+
+				USE_SLIDER: 0,
+
+			},
+
+			uniforms: {
+
+				sigma: { value: 5.0 },
+				threshold: { value: 0.03 },
+				kSigma: { value: 1.0 },
+
+				slider: { value: 0.0 },
+
+				map: { value: null },
+
+			},
+
+			vertexShader: `
+
+				varying vec2 vUv;
+
+				void main() {
+
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+				}
+
+			`,
+
+			fragmentShader: `
+
+				//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+				//  Copyright (c) 2018-2019 Michele Morrone
+				//  All rights reserved.
+				//
+				//  https://michelemorrone.eu - https://BrutPitt.com
+				//
+				//  me@michelemorrone.eu - brutpitt@gmail.com
+				//  twitter: @BrutPitt - github: BrutPitt
+				//
+				//  https://github.com/BrutPitt/glslSmartDeNoise/
+				//
+				//  This software is distributed under the terms of the BSD 2-Clause license
+				//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+				uniform sampler2D map;
+
+				uniform float sigma;
+				uniform float threshold;
+				uniform float kSigma;
+
+				uniform float slider;
+
+				varying vec2 vUv;
+
+				#define INV_SQRT_OF_2PI 0.39894228040143267793994605993439
+				#define INV_PI 0.31830988618379067153776752674503
+
+				// Parameters:
+				//	 sampler2D tex	 - sampler image / texture
+				//	 vec2 uv		   - actual fragment coord
+				//	 float sigma  >  0 - sigma Standard Deviation
+				//	 float kSigma >= 0 - sigma coefficient
+				//		 kSigma * sigma  -->  radius of the circular kernel
+				//	 float threshold   - edge sharpening threshold
+				vec4 smartDeNoise( sampler2D tex, vec2 uv, float sigma, float kSigma, float threshold ) {
+
+					float radius = round( kSigma * sigma );
+					float radQ = radius * radius;
+
+					float invSigmaQx2 = 0.5 / ( sigma * sigma );
+					float invSigmaQx2PI = INV_PI * invSigmaQx2;
+
+					float invThresholdSqx2 = 0.5 / ( threshold * threshold );
+					float invThresholdSqrt2PI = INV_SQRT_OF_2PI / threshold;
+
+					vec4 centrPx = texture2D( tex, uv );
+
+					float zBuff = 0.0;
+					vec4 aBuff = vec4( 0.0 );
+					vec2 size = vec2( textureSize( tex, 0 ) );
+
+					vec2 d;
+					for ( d.x = - radius; d.x <= radius; d.x ++ ) {
+
+						float pt = sqrt( radQ - d.x * d.x );
+
+						for ( d.y = - pt; d.y <= pt; d.y ++ ) {
+
+							float blurFactor = exp( - dot( d, d ) * invSigmaQx2 ) * invSigmaQx2PI;
+
+							vec4 walkPx = texture2D( tex, uv + d / size );
+
+							vec4 dC = walkPx - centrPx;
+							float deltaFactor = exp( - dot( dC.rgb, dC.rgb ) * invThresholdSqx2 ) * invThresholdSqrt2PI * blurFactor;
+
+							zBuff += deltaFactor;
+							aBuff += deltaFactor * walkPx;
+
+						}
+
+					}
+
+					return aBuff / zBuff;
+
+				}
+
+				void main() {
+
+					vec4 denoised = smartDeNoise( map, vec2( vUv.x, vUv.y ), sigma, kSigma, threshold );
+
+					#if USE_SLIDER
+
+					float slide = slider * 0.5 + 0.5;
+					float szSlide = max( 0.001, 1.0 / float( textureSize( map, 0 ).x ) );
+
+					gl_FragColor = ( vUv.x < slide - szSlide ) ? texture2D( map, vec2( vUv.x, vUv.y ) ) : ( ( vUv.x > slide + szSlide ) ? denoised : vec4( 1.0 ) );
+
+					#else
+
+					gl_FragColor = denoised;
+
+					#endif
+
+				}
+
+			`
+
+		} );
+
+		this.setValues( parameters );
+
+	}
+
+}

--- a/src/materials/DenoiseMaterial.js
+++ b/src/materials/DenoiseMaterial.js
@@ -111,7 +111,7 @@ export class DenoiseMaterial extends MaterialBase {
 							vec4 walkPx = texture2D( tex, uv + d / size );
 
 							vec4 dC = walkPx - centrPx;
-							float deltaFactor = exp( - dot( dC.rgb, dC.rgb ) * invThresholdSqx2 ) * invThresholdSqrt2PI * blurFactor;
+							float deltaFactor = exp( - dot( dC.rgba, dC.rgba ) * invThresholdSqx2 ) * invThresholdSqrt2PI * blurFactor;
 
 							zBuff += deltaFactor;
 							aBuff += deltaFactor * walkPx;


### PR DESCRIPTION
Solves issue https://github.com/gkjohnson/three-gpu-pathtracer/issues/85

Added support for denoising with glslSmartDeNoise. Tuned the parameters a bit to find a good balance without too much blur.

Initially I tried adding `DenoiseMaterial` to the main `fsQuad` but due to how THREE.js handles tone mapping this broke tone mapping, so it has to go into `PathTracingRenderer`.

When additional denoisers are added these could be set by changing the `ptRenderer.denoiser` material.

I've added this only to `materialBall.js` and it defaults to enabled, with the slider defaulting to enabled also, we can turn this off before merging the PR.