### PR TITLE
Allow users to pass an array of Object3Ds to the pathtracer instead of an entire scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for area lights.
 - Support for spotlights.
 - Support for threejs compatible texture transforms.
+- Support for Clearcoat properties.
 
 ### Fixed
 - Black renders on M1 Safari devices.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Utility class for generating the set of data required for initializing the path 
 ### .generate
 
 ```js
-generate( scene : Object3D, options = {} : Object ) : {
+generate( scene : Object3D | Array<Object3D>, options = {} : Object ) : {
 	bvh : MeshBVH,
 	materials : Array<Material>,
 	textures : Array<Texture>,
@@ -295,7 +295,7 @@ See note in [Asyncronous Generation](#asynchronous-generation) use snippet.
 ### .generate
 
 ```js
-async generate( scene : Object3D, options = {} : Object ) : {
+async generate( scene : Object3D | Array<Object3D>, options = {} : Object ) : {
 	bvh : MeshBVH,
 	materials : Array<Material>,
 	textures : Array<Texture>,
@@ -380,7 +380,7 @@ If geometry or materials are added or removed from the scene then `reset` must b
 ### constructor
 
 ```js
-constructor( scene : Object3D )
+constructor( scene : Object3D | Array<Object3D> )
 ```
 
 Takes the scene to convert.

--- a/src/core/DynamicPathTracingSceneGenerator.js
+++ b/src/core/DynamicPathTracingSceneGenerator.js
@@ -12,7 +12,7 @@ export class DynamicPathTracingSceneGenerator {
 
 	constructor( scene ) {
 
-		this.scene = scene;
+		this.objects = Array.isArray( scene ) ? scene : [ scene ];
 		this.bvh = null;
 		this.geometry = new BufferGeometry();
 		this.materials = null;
@@ -28,7 +28,7 @@ export class DynamicPathTracingSceneGenerator {
 		this.geometry = new BufferGeometry();
 		this.materials = null;
 		this.textures = null;
-		this.staticGeometryGenerator = new StaticGeometryGenerator( this.scene );
+		this.staticGeometryGenerator = new StaticGeometryGenerator( this.objects );
 
 	}
 
@@ -36,7 +36,7 @@ export class DynamicPathTracingSceneGenerator {
 
 	generate() {
 
-		const { scene, staticGeometryGenerator, geometry } = this;
+		const { objects, staticGeometryGenerator, geometry } = this;
 		if ( this.bvh === null ) {
 
 			const attributes = [ 'position', 'normal', 'tangent', 'uv' ];
@@ -45,22 +45,22 @@ export class DynamicPathTracingSceneGenerator {
 
 				if ( c.isMesh ) {
 
-					const normalMapRequired = ! ! c.material.normalMap;
-					setCommonAttributes( c.geometry, { attributes, normalMapRequired } );
+					c.traverse( ( cTrav ) => {
+
+						if ( cTrav.isMesh ) {
+
+							const normalMapRequired = ! ! c.material.normalMap;
+							setCommonAttributes( c.geometry, { attributes, normalMapRequired } );
+
+						}
+
+					} );
 
 				}
 
 			}
 
-			if ( scene instanceof Object3D ) {
-
-				scene.traverse( checkObject );
-
-			} else if ( scene instanceof Array ) {
-
-				scene.forEach( checkObject );
-
-			}
+			objects.forEach( checkObject );
 
 			const textureSet = new Set();
 			const materials = staticGeometryGenerator.getMaterials();
@@ -94,7 +94,7 @@ export class DynamicPathTracingSceneGenerator {
 				bvh: this.bvh,
 				materials: this.materials,
 				textures: this.textures,
-				scene,
+				objects,
 			};
 
 		} else {
@@ -106,7 +106,7 @@ export class DynamicPathTracingSceneGenerator {
 				bvh: this.bvh,
 				materials: this.materials,
 				textures: this.textures,
-				scene,
+				objects,
 			};
 
 		}

--- a/src/core/DynamicPathTracingSceneGenerator.js
+++ b/src/core/DynamicPathTracingSceneGenerator.js
@@ -1,4 +1,4 @@
-import { BufferGeometry } from 'three';
+import { BufferGeometry, Object3D } from 'three';
 import { StaticGeometryGenerator, MeshBVH } from 'three-mesh-bvh';
 import { setCommonAttributes, getGroupMaterialIndicesAttribute } from '../utils/GeometryPreparationUtils.js';
 
@@ -40,7 +40,8 @@ export class DynamicPathTracingSceneGenerator {
 		if ( this.bvh === null ) {
 
 			const attributes = [ 'position', 'normal', 'tangent', 'uv' ];
-			scene.traverse( c => {
+
+			function checkObject( c ) {
 
 				if ( c.isMesh ) {
 
@@ -49,7 +50,17 @@ export class DynamicPathTracingSceneGenerator {
 
 				}
 
-			} );
+			}
+
+			if ( scene instanceof Object3D ) {
+
+				scene.traverse( checkObject );
+
+			} else if ( scene instanceof Array ) {
+
+				scene.forEach( checkObject );
+
+			}
 
 			const textureSet = new Set();
 			const materials = staticGeometryGenerator.getMaterials();

--- a/src/core/DynamicPathTracingSceneGenerator.js
+++ b/src/core/DynamicPathTracingSceneGenerator.js
@@ -41,26 +41,20 @@ export class DynamicPathTracingSceneGenerator {
 
 			const attributes = [ 'position', 'normal', 'tangent', 'uv' ];
 
-			function checkObject( c ) {
+			for ( let i = 0, l = objects.length; i < l; i ++ ) {
 
-				if ( c.isMesh ) {
+				objects[ i ].traverse( ( c ) => {
 
-					c.traverse( ( cTrav ) => {
+					if ( c.isMesh ) {
 
-						if ( cTrav.isMesh ) {
+						const normalMapRequired = ! ! c.material.normalMap;
+						setCommonAttributes( c.geometry, { attributes, normalMapRequired } );
 
-							const normalMapRequired = ! ! c.material.normalMap;
-							setCommonAttributes( c.geometry, { attributes, normalMapRequired } );
+					}
 
-						}
-
-					} );
-
-				}
+				} );
 
 			}
-
-			objects.forEach( checkObject );
 
 			const textureSet = new Set();
 			const materials = staticGeometryGenerator.getMaterials();

--- a/src/core/DynamicPathTracingSceneGenerator.js
+++ b/src/core/DynamicPathTracingSceneGenerator.js
@@ -1,4 +1,4 @@
-import { BufferGeometry, Object3D } from 'three';
+import { BufferGeometry } from 'three';
 import { StaticGeometryGenerator, MeshBVH } from 'three-mesh-bvh';
 import { setCommonAttributes, getGroupMaterialIndicesAttribute } from '../utils/GeometryPreparationUtils.js';
 

--- a/src/core/PathTracingSceneGenerator.js
+++ b/src/core/PathTracingSceneGenerator.js
@@ -38,11 +38,7 @@ export class PathTracingSceneGenerator {
 
 		if ( scene instanceof Object3D ) {
 
-			scene.traverse( c => {
-
-				checkObject( c );
-
-			} );
+			scene.traverse( checkObject );
 
 		} else if ( scene instanceof Array ) {
 

--- a/src/core/PathTracingSceneGenerator.js
+++ b/src/core/PathTracingSceneGenerator.js
@@ -1,4 +1,4 @@
-import { Mesh } from 'three';
+import { Mesh, Object3D } from 'three';
 import { SAH, MeshBVH, StaticGeometryGenerator } from 'three-mesh-bvh';
 import { mergeMeshes } from '../utils/GeometryPreparationUtils.js';
 
@@ -8,7 +8,8 @@ export class PathTracingSceneGenerator {
 
 		const meshes = [];
 		const lights = [];
-		scene.traverse( c => {
+
+		function checkObject( c ) {
 
 			if ( c.isSkinnedMesh || c.isMesh && c.morphTargetInfluences ) {
 
@@ -33,7 +34,21 @@ export class PathTracingSceneGenerator {
 
 			}
 
-		} );
+		}
+
+		if ( scene instanceof Object3D ) {
+
+			scene.traverse( c => {
+
+				checkObject( c );
+
+			} );
+
+		} else if ( scene instanceof Array ) {
+
+			scene.forEach( checkObject );
+
+		}
 
 		return {
 			...mergeMeshes( meshes, {

--- a/src/core/PathTracingSceneGenerator.js
+++ b/src/core/PathTracingSceneGenerator.js
@@ -1,4 +1,4 @@
-import { Mesh, Object3D } from 'three';
+import { Mesh } from 'three';
 import { SAH, MeshBVH, StaticGeometryGenerator } from 'three-mesh-bvh';
 import { mergeMeshes } from '../utils/GeometryPreparationUtils.js';
 

--- a/src/core/PathTracingSceneGenerator.js
+++ b/src/core/PathTracingSceneGenerator.js
@@ -6,45 +6,43 @@ export class PathTracingSceneGenerator {
 
 	prepScene( scene ) {
 
+		scene = Array.isArray( scene ) ? scene : [ scene ];
+
 		const meshes = [];
 		const lights = [];
 
-		function checkObject( c ) {
+		function checkObject( checkObject ) {
 
-			if ( c.isSkinnedMesh || c.isMesh && c.morphTargetInfluences ) {
+			checkObject.traverse( ( c ) => {
 
-				const generator = new StaticGeometryGenerator( c );
-				generator.applyWorldTransforms = false;
-				const mesh = new Mesh(
-					generator.generate(),
-					c.material,
-				);
-				mesh.matrixWorld.copy( c.matrixWorld );
-				mesh.matrix.copy( c.matrixWorld );
-				mesh.matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );
-				meshes.push( mesh );
+				if ( c.isSkinnedMesh || c.isMesh && c.morphTargetInfluences ) {
 
-			} else if ( c.isMesh ) {
+					const generator = new StaticGeometryGenerator( c );
+					generator.applyWorldTransforms = false;
+					const mesh = new Mesh(
+						generator.generate(),
+						c.material,
+					);
+					mesh.matrixWorld.copy( c.matrixWorld );
+					mesh.matrix.copy( c.matrixWorld );
+					mesh.matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );
+					meshes.push( mesh );
 
-				meshes.push( c );
+				} else if ( c.isMesh ) {
 
-			} else if ( c.isRectAreaLight ) {
+					meshes.push( c );
 
-				lights.push( c );
+				} else if ( c.isRectAreaLight ) {
 
-			}
+					lights.push( c );
 
-		}
+				}
 
-		if ( scene instanceof Object3D ) {
-
-			scene.traverse( checkObject );
-
-		} else if ( scene instanceof Array ) {
-
-			scene.forEach( checkObject );
+			} );
 
 		}
+
+		scene.forEach( checkObject );
 
 		return {
 			...mergeMeshes( meshes, {

--- a/src/core/PathTracingSceneGenerator.js
+++ b/src/core/PathTracingSceneGenerator.js
@@ -11,9 +11,9 @@ export class PathTracingSceneGenerator {
 		const meshes = [];
 		const lights = [];
 
-		function checkObject( checkObject ) {
+		for ( let i = 0, l = scene.length; i < l; i ++ ) {
 
-			checkObject.traverse( ( c ) => {
+			scene[ i ].traverse( ( c ) => {
 
 				if ( c.isSkinnedMesh || c.isMesh && c.morphTargetInfluences ) {
 
@@ -41,8 +41,6 @@ export class PathTracingSceneGenerator {
 			} );
 
 		}
-
-		scene.forEach( checkObject );
 
 		return {
 			...mergeMeshes( meshes, {


### PR DESCRIPTION
See #204 

This allows users to perform their own filtering of a scene's objects prior to passing it to the pathtracer, in case there are any elements of the scene they'd like to omit from the path-traced rendering.