### PR TITLE
Add utility for graphing shader functions

### DIFF
--- a/example/graphing.html
+++ b/example/graphing.html
@@ -25,11 +25,49 @@
 			text-align: center;
 			width: 100%;
 			padding: 5px;
+			pointer-events: none;
+		}
+
+		#dataContainer {
+			position: fixed;
+			font-family: monospace;
+			color: white;
+			pointer-events: none;
+			width: 0;
+			height: 0;
+			visibility: hidden;
+		}
+
+		#data {
+			margin-top: 10px;
+			transform: translate( -50%, 0 );
+			display: inline-block;
+			white-space: pre;
+		}
+
+		#dataContainer::after {
+			content: '';
+			position: absolute;
+			border: 1px solid white;
+			border-radius: 10px;
+			width: 5px;
+			height: 5px;
+			top: 0;
+			left: 0;
+			display: inline-block;
+			transform: translate( -50%, -50% );
+		}
+
+		canvas {
+			cursor: none;
 		}
     </style>
 </head>
 
 <body>
+	<div id="dataContainer">
+		<div id="data">TEST</div>
+	</div>
 	<div id="info">Utility for graphing shader function outputs.</div>
     <script type="module" src="./graphing.js"></script>
 </body>

--- a/example/graphing.html
+++ b/example/graphing.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>PGM File Loading</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+    <style type="text/css">
+        html,
+        body {
+            padding: 0;
+            margin: 0;
+            overflow: hidden;
+        }
+
+        canvas {
+            width: 100%;
+            height: 100%;
+        }
+
+		#info {
+			position: absolute;
+			font-family: monospace;
+			color: white;
+			text-align: center;
+			width: 100%;
+			padding: 5px;
+		}
+    </style>
+</head>
+
+<body>
+	<div id="info">Utility for graphing shader function outputs.</div>
+    <script type="module" src="./graphing.js"></script>
+</body>
+
+</html>

--- a/example/graphing.html
+++ b/example/graphing.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>PGM File Loading</title>
+    <title>Shader Graphing Utility</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
     <style type="text/css">

--- a/example/graphing.js
+++ b/example/graphing.js
@@ -144,7 +144,7 @@ async function init() {
 		dataContainerEl.style.top = `${ e.clientY }px`;
 
 		const data = mouseToGraphValue( e.clientX, e.clientY );
-		dataEl.innerText = `x: ${ data.x.toFixed( 3 ) }\ny: ${ data.y.toFixed( 3 ) }`
+		dataEl.innerText = `x: ${ data.x.toFixed( 3 ) }\ny: ${ data.y.toFixed( 3 ) }`;
 
 	} );
 

--- a/example/graphing.js
+++ b/example/graphing.js
@@ -10,9 +10,15 @@ let zoom = 10;
 let dataEl, dataContainerEl;
 const params = {
 	aspect: 1,
+	displayX: true,
+	displayY: true,
+	displayZ: true,
+	displayW: true,
 	reset() {
+
 		zoom = 10;
 		cameraCenter.set( 0, 0 );
+
 	}
 };
 
@@ -80,11 +86,14 @@ async function init() {
 	const gui = new GUI();
 	gui.add( plane.material, 'dim' );
 	gui.add( plane.material, 'thickness', 0.5, 10.0 );
-	gui.add( plane.material, 'graphCount', 1.0, 4.0, 1.0 );
+	gui.add( params, 'aspect', 0.1, 2 );
 	gui.add( params, 'reset' );
 
-	const aspectFolder = gui.addFolder( 'aspect' );
-	aspectFolder.add( params, 'aspect', 0.1, 2 );
+	const graphFolder = gui.addFolder( 'graphs' );
+	graphFolder.add( params, 'displayX' ).name( 'display graph 1' );
+	graphFolder.add( params, 'displayY' ).name( 'display graph 2' );
+	graphFolder.add( params, 'displayZ' ).name( 'display graph 3' );
+	graphFolder.add( params, 'displayW' ).name( 'display graph 4' );
 
 	let clicked = false;
 	let prevX = - 1;
@@ -197,10 +206,16 @@ function animation() {
 		- cameraCenter.x + 0.5 * xWidth * zoom,
 	);
 
-
 	mat.yRange.set(
 		cameraCenter.y - 0.5 * yWidth * zoom,
 		cameraCenter.y + 0.5 * yWidth * zoom,
+	);
+
+	mat.graphDisplay.set(
+		Number( params.displayX ),
+		Number( params.displayY ),
+		Number( params.displayZ ),
+		Number( params.displayW ),
 	);
 
 	renderer.render( scene, camera );

--- a/example/graphing.js
+++ b/example/graphing.js
@@ -1,13 +1,24 @@
 import * as THREE from 'three';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import GUI from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import { GraphMaterial } from '../src/index.js';
 import { shaderGGXFunctions } from '../src/shader/shaderGGXFunctions.js';
 import { shaderUtils } from '../src/shader/shaderUtils.js';
 
-let camera, scene, renderer, controls;
+let camera, scene, renderer, plane;
+let xRange, yRange;
+let cameraCenter;
+let zoom = 10;
+const params = {
+	aspect: 1,
+};
 
 init();
+
+function getAspect() {
+
+	return params.aspect * window.innerHeight / window.innerWidth;
+
+}
 
 // init
 async function init() {
@@ -27,14 +38,16 @@ async function init() {
 
 	scene = new THREE.Scene();
 
+	xRange = new THREE.Vector2( 0, 1.0 );
+	yRange = new THREE.Vector2( 0, 5.0 );
+	cameraCenter = new THREE.Vector2();
+
 	// image plane
-	const plane = new THREE.Mesh(
+	plane = new THREE.Mesh(
 		new THREE.PlaneGeometry(),
 		new GraphMaterial( {
 			side: THREE.DoubleSide,
-			thickness: 2,
-			xRange: new THREE.Vector2( 0, 1.0 ),
-			yRange: new THREE.Vector2( 0, 5.0 ),
+			thickness: 1,
 			functionContent: /* glsl */`
 				#include <common>
 				${ shaderUtils }
@@ -57,32 +70,106 @@ async function init() {
 			`
 		} )
 	);
-	plane.scale.setScalar( 1.75 );
+	plane.scale.setScalar( 2.0 );
 	scene.add( plane );
 
-
+	cameraCenter.set(
+		- zoom * 0.45,
+		getAspect() * zoom * 0.4,
+	);
 
 	const gui = new GUI();
-	gui.add( plane.material, 'overlay' );
-	gui.add( plane.material, 'thickness', 1.0, 3.0 );
+	gui.add( plane.material, 'dim' );
+	gui.add( plane.material, 'thickness', 0.1, 10.0 );
 	gui.add( plane.material, 'graphCount', 1.0, 4.0, 1.0 );
 
+	const aspectFolder = gui.addFolder( 'aspect' );
+	aspectFolder.add( params, 'aspect', 0.1, 2 );
+
 	const xAxis = gui.addFolder( 'x axis' );
-	xAxis.add( plane.material.xRange, 'x', - 20, 20, 0.25 ).name( 'min' );
-	xAxis.add( plane.material.xRange, 'y', - 20, 20, 0.25 ).name( 'min' );
+	xAxis.add( xRange, 'x', - 20, 20, 0.25 ).name( 'min' );
+	xAxis.add( xRange, 'y', - 20, 20, 0.25 ).name( 'min' );
 
 	const yAxis = gui.addFolder( 'y axis' );
-	yAxis.add( plane.material.yRange, 'x', - 10, 10, 0.25 ).name( 'min' );
-	yAxis.add( plane.material.yRange, 'y', - 10, 10, 0.25 ).name( 'min' );
+	yAxis.add( yRange, 'x', - 10, 10, 0.25 ).name( 'min' );
+	yAxis.add( yRange, 'y', - 10, 10, 0.25 ).name( 'min' );
 
-	controls = new OrbitControls( camera, renderer.domElement );
-	controls.mouseButtons.LEFT = THREE.MOUSE.PAN;
+	let clicked = false;
+	let prevX = - 1;
+	let prevY = - 1;
+	renderer.domElement.addEventListener( 'pointerdown', e => {
+
+		clicked = true;
+		prevX = e.clientX;
+		prevY = e.clientY;
+
+	} );
+
+	renderer.domElement.addEventListener( 'pointermove', e => {
+
+		clicked = Boolean( e.buttons & 1 );
+		if ( clicked ) {
+
+			const deltaX = e.clientX - prevX;
+			const deltaY = e.clientY - prevY;
+
+			prevX = e.clientX;
+			prevY = e.clientY;
+
+			const xWidth = 1;
+			const yWidth = getAspect();
+
+			const graphDeltaX = zoom * xWidth * deltaX / window.innerWidth;
+			const graphDeltaY = zoom * yWidth * deltaY / window.innerHeight;
+
+			cameraCenter.x += graphDeltaX;
+			cameraCenter.y += graphDeltaY;
+
+		}
+
+	} );
+
+	renderer.domElement.addEventListener( 'wheel', e => {
+
+		const mouseX = e.clientX;
+		const mouseY = e.clientY;
+
+		const xWidth = 1;
+		const yWidth = getAspect();
+
+		const centerRelX = ( mouseX / window.innerWidth ) - 0.5;
+		const centerRelY = ( mouseY / window.innerHeight ) - 0.5;
+
+		const graphX = zoom * xWidth * centerRelX;
+		const graphY = zoom * yWidth * centerRelY;
+
+		const beforeZoom = zoom;
+		const delta = Math.pow( 0.95, 1.0 );
+
+		if ( e.deltaY < 0 ) {
+
+			zoom *= delta;
+
+		} else {
+
+			zoom /= delta;
+
+		}
+
+		zoom = Math.max( zoom, 0.1 );
+		zoom = Math.min( zoom, 100 );
+
+		const afterX = graphX * zoom / beforeZoom;
+		const afterY = graphY * zoom / beforeZoom;
+
+		cameraCenter.x -= graphX - afterX;
+		cameraCenter.y -= graphY - afterY;
+
+	} );
 
 	window.addEventListener( 'resize', () => {
 
 		renderer.setSize( window.innerWidth, window.innerHeight );
-		camera.aspect = window.innerWidth / window.innerHeight;
-		camera.updateProjectionMatrix();
 
 	} );
 
@@ -90,6 +177,21 @@ async function init() {
 
 // animation
 function animation() {
+
+	const mat = plane.material;
+	const xWidth = 1;
+	const yWidth = getAspect();
+
+	mat.xRange.set(
+		- cameraCenter.x - 0.5 * xWidth * zoom,
+		- cameraCenter.x + 0.5 * xWidth * zoom,
+	);
+
+
+	mat.yRange.set(
+		cameraCenter.y - 0.5 * yWidth * zoom,
+		cameraCenter.y + 0.5 * yWidth * zoom,
+	);
 
 	renderer.render( scene, camera );
 

--- a/example/graphing.js
+++ b/example/graphing.js
@@ -4,6 +4,27 @@ import { GraphMaterial } from '../src/index.js';
 import { shaderGGXFunctions } from '../src/shader/shaderGGXFunctions.js';
 import { shaderUtils } from '../src/shader/shaderUtils.js';
 
+const graphFunctionSnippet = /* glsl */`
+	#include <common>
+	${ shaderUtils }
+	${ shaderGGXFunctions }
+
+	vec4 graphFunction( float x ) {
+
+		vec3 wi = normalize( vec3( 1.0, 1.0, 1.0 ) );
+		vec3 halfVec = vec3( 0.0, 0.0, 1.0 );
+		float theta = dot( wi, halfVec );
+
+		return vec4(
+			ggxPDF( wi, halfVec, x ),
+			ggxDistribution( halfVec, x ),
+			ggxShadowMaskG1( theta, x ),
+			ggxLamda( theta, x )
+		);
+
+	}
+`
+
 let camera, scene, renderer, plane;
 let cameraCenter;
 let zoom = 10;
@@ -53,26 +74,7 @@ async function init() {
 		new GraphMaterial( {
 			side: THREE.DoubleSide,
 			thickness: 1,
-			functionContent: /* glsl */`
-				#include <common>
-				${ shaderUtils }
-				${ shaderGGXFunctions }
-
-				vec4 callback( float x ) {
-
-					vec3 wi = normalize( vec3( 1.0, 1.0, 1.0 ) );
-					vec3 halfVec = vec3( 0.0, 0.0, 1.0 );
-					float theta = dot( wi, halfVec );
-
-					return vec4(
-						ggxPDF( wi, halfVec, x ),
-						ggxDistribution( halfVec, x ),
-						ggxShadowMaskG1( theta, x ),
-						ggxLamda( theta, x )
-					);
-
-				}
-			`
+			graphFunctionSnippet,
 		} )
 	);
 	plane.scale.setScalar( 2.0 );

--- a/example/graphing.js
+++ b/example/graphing.js
@@ -1,0 +1,96 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import GUI from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import { GraphMaterial } from '../src/index.js';
+import { shaderGGXFunctions } from '../src/shader/shaderGGXFunctions.js';
+import { shaderUtils } from '../src/shader/shaderUtils.js';
+
+let camera, scene, renderer, controls;
+
+init();
+
+// init
+async function init() {
+
+	// renderer init
+	renderer = new THREE.WebGLRenderer( { antialias: true } );
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.setClearColor( 0x11161C );
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.outputEncoding = THREE.sRGBEncoding;
+	renderer.setAnimationLoop( animation );
+	document.body.appendChild( renderer.domElement );
+
+	// init camera
+	camera = new THREE.OrthographicCamera();
+	camera.position.set( 0, 0, 1.5 );
+
+	scene = new THREE.Scene();
+
+	// image plane
+	const plane = new THREE.Mesh(
+		new THREE.PlaneGeometry(),
+		new GraphMaterial( {
+			side: THREE.DoubleSide,
+			thickness: 2,
+			xRange: new THREE.Vector2( 0, 1.0 ),
+			yRange: new THREE.Vector2( 0, 5.0 ),
+			functionContent: /* glsl */`
+				#include <common>
+				${ shaderUtils }
+				${ shaderGGXFunctions }
+
+				vec4 callback( float x ) {
+
+					vec3 wi = normalize( vec3( 1.0, 1.0, 1.0 ) );
+					vec3 halfVec = vec3( 0.0, 0.0, 1.0 );
+					float theta = dot( wi, halfVec );
+
+					return vec4(
+						ggxPDF( wi, halfVec, x ),
+						ggxDistribution( halfVec, x ),
+						ggxShadowMaskG1( theta, x ),
+						ggxLamda( theta, x )
+					);
+
+				}
+			`
+		} )
+	);
+	plane.scale.setScalar( 1.75 );
+	scene.add( plane );
+
+
+
+	const gui = new GUI();
+	gui.add( plane.material, 'overlay' );
+	gui.add( plane.material, 'thickness', 1.0, 3.0 );
+	gui.add( plane.material, 'graphCount', 1.0, 4.0, 1.0 );
+
+	const xAxis = gui.addFolder( 'x axis' );
+	xAxis.add( plane.material.xRange, 'x', - 20, 20, 0.25 ).name( 'min' );
+	xAxis.add( plane.material.xRange, 'y', - 20, 20, 0.25 ).name( 'min' );
+
+	const yAxis = gui.addFolder( 'y axis' );
+	yAxis.add( plane.material.yRange, 'x', - 10, 10, 0.25 ).name( 'min' );
+	yAxis.add( plane.material.yRange, 'y', - 10, 10, 0.25 ).name( 'min' );
+
+	controls = new OrbitControls( camera, renderer.domElement );
+	controls.mouseButtons.LEFT = THREE.MOUSE.PAN;
+
+	window.addEventListener( 'resize', () => {
+
+		renderer.setSize( window.innerWidth, window.innerHeight );
+		camera.aspect = window.innerWidth / window.innerHeight;
+		camera.updateProjectionMatrix();
+
+	} );
+
+}
+
+// animation
+function animation() {
+
+	renderer.render( scene, camera );
+
+}

--- a/example/graphing.js
+++ b/example/graphing.js
@@ -23,7 +23,7 @@ const graphFunctionSnippet = /* glsl */`
 		);
 
 	}
-`
+`;
 
 let camera, scene, renderer, plane;
 let cameraCenter;

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,8 @@ export * from './utils/BlurredEnvMapGenerator.js';
 export * from './utils/IESLoader.js';
 
 // materials
-export * from './materials/DenoiseMaterial';
+export * from './materials/DenoiseMaterial.js';
+export * from './materials/GraphMaterial.js';
 export * from './materials/MaterialBase.js';
 export * from './materials/PhysicalPathTracingMaterial.js';
 

--- a/src/materials/GraphMaterial.js
+++ b/src/materials/GraphMaterial.js
@@ -35,6 +35,7 @@ export class GraphMaterial extends MaterialBase {
 
 			uniforms: {
 
+				dim: { value: true },
 				thickness: { value: 1 },
 				graphCount: { value: 4 },
 				overlay: { value: true },
@@ -44,7 +45,7 @@ export class GraphMaterial extends MaterialBase {
 					new Color( 0xe91e63 ).convertSRGBToLinear(),
 					new Color( 0x4caf50 ).convertSRGBToLinear(),
 					new Color( 0x03a9f4 ).convertSRGBToLinear(),
-					new Color( 0x666666 ).convertSRGBToLinear(),
+					new Color( 0xffc107 ).convertSRGBToLinear(),
 				] },
 
 			},
@@ -65,6 +66,7 @@ export class GraphMaterial extends MaterialBase {
 			fragmentShader: /* glsl */`
 				varying vec2 vUv;
 				uniform bool overlay;
+				uniform bool dim;
 				uniform float graphCount;
 				uniform float thickness;
 				uniform vec2 xRange;
@@ -113,8 +115,8 @@ export class GraphMaterial extends MaterialBase {
 					float axisIntensity = 1.0 - min( distToZero.x, distToZero.y );
 					float markerIntensity = 1.0 - min( distToAxis.x, distToAxis.y );
 
-					vec3 markerColor = mix( vec3( 1.0 ), vec3( 0.65 ), markerIntensity );
-					vec3 backgroundColor = mix( markerColor, vec3( 0.25 ), axisIntensity );
+					vec3 markerColor = mix( vec3( 0.005 ), vec3( 0.05 ), markerIntensity );
+					vec3 backgroundColor = mix( markerColor, vec3( 0.2 ), axisIntensity );
 					return backgroundColor;
 
 				}
@@ -152,6 +154,16 @@ export class GraphMaterial extends MaterialBase {
 					// initialize the background
 					gl_FragColor.rgb = getBackground( point, yWidth );
 					gl_FragColor.a = 1.0;
+
+					if ( dim && ( point.x < 0.0 || point.y < 0.0 ) ) {
+
+						graph = mix(
+							vec4( 1.0 ),
+							graph,
+							0.05
+						);
+
+					}
 
 					// color the charts
 					if ( sectionCount > 1.0 ) {

--- a/src/materials/GraphMaterial.js
+++ b/src/materials/GraphMaterial.js
@@ -1,0 +1,221 @@
+import { NoBlending, Color, Vector2 } from 'three';
+import { MaterialBase } from './MaterialBase.js';
+
+export class GraphMaterial extends MaterialBase {
+
+	get functionContent() {
+
+		return this._functionContent;
+
+	}
+
+	set functionContent( v ) {
+
+		this._functionContent = v;
+
+	}
+
+	constructor( parameters ) {
+
+		super( {
+
+			blending: NoBlending,
+
+			transparent: false,
+
+			depthWrite: false,
+
+			depthTest: false,
+
+			defines: {
+
+				USE_SLIDER: 0,
+
+			},
+
+			uniforms: {
+
+				thickness: { value: 1 },
+				graphCount: { value: 4 },
+				overlay: { value: true },
+				xRange: { value: new Vector2( - 2.0, 2.0 ) },
+				yRange: { value: new Vector2( - 2.0, 2.0 ) },
+				colors: { value: [
+					new Color( 0xe91e63 ).convertSRGBToLinear(),
+					new Color( 0x4caf50 ).convertSRGBToLinear(),
+					new Color( 0x03a9f4 ).convertSRGBToLinear(),
+					new Color( 0x666666 ).convertSRGBToLinear(),
+				] },
+
+			},
+
+			vertexShader: /* glsl */`
+
+				varying vec2 vUv;
+
+				void main() {
+
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+				}
+
+			`,
+
+			fragmentShader: /* glsl */`
+				varying vec2 vUv;
+				uniform bool overlay;
+				uniform float graphCount;
+				uniform float thickness;
+				uniform vec2 xRange;
+				uniform vec2 yRange;
+				uniform vec3 colors[ 4 ];
+
+				__FUNCTION_CONTENT__
+
+				float map( float _min, float _max, float v ) {
+
+					float len = _max - _min;
+					return _min + len * v;
+
+				}
+
+				vec3 getBackground( vec2 point, float steepness ) {
+
+					vec2 pw = fwidth( point );
+					vec2 halfWidth = pw * 0.5;
+
+					// x, y axes
+					vec2 distToZero = smoothstep(
+						- halfWidth * 0.5,
+						halfWidth * 0.5,
+						abs( point.xy ) - pw
+					);
+
+					// 1 unit markers
+					vec2 temp;
+					vec2 modAxis = abs( modf( point + vec2( 0.5 ), temp ) ) - 0.5;
+					vec2 distToAxis = smoothstep(
+						- halfWidth,
+						halfWidth,
+						abs( modAxis.xy ) - pw * 0.5
+					);
+
+					// if we're at a chart boundary then remove the artifacts
+					if ( abs( pw.y ) > steepness * 0.5 ) {
+
+						distToZero.y = 1.0;
+						distToAxis.y = 1.0;
+
+					}
+
+					// mix colors into a background color
+					float axisIntensity = 1.0 - min( distToZero.x, distToZero.y );
+					float markerIntensity = 1.0 - min( distToAxis.x, distToAxis.y );
+
+					vec3 markerColor = mix( vec3( 1.0 ), vec3( 0.65 ), markerIntensity );
+					vec3 backgroundColor = mix( markerColor, vec3( 0.25 ), axisIntensity );
+					return backgroundColor;
+
+				}
+
+				void main() {
+
+					// from uniforms
+					float sectionCount = overlay ? 1.0 : graphCount;
+					float yWidth = abs( yRange.y - yRange.x );
+
+					// separate into sections
+					float _section;
+					float sectionY = modf( sectionCount * vUv.y, _section );
+					int section = int( sectionCount - _section - 1.0 );
+
+					// get the current point
+					vec2 point = vec2(
+						map( xRange.x, xRange.y, vUv.x ),
+						map( yRange.x, yRange.y, sectionY )
+					);
+
+					// get the results
+					vec4 result = callback( point.x );
+					vec4 delta = result - vec4( point.y );
+					vec4 halfDdf = fwidth( delta ) * 0.5;
+					if ( fwidth( point.y ) > yWidth * 0.5 ) {
+
+						halfDdf = vec4( 0.0 );
+
+					}
+
+					// graph display intensity
+					vec4 graph = smoothstep( - halfDdf, halfDdf, abs( delta ) - thickness * halfDdf );
+
+					// initialize the background
+					gl_FragColor.rgb = getBackground( point, yWidth );
+					gl_FragColor.a = 1.0;
+
+					// color the charts
+					if ( sectionCount > 1.0 ) {
+
+						gl_FragColor.rgb = mix(
+							colors[ section ],
+							gl_FragColor.rgb,
+							graph[ section ]
+						);
+
+					} else {
+
+						for ( int i = 0; i < int( graphCount ); i ++ ) {
+
+							gl_FragColor.rgb = mix(
+								colors[ i ],
+								gl_FragColor.rgb,
+								graph[ i ]
+							);
+
+						}
+
+					}
+
+					#include <encodings_fragment>
+
+				}
+
+			`
+
+		} );
+
+
+		this._functionContent = /* glsl */`
+			vec4 callback( float x ) {
+
+				return vec4(
+					sin( x * 3.1415926535 ),
+					cos( x ),
+					0.0,
+					0.0
+				);
+
+			}
+		`;
+
+		this.setValues( parameters );
+
+	}
+
+	onBeforeCompile( shader ) {
+
+		shader.fragmentShader = shader.fragmentShader.replace(
+			'__FUNCTION_CONTENT__',
+			this._functionContent,
+		);
+		return shader;
+
+	}
+
+	customProgramCacheKey() {
+
+		return this._functionContent;
+
+	}
+
+}

--- a/src/materials/GraphMaterial.js
+++ b/src/materials/GraphMaterial.js
@@ -3,15 +3,15 @@ import { MaterialBase } from './MaterialBase.js';
 
 export class GraphMaterial extends MaterialBase {
 
-	get functionContent() {
+	get graphFunctionSnippet() {
 
-		return this._functionContent;
+		return this._graphFunctionSnippet;
 
 	}
 
-	set functionContent( v ) {
+	set graphFunctionSnippet( v ) {
 
-		this._functionContent = v;
+		this._graphFunctionSnippet = v;
 
 	}
 
@@ -141,7 +141,7 @@ export class GraphMaterial extends MaterialBase {
 					);
 
 					// get the results
-					vec4 result = callback( point.x );
+					vec4 result = graphFunction( point.x );
 					vec4 delta = result - vec4( point.y );
 					vec4 halfDdf = fwidth( delta ) * 0.5;
 					if ( fwidth( point.y ) > yWidth * 0.5 ) {
@@ -207,8 +207,8 @@ export class GraphMaterial extends MaterialBase {
 		} );
 
 
-		this._functionContent = /* glsl */`
-			vec4 callback( float x ) {
+		this._graphFunctionSnippet = /* glsl */`
+			vec4 graphFunctionSnippet( float x ) {
 
 				return vec4(
 					sin( x * 3.1415926535 ),
@@ -228,7 +228,7 @@ export class GraphMaterial extends MaterialBase {
 
 		shader.fragmentShader = shader.fragmentShader.replace(
 			'__FUNCTION_CONTENT__',
-			this._functionContent,
+			this._graphFunctionSnippet,
 		);
 		return shader;
 
@@ -236,7 +236,7 @@ export class GraphMaterial extends MaterialBase {
 
 	customProgramCacheKey() {
 
-		return this._functionContent;
+		return this._graphFunctionSnippet;
 
 	}
 

--- a/src/materials/GraphMaterial.js
+++ b/src/materials/GraphMaterial.js
@@ -1,4 +1,4 @@
-import { NoBlending, Color, Vector2 } from 'three';
+import { NoBlending, Color, Vector2, Vector4 } from 'three';
 import { MaterialBase } from './MaterialBase.js';
 
 export class GraphMaterial extends MaterialBase {
@@ -38,6 +38,7 @@ export class GraphMaterial extends MaterialBase {
 				dim: { value: true },
 				thickness: { value: 1 },
 				graphCount: { value: 4 },
+				graphDisplay: { value: new Vector4( 1.0, 1.0, 1.0, 1.0 ) },
 				overlay: { value: true },
 				xRange: { value: new Vector2( - 2.0, 2.0 ) },
 				yRange: { value: new Vector2( - 2.0, 2.0 ) },
@@ -67,6 +68,7 @@ export class GraphMaterial extends MaterialBase {
 				varying vec2 vUv;
 				uniform bool overlay;
 				uniform bool dim;
+				uniform bvec4 graphDisplay;
 				uniform float graphCount;
 				uniform float thickness;
 				uniform vec2 xRange;
@@ -168,21 +170,29 @@ export class GraphMaterial extends MaterialBase {
 					// color the charts
 					if ( sectionCount > 1.0 ) {
 
-						gl_FragColor.rgb = mix(
-							colors[ section ],
-							gl_FragColor.rgb,
-							graph[ section ]
-						);
+						if ( graphDisplay[ section ] ) {
+
+							gl_FragColor.rgb = mix(
+								colors[ section ],
+								gl_FragColor.rgb,
+								graph[ section ]
+							);
+
+						}
 
 					} else {
 
 						for ( int i = 0; i < int( graphCount ); i ++ ) {
 
-							gl_FragColor.rgb = mix(
-								colors[ i ],
-								gl_FragColor.rgb,
-								graph[ i ]
-							);
+							if ( graphDisplay[ i ] ) {
+
+								gl_FragColor.rgb = mix(
+									colors[ i ],
+									gl_FragColor.rgb,
+									graph[ i ]
+								);
+
+							}
 
 						}
 


### PR DESCRIPTION
Fix #243 

Adds an example for charting shader function output.

<img width="626" alt="image" src="https://user-images.githubusercontent.com/734200/193436408-4f48c84c-9804-40b1-a46c-7a53152c3e85.png">
