### PR TITLE
Align IES Profile loading with existing patterns

### DIFF
--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -88,6 +88,7 @@ const params = {
 	checkerboardTransparency: true,
 	showTransformControls: true,
 	cameraProjection: 'Perspective',
+	iesProfile: - 1,
 };
 
 if ( window.location.hash.includes( 'transmission' ) ) {
@@ -288,7 +289,6 @@ async function init() {
 
 						new IESLoader().load( iesProfileURLs[ iesIndex ], tex => {
 
-							console.log('GOT HERE', tex)
 							spotLight.iesTexture = tex;
 							resolve( tex );
 
@@ -593,7 +593,12 @@ async function init() {
 	matFolder5.add( spotLight1, 'distance', 0.0, 20.0 ).onChange( reset );
 	matFolder5.add( spotLight1, 'angle', 0.0, Math.PI / 2.0 ).onChange( reset );
 	matFolder5.add( spotLight1, 'penumbra', 0.0, 1.0 ).onChange( reset );
-	// matFolder5.add( spotLight1, 'iesProfile', - 1, iesProfileURLs.length - 1, 1 ).onChange( reset );
+	matFolder5.add( params, 'iesProfile', - 1, iesProfileURLs.length - 1, 1 ).onChange( v => {
+
+		spotLight1.iesTexture = v === - 1 ? null : iesTextures[ v ];
+		reset();
+
+	} );
 
 	animate();
 

--- a/src/core/PhysicalSpotLight.js
+++ b/src/core/PhysicalSpotLight.js
@@ -1,0 +1,14 @@
+import { SpotLight } from 'three';
+
+export class PhysicalSpotLight extends SpotLight {
+
+	constructor( ...args ) {
+
+		super( ...args );
+
+		this.iesTexture = null;
+		this.radius = 0;
+
+	}
+
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export * from './core/DynamicPathTracingSceneGenerator.js';
 export * from './core/MaterialReducer.js';
 export * from './core/PhysicalCamera.js';
 export * from './core/EquirectCamera.js';
+export * from './core/PhysicalSpotLight.js';
 
 // uniforms
 export * from './uniforms/MaterialsTexture.js';

--- a/src/uniforms/IESProfilesTexture.js
+++ b/src/uniforms/IESProfilesTexture.js
@@ -40,34 +40,7 @@ export class IESProfilesTexture extends WebGLArrayRenderTarget {
 
 	}
 
-	async updateFrom( renderer, iesProfiles ) {
-
-		const textures = [ ];
-		const promises = [ ];
-
-		iesProfiles.forEach( iesProfileURL => {
-
-			promises.push( new Promise( resolve => {
-
-				this.iesLoader
-					.load( iesProfileURL, texture => {
-
-						textures.push( texture );
-						resolve();
-
-					} );
-
-			} ) );
-
-		} );
-
-		await Promise.all( promises );
-
-		this._setTextures( renderer, textures );
-
-	}
-
-	_setTextures( renderer, textures ) {
+	async updateFrom( renderer, textures ) {
 
 		// save previous renderer state
 		const prevRenderTarget = renderer.getRenderTarget();

--- a/src/uniforms/SpotLightsTexture.js
+++ b/src/uniforms/SpotLightsTexture.js
@@ -112,7 +112,6 @@ export class SpotLightsTexture extends DataTexture {
 			// penumbraCos
 			floatArray[ baseIndex + ( index ++ ) ] = Math.cos( sl.angle * ( 1 - sl.penumbra ) );
 
-			console.log( iesTextures );
 			// iesProfile
 			floatArray[ baseIndex + ( index ++ ) ] = iesTextures.indexOf( sl.iesTexture );
 

--- a/src/uniforms/SpotLightsTexture.js
+++ b/src/uniforms/SpotLightsTexture.js
@@ -16,7 +16,7 @@ export class SpotLightsTexture extends DataTexture {
 
 	}
 
-	updateFrom( spotLights ) {
+	updateFrom( spotLights, iesTextures = [] ) {
 
 		const pixelCount = spotLights.length * SPOT_LIGHT_PIXELS;
 		const dimension = Math.ceil( Math.sqrt( pixelCount ) );
@@ -112,8 +112,9 @@ export class SpotLightsTexture extends DataTexture {
 			// penumbraCos
 			floatArray[ baseIndex + ( index ++ ) ] = Math.cos( sl.angle * ( 1 - sl.penumbra ) );
 
+			console.log( iesTextures );
 			// iesProfile
-			floatArray[ baseIndex + ( index ++ ) ] = sl.iesProfile;
+			floatArray[ baseIndex + ( index ++ ) ] = iesTextures.indexOf( sl.iesTexture );
 
 		}
 


### PR DESCRIPTION
Fix #226

Adds a "PhysicalSpotLight" class with "radius" and "iesTexture" classes as well as updates the loading and updating of IES Profiles / spot lights to align with the materials texture pattern. Now textures can be assigned on the spotlights instead of indices.

cc @richardassar if you're interested!