### PR TITLE
Fix normapMap texture.repeat

### DIFF
--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -610,7 +610,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								vec3 bitangent = normalize( cross( normal, tangent ) * tangentSample.w );
 								mat3 vTBN = mat3( tangent, bitangent, normal );
 
-								vec3 uvPrime = material.normalMapTransform * vec3( uv, 1 );
+								vec3 uvPrime = material.mapTransform * vec3( uv, 1 );
 								vec3 texNormal = texture2D( textures, vec3( uvPrime.xy, material.normalMap ) ).xyz * 2.0 - 1.0;
 								texNormal.xy *= material.normalScale;
 								normal = vTBN * texNormal;

--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -55,7 +55,6 @@ export const shaderMaterialStructs = /* glsl */ `
 		mat3 roughnessMapTransform;
 		mat3 transmissionMapTransform;
 		mat3 emissiveMapTransform;
-		mat3 normalMapTransform;
 
 	};
 
@@ -76,7 +75,7 @@ export const shaderMaterialStructs = /* glsl */ `
 
 	Material readMaterialInfo( sampler2D tex, uint index ) {
 
-		uint i = index * 19u;
+		uint i = index * 17u;
 
 		vec4 s0 = texelFetch1D( tex, i + 0u );
 		vec4 s1 = texelFetch1D( tex, i + 1u );
@@ -122,7 +121,6 @@ export const shaderMaterialStructs = /* glsl */ `
 		m.roughnessMapTransform = m.roughnessMap == - 1 ? mat3( 0 ) : readTextureTransform( tex, firstTextureTransformIdx + 4u );
 		m.transmissionMapTransform = m.transmissionMap == - 1 ? mat3( 0 ) : readTextureTransform( tex, firstTextureTransformIdx + 6u );
 		m.emissiveMapTransform = m.emissiveMap == - 1 ? mat3( 0 ) : readTextureTransform( tex, firstTextureTransformIdx + 8u );
-		m.normalMapTransform = m.normalMap == - 1 ? mat3( 0 ) : readTextureTransform( tex, firstTextureTransformIdx + 10u );
 
 		return m;
 

--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -1,6 +1,6 @@
 import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, FrontSide, BackSide, DoubleSide } from 'three';
 
-const MATERIAL_PIXELS = 19;
+const MATERIAL_PIXELS = 17;
 const MATERIAL_STRIDE = MATERIAL_PIXELS * 4;
 
 export class MaterialsTexture extends DataTexture {
@@ -238,9 +238,6 @@ export class MaterialsTexture extends DataTexture {
 
 			// emissiveMap transform
 			index += writeTextureMatrixToArray( m, 'emissiveMap', floatArray, index );
-
-			// normalMap transform
-			index += writeTextureMatrixToArray( m, 'normalMap', floatArray, index );
 
 		}
 


### PR DESCRIPTION
Resolves https://github.com/gkjohnson/three-gpu-pathtracer/issues/195

- Transform `normalMap` by the `mapTransform` and apply `normalScale`

Behaviour is confirmed on [discourse.threejs.org](https://discourse.threejs.org/t/different-repeats-for-map-and-bumpmap-textures/9885/2) posts, from test and from consulting the THREE.js source code.