### PR TITLE
Add support for reflecting the background directly

### DIFF
--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -906,7 +906,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								if ( envMaterialPdf > 0.0 && isValidSampleColor ) {
 
 									// determine whether the ray is a shadow ray so we can use this for specular reflection determination
-									bool isShadowRay = specularPdf < 0.1 * rand();
+									bool isShadowRay = specularPdf < rand();
 									if ( i <= 1 && ! isShadowRay ) {
 
 										envColor = sampleBackground( envDirection );

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -906,7 +906,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 								if ( envMaterialPdf > 0.0 && isValidSampleColor ) {
 
 									// determine whether the ray is a shadow ray so we can use this for specular reflection determination
-									bool isShadowRay = specularPdf < 0.5;
+									bool isShadowRay = specularPdf < 0.1 * rand();
 									if ( i <= 1 && ! isShadowRay ) {
 
 										envColor = sampleBackground( envDirection );

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -481,10 +481,10 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 						if ( ! hit ) {
 
-							if ( i == 0 || transmissiveRay ) {
+							if ( i == 0 || transmissiveRay || i == 1 && ! isShadowRay ) {
 
 								gl_FragColor.rgb += sampleBackground( environmentRotation * rayDirection ) * throughputColor;
-								gl_FragColor.a = backgroundAlpha;
+								gl_FragColor.a = i == 1 && ! isShadowRay ? 1.0 : backgroundAlpha;
 
 							} else {
 
@@ -876,6 +876,14 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 							vec3 envColor, envDirection;
 							float envPdf = randomEnvMapSample( envMapInfo, envColor, envDirection );
 							envDirection = invEnvironmentRotation * envDirection;
+
+							// TODO: This shadow ray needs to be determined by whether the _new_ evn-sampled direction is a shadow ray
+							// not the last randomly sampled ray direction
+							if ( i <= 1 && ! isShadowRay ) {
+
+								envColor = sampleBackground( envDirection );
+
+							}
 
 							// this env sampling is not set up for transmissive sampling and yields overly bright
 							// results so we ignore the sample in this case.

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -407,12 +407,10 @@ float bsdfEval( vec3 wo, vec3 clearcoatWo, vec3 wi, vec3 clearcoatWi, SurfaceRec
 
 }
 
-float bsdfResult( vec3 wo, vec3 clearcoatWo, vec3 wi, vec3 clearcoatWi, SurfaceRec surf, out vec3 color ) {
+float bsdfResult( vec3 wo, vec3 clearcoatWo, vec3 wi, vec3 clearcoatWi, SurfaceRec surf, out float specularPdf, out vec3 color ) {
 
 	float[ 4 ] pdf;
 	getLobeWeights( wo, clearcoatWo, surf, pdf );
-
-	float specularPdf;
 	return bsdfEval( wo, clearcoatWo, wi, clearcoatWi, surf, pdf, specularPdf, color );
 
 }


### PR DESCRIPTION
Fix #266

**TODO**
- Might want to provide an individual material for "shadow catcher" or "geom reflection catcher" if we want to support a cut-away floor with transparency.
- ~Specular pdf needs to be handled separately for MIS (#300)~
- For some reason the hot spots are unexpectedly dark 