### PR TITLE
Only traverse visible objects and scenes

### DIFF
--- a/src/core/PathTracingSceneGenerator.js
+++ b/src/core/PathTracingSceneGenerator.js
@@ -13,7 +13,7 @@ export class PathTracingSceneGenerator {
 
 		for ( let i = 0, l = scene.length; i < l; i ++ ) {
 
-			scene[ i ].traverse( c => {
+			scene[ i ].traverseVisible( c => {
 
 				if ( c.isSkinnedMesh || c.isMesh && c.morphTargetInfluences ) {
 


### PR DESCRIPTION
I think it makes sense for a renderer to only traverse visible objects. Although perhaps you also want to traverse lights that aren't marked as visible. In that case, having a parameter like `onlyVisible` on the `generate` function could allow us to configure this.