### PR TITLE
Fix specular edge artifacts

### DIFF
--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -73,9 +73,6 @@ float specularPDF( vec3 wo, vec3 wi, SurfaceRec surf ) {
 	// See 14.1.1 Microfacet BxDFs in https://www.pbr-book.org/
 	float filteredRoughness = surf.filteredRoughness;
 	vec3 halfVector = getHalfVector( wi, wo );
-	if ( wi.z * wo.z < 0.0 ) {
-		return 0.0;
-	}
 
 	float incidentTheta = acos( wo.z );
 	float D = ggxDistribution( halfVector, filteredRoughness );

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -70,10 +70,18 @@ vec3 diffuseColor( vec3 wo, vec3 wi, SurfaceRec surf ) {
 // specular
 float specularPDF( vec3 wo, vec3 wi, SurfaceRec surf ) {
 
-	// See equation (27) in http://jcgt.org/published/0003/02/03/
+	// See 14.1.1 Microfacet BxDFs in https://www.pbr-book.org/
 	float filteredRoughness = surf.filteredRoughness;
 	vec3 halfVector = getHalfVector( wi, wo );
-	return ggxPDF( wo, halfVector, filteredRoughness ) / ( 4.0 * dot( wi, halfVector ) );
+	if ( wi.z * wo.z < 0.0 ) {
+		return 0.0;
+	}
+
+	float incidentTheta = acos( wo.z );
+	float D = ggxDistribution( halfVector, filteredRoughness );
+	float G1 = ggxShadowMaskG1( incidentTheta, filteredRoughness );
+	float ggxPdf = D * G1 * max( 0.0, abs( dot( wo, halfVector ) ) ) / abs ( wo.z );
+	return ggxPdf / ( 4.0 * dot( wo, halfVector ) );
 
 }
 


### PR DESCRIPTION
Update the specularPDF method so that it takes the absolute value of several parameters - see https://www.pbr-book.org/3ed-2018/Light_Transport_I_Surface_Reflection/Sampling_Reflection_Functions for an in-depth explanation.

This change fixes the issues with white highlights on glancing edges described in #215 

**Before**
![image](https://user-images.githubusercontent.com/85718573/180629834-59d4b308-bf60-46ce-ab0f-5afaa2e2b0da.png)

**After**
![image](https://user-images.githubusercontent.com/85718573/180629871-3bed036b-4428-47fe-a3ce-682cc7318895.png)
