### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "yargs": "^17.5.1"
   },
   "peerDependencies": {
-    "three": "^0.139.2",
+    "three": ">=0.139.2",
     "xatlas-web": "^0.1.0"
   },
   "scripts": {


### PR DESCRIPTION
Correctly resolve npm dependencies.
Fixes errors during `npm install` in other projects.

UPD:

Reason:
1. Start a new project
2. Npm i three@latest
3. Npm i three-gpu-pathtracer

3rd item will throw error because this project explicitly defines an exact version of threejs in peer dependencies, but at the same time uses almost the latest threejs version.

Solution:
Allow not an exact version of threejs in peer dependencies, but a version greater than N.
That is done in that PR