### PR TITLE
More sampling updates

### DIFF
--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -800,8 +800,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						// frontFace is used to determine transmissive properties and PDF. If no transmission is used
 						// then we can just always assume this is a front face.
 						surfaceRec.frontFace = side == 1.0 || transmission == 0.0;
-						surfaceRec.iorRatio = material.thinFilm || surfaceRec.frontFace ? 1.0 / material.ior : material.ior;
-						surfaceRec.f0 = iorRatioToF0( surfaceRec.iorRatio );
+						surfaceRec.eta = material.thinFilm || surfaceRec.frontFace ? 1.0 / material.ior : material.ior;
+						surfaceRec.f0 = iorRatioToF0( surfaceRec.eta );
 						surfaceRec.thinFilm = material.thinFilm;
 
 						// Compute the filtered roughness value to use during specular reflection computations.

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -801,6 +801,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						// then we can just always assume this is a front face.
 						surfaceRec.frontFace = side == 1.0 || transmission == 0.0;
 						surfaceRec.iorRatio = material.thinFilm || surfaceRec.frontFace ? 1.0 / material.ior : material.ior;
+						surfaceRec.f0 = iorRatioToF0( surfaceRec.iorRatio );
 						surfaceRec.thinFilm = material.thinFilm;
 
 						// Compute the filtered roughness value to use during specular reflection computations.

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -59,9 +59,9 @@ float disneyFresnel( SurfaceRec surf, vec3 wo, vec3 wi, vec3 wh ) {
 	float dotHV = dot( wo, wh );
 	float dotHL = dot( wi, wh );
 
-    float metallicFresnel = schlickFresnel( dotHL, surf.f0 );
-    float dielectricFresnel = dielectricFresnel( abs( dotHV ), surf.eta );
-    return mix( dielectricFresnel, metallicFresnel, surf.metalness );
+	float metallicFresnel = schlickFresnel( dotHL, surf.f0 );
+	float dielectricFresnel = dielectricFresnel( abs( dotHV ), surf.eta );
+	return mix( dielectricFresnel, metallicFresnel, surf.metalness );
 
 }
 
@@ -74,12 +74,12 @@ float diffuseEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, out vec3 color ) 
 	float metalFactor = ( 1.0 - surf.metalness );
 	float transFactor = ( 1.0 - surf.transmission );
 	float rr = 0.5 + 2.0 * surf.roughness * fl * fl;
-    float retro = rr * ( fl + fv + fl * fv * ( rr - 1.0f ) );
+	float retro = rr * ( fl + fv + fl * fv * ( rr - 1.0f ) );
 	float lambert = ( 1.0f - 0.5f * fl ) * ( 1.0f - 0.5f * fv );
 
 	// TODO: subsurface approx?
 
-    color = transFactor * metalFactor * normalize( wi ).z * surf.color * ( retro + lambert ) / PI;
+	color = transFactor * metalFactor * normalize( wi ).z * surf.color * ( retro + lambert ) / PI;
 	return wi.z / PI;
 
 }

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -324,8 +324,6 @@ void getLobeWeights( vec3 wo, vec3 wi, vec3 wh, vec3 clearcoatWo, SurfaceRec sur
 	float metalness = surf.metalness;
 	float transmission = surf.transmission;
 
-	// TODO: we should compute a half vector ahead of time and pass it into the sampling functions
-	// so all functions will use the same half vector
 	float eta = surf.eta;
 	float f0 = surf.f0;
 	float cosTheta = min( wo.z, 1.0 );
@@ -343,6 +341,7 @@ void getLobeWeights( vec3 wo, vec3 wi, vec3 wh, vec3 clearcoatWo, SurfaceRec sur
 	float diffuseLuminance = luminance( surf.color );
 	float specularLuminance = luminance( surf.specularColor );
 
+	// add 0.01 to specular so we don't have a case where the total weight is 0
 	float diffuseWeight = diffuseLuminance * ( 1.0 - transmission ) * ( 1.0 - metalness );
 	float specularWeight = 0.01 + reflectance;
 	float transmissionWeight = transmission * ( 1.0 - metalness );

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -368,6 +368,11 @@ float bsdfEval( vec3 wo, vec3 clearcoatWo, vec3 wi, vec3 clearcoatWi, SurfaceRec
 	float cpdf = 0.0;
 	color = vec3( 0.0 );
 
+	// get the half vector - assuming if the light incident vector is on the other side
+	// of the that it's transmissive. Scale by the ior ratio to retrieve the appropriate half vector
+	// TODO: verify this?
+	vec3 halfVector = getHalfVector( wi, wo, surf.eta );
+
 	// diffuse
 	if ( diffuseWeight > 0.0 && w.z > 0.0 ) {
 

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -343,8 +343,8 @@ void getLobeWeights( vec3 wo, vec3 wi, vec3 wh, vec3 clearcoatWo, SurfaceRec sur
 	float specularLuminance = luminance( surf.specularColor );
 
 	float diffuseWeight = diffuseLuminance * ( 1.0 - transmission ) * ( 1.0 - metalness );
-	float specularWeight = mix( mix( specularLuminance, 1.0, reflectance ), 1.0, metalness );
-	float transmissionWeight = diffuseLuminance * transmission * ( 1.0 - reflectance ) * ( 1.0 - metalness );
+	float specularWeight = 0.01 + reflectance;
+	float transmissionWeight = transmission * ( 1.0 - metalness );
 	float clearcoatWeight = surf.clearcoat * schlickFresnel( clearcoatWo.z, 0.04 );
 
 	float totalWeight = diffuseWeight + specularWeight + transmissionWeight + clearcoatWeight;

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -256,7 +256,7 @@ float clearcoatEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, inout vec3 colo
 	bool frontFace = surf.frontFace;
 	float filteredClearcoatRoughness = surf.filteredClearcoatRoughness;
 
-	float eta =  frontFace ? 1.0 / ior : ior;
+	float eta = frontFace ? 1.0 / ior : ior;
 	float G = ggxShadowMaskG2( wi, wo, filteredClearcoatRoughness );
 	float D = ggxDistribution( wh, filteredClearcoatRoughness );
 	float F = schlickFresnel( dot( wi, wh ), f0 );
@@ -330,7 +330,7 @@ void getLobeWeights( vec3 wo, vec3 wi, vec3 wh, vec3 clearcoatWo, SurfaceRec sur
 	float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
 
 	// TODO: does "cannot refract" belong in disney fresnel?
-	float reflectance =  disneyFresnel( surf, wo, wi, wh );
+	float reflectance = disneyFresnel( surf, wo, wi, wh );
 	bool cannotRefract = eta * sinTheta > 1.0;
 	if ( cannotRefract ) {
 
@@ -338,12 +338,8 @@ void getLobeWeights( vec3 wo, vec3 wi, vec3 wh, vec3 clearcoatWo, SurfaceRec sur
 
 	}
 
-	float diffuseLuminance = luminance( surf.color );
-	float specularLuminance = luminance( surf.specularColor );
-
-	// add 0.01 to specular so we don't have a case where the total weight is 0
-	float diffuseWeight = diffuseLuminance * ( 1.0 - transmission ) * ( 1.0 - metalness );
-	float specularWeight = 0.01 + reflectance;
+	float diffuseWeight = ( 1.0 - transmission ) * ( 1.0 - metalness );
+	float specularWeight = 0.5;
 	float transmissionWeight = transmission * ( 1.0 - metalness );
 	float clearcoatWeight = surf.clearcoat * schlickFresnel( clearcoatWo.z, 0.04 );
 

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -326,7 +326,7 @@ void getLobeWeights( vec3 wo, vec3 wi, vec3 wh, vec3 clearcoatWo, SurfaceRec sur
 
 	// TODO: we should compute a half vector ahead of time and pass it into the sampling functions
 	// so all functions will use the same half vector
-	float eta =  surf.eta;
+	float eta = surf.eta;
 	float f0 = surf.f0;
 	float cosTheta = min( wo.z, 1.0 );
 	float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -26,6 +26,7 @@ struct SurfaceRec {
 	bool thinFilm;
 	float ior;
 	float iorRatio;
+	float f0;
 	float clearcoat;
 	float clearcoatRoughness;
 	float filteredClearcoatRoughness;
@@ -371,10 +372,10 @@ float bsdfEval( vec3 wo, vec3 clearcoatWo, vec3 wi, vec3 clearcoatWi, SurfaceRec
 	// get the half vector - assuming if the light incident vector is on the other side
 	// of the that it's transmissive. Scale by the ior ratio to retrieve the appropriate half vector
 	// TODO: verify this?
-	vec3 halfVector = getHalfVector( wi, wo, surf.eta );
+	vec3 halfVector = getHalfVector( wi, wo, surf.iorRatio );
 
 	// diffuse
-	if ( diffuseWeight > 0.0 && w.z > 0.0 ) {
+	if ( diffuseWeight > 0.0 && wi.z > 0.0 ) {
 
 		dpdf = diffuseEval( wo, wi, surf, color );
 		color *= 1.0 - surf.transmission;
@@ -382,7 +383,7 @@ float bsdfEval( vec3 wo, vec3 clearcoatWo, vec3 wi, vec3 clearcoatWi, SurfaceRec
 	}
 
 	// ggx specular
-	if ( specularWeight > 0.0 && w.z > 0.0 ) {
+	if ( specularWeight > 0.0 && wi.z > 0.0 ) {
 
 		vec3 outColor;
 		spdf = specularEval( wo, wi, surf, outColor );

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -5,6 +5,7 @@ import { shaderIridescenceFunctions } from './shaderIridescenceFunctions.js';
 /*
 wi     : incident vector or light vector (pointing toward the light)
 wo     : outgoing vector or view vector (pointing towards the camera)
+wh     : computed half vector from wo and wi
 Eval   : Get the color and pdf for a direction
 Sample : Get the direction, color, and pdf for a sample
 eta    : Greek character used to denote the "ratio of ior"
@@ -53,10 +54,10 @@ ${ shaderGGXFunctions }
 ${ shaderSheenFunctions }
 ${ shaderIridescenceFunctions }
 
-float disneyFresnel( SurfaceRec surf, vec3 wo, vec3 wi, vec3 halfVector ) {
+float disneyFresnel( SurfaceRec surf, vec3 wo, vec3 wi, vec3 wh ) {
 
-	float dotHV = dot( wo, halfVector );
-	float dotHL = dot( wi, halfVector );
+	float dotHV = dot( wo, wh );
+	float dotHL = dot( wi, wh );
 
     float metallicFresnel = schlickFresnel( dotHL, surf.f0 );
     float dielectricFresnel = dielectricFresnel( abs( dotHV ), surf.eta );
@@ -65,7 +66,7 @@ float disneyFresnel( SurfaceRec surf, vec3 wo, vec3 wi, vec3 halfVector ) {
 }
 
 // diffuse
-float diffuseEval( vec3 wo, vec3 wi, SurfaceRec surf, out vec3 color ) {
+float diffuseEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, out vec3 color ) {
 
 	// TODO: scale by 1 - F here
 	// note on division by PI
@@ -91,19 +92,18 @@ vec3 diffuseDirection( vec3 wo, SurfaceRec surf ) {
 }
 
 // specular
-float specularEval( vec3 wo, vec3 wi, SurfaceRec surf, out vec3 color ) {
+float specularEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, out vec3 color ) {
 
 	// if roughness is set to 0 then D === NaN which results in black pixels
 	float metalness = surf.metalness;
 	float filteredRoughness = surf.filteredRoughness;
 
-	vec3 halfVector = getHalfVector( wo, wi );
 	float eta =  surf.eta;
 	float G = ggxShadowMaskG2( wi, wo, filteredRoughness );
-	float D = ggxDistribution( halfVector, filteredRoughness );
+	float D = ggxDistribution( wh, filteredRoughness );
 
 	float f0 = iorRatioToF0( eta );
-	vec3 F = vec3( schlickFresnel( dot( wi, halfVector ), f0 ) );
+	vec3 F = vec3( schlickFresnel( dot( wi, wh ), f0 ) );
 
 	float cosTheta = min( wo.z, 1.0 );
 	float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
@@ -114,7 +114,7 @@ float specularEval( vec3 wo, vec3 wi, SurfaceRec surf, out vec3 color ) {
 
 	}
 
-	vec3 iridescenceFresnel = evalIridescence( 1.0, surf.iridescenceIor, dot( wi, halfVector ), surf.iridescenceThickness, vec3( f0 ) );
+	vec3 iridescenceFresnel = evalIridescence( 1.0, surf.iridescenceIor, dot( wi, wh ), surf.iridescenceThickness, vec3( f0 ) );
 	vec3 metalF = mix( F, iridescenceFresnel, surf.iridescence );
 	vec3 dialectricF = F * surf.specularIntensity;
 	F = mix( dialectricF, metalF, metalness );
@@ -129,8 +129,8 @@ float specularEval( vec3 wo, vec3 wi, SurfaceRec surf, out vec3 color ) {
 	// See 14.1.1 Microfacet BxDFs in https://www.pbr-book.org/
 	float incidentTheta = acos( wo.z );
 	float G1 = ggxShadowMaskG1( incidentTheta, filteredRoughness );
-	float ggxPdf = D * G1 * max( 0.0, abs( dot( wo, halfVector ) ) ) / abs ( wo.z );
-	return ggxPdf / ( 4.0 * dot( wo, halfVector ) );
+	float ggxPdf = D * G1 * max( 0.0, abs( dot( wo, wh ) ) ) / abs ( wo.z );
+	return ggxPdf / ( 4.0 * dot( wo, wh ) );
 
 }
 
@@ -205,7 +205,7 @@ function transmissionDirection( wo, hit, material, lightDirection ) {
 
 // TODO: This is just using a basic cosine-weighted specular distribution with an
 // incorrect PDF value at the moment. Update it to correctly use a GGX distribution
-float transmissionEval( vec3 wo, vec3 wi, SurfaceRec surf, out vec3 color ) {
+float transmissionEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, out vec3 color ) {
 
 	// only attenuate the color if it's on the way in
 	vec3 col = surf.thinFilm || surf.frontFace ? surf.color : vec3( 1.0 );
@@ -247,19 +247,18 @@ vec3 transmissionDirection( vec3 wo, SurfaceRec surf ) {
 
 
 // clearcoat
-float clearcoatEval( vec3 wo, vec3 wi, SurfaceRec surf, inout vec3 color ) {
+float clearcoatEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, inout vec3 color ) {
 
 	float ior = 1.5;
 	float f0 = iorRatioToF0( ior );
 	bool frontFace = surf.frontFace;
 	float filteredClearcoatRoughness = surf.filteredClearcoatRoughness;
 
-	vec3 halfVector = getHalfVector( wo, wi );
 	float eta =  frontFace ? 1.0 / ior : ior;
 	float G = ggxShadowMaskG2( wi, wo, filteredClearcoatRoughness );
-	float D = ggxDistribution( halfVector, filteredClearcoatRoughness );
+	float D = ggxDistribution( wh, filteredClearcoatRoughness );
 
-	float F = schlickFresnel( dot( wi, halfVector ), f0 );
+	float F = schlickFresnel( dot( wi, wh ), f0 );
 	float cosTheta = min( wo.z, 1.0 );
 	float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
 	bool cannotRefract = eta * sinTheta > 1.0;
@@ -274,7 +273,7 @@ float clearcoatEval( vec3 wo, vec3 wi, SurfaceRec surf, inout vec3 color ) {
 
 	// PDF
 	// See equation (27) in http://jcgt.org/published/0003/02/03/
-	return ggxPDF( wo, halfVector, filteredClearcoatRoughness ) / ( 4.0 * dot( wi, halfVector ) );
+	return ggxPDF( wo, wh, filteredClearcoatRoughness ) / ( 4.0 * dot( wi, wh ) );
 
 }
 
@@ -296,13 +295,11 @@ vec3 clearcoatDirection( vec3 wo, SurfaceRec surf ) {
 }
 
 // sheen
-vec3 sheenColor( vec3 wo, vec3 wi, SurfaceRec surf ) {
-
-	vec3 halfVector = getHalfVector( wo, wi );
+vec3 sheenColor( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf ) {
 
 	float cosThetaO = saturateCos( wo.z );
 	float cosThetaI = saturateCos( wi.z );
-	float cosThetaH = halfVector.z;
+	float cosThetaH = wh.z;
 
 	float D = velvetD( cosThetaH, surf.sheenRoughness );
 	float G = velvetG( cosThetaO, cosThetaI, surf.sheenRoughness );
@@ -384,15 +381,12 @@ float bsdfEval( vec3 wo, vec3 clearcoatWo, vec3 wi, vec3 clearcoatWi, SurfaceRec
 	float cpdf = 0.0;
 	color = vec3( 0.0 );
 
-	// get the half vector - assuming if the light incident vector is on the other side
-	// of the that it's transmissive. Scale by the ior ratio to retrieve the appropriate half vector
-	// TODO: verify this?
 	vec3 halfVector = getHalfVector( wi, wo, surf.eta );
 
 	// diffuse
 	if ( diffuseWeight > 0.0 && wi.z > 0.0 ) {
 
-		dpdf = diffuseEval( wo, wi, surf, color );
+		dpdf = diffuseEval( wo, wi, halfVector, surf, color );
 		color *= 1.0 - surf.transmission;
 
 	}
@@ -401,7 +395,7 @@ float bsdfEval( vec3 wo, vec3 clearcoatWo, vec3 wi, vec3 clearcoatWi, SurfaceRec
 	if ( specularWeight > 0.0 && wi.z > 0.0 ) {
 
 		vec3 outColor;
-		spdf = specularEval( wo, wi, surf, outColor );
+		spdf = specularEval( wo, wi, getHalfVector( wi, wo ), surf, outColor );
 		color += outColor;
 
 	}
@@ -409,18 +403,19 @@ float bsdfEval( vec3 wo, vec3 clearcoatWo, vec3 wi, vec3 clearcoatWi, SurfaceRec
 	// transmission
 	if ( transmissionWeight > 0.0 && wi.z < 0.0 ) {
 
-		tpdf = transmissionEval( wo, wi, surf, color );
+		tpdf = transmissionEval( wo, wi, halfVector, surf, color );
 
 	}
 
 	// sheen
 	color *= sheenAlbedoScaling( wo, wi, surf );
-	color += sheenColor( wo, wi, surf );
+	color += sheenColor( wo, wi, halfVector, surf );
 
 	// clearcoat
 	if ( clearcoatWi.z >= 0.0 && clearcoatWeight > 0.0 ) {
 
-		cpdf = clearcoatEval( clearcoatWo, clearcoatWi, surf, color );
+		vec3 clearcoatHalfVector = getHalfVector( clearcoatWo, clearcoatWi );
+		cpdf = clearcoatEval( clearcoatWo, clearcoatWi, clearcoatHalfVector, surf, color );
 
 	}
 

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -68,16 +68,20 @@ float disneyFresnel( SurfaceRec surf, vec3 wo, vec3 wi, vec3 wh ) {
 // diffuse
 float diffuseEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, out vec3 color ) {
 
-	// TODO: scale by 1 - F here
-	// note on division by PI
-	// https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
-	float metalFactor = ( 1.0 - surf.metalness );
-	color = surf.color * metalFactor * wi.z / PI;
+	// float halfVector = getHalfVector( wo, wi );
+	float fl = schlickFresnel( wi.z, 0.0 );
+	float fv = schlickFresnel( wo.z, 0.0 );
 
-	// PDF
-	// https://raytracing.github.io/books/RayTracingTheRestOfYourLife.html#lightscattering/thescatteringpdf
-	float cosValue = wi.z;
-	return cosValue / PI;
+	float metalFactor = ( 1.0 - surf.metalness );
+	float transFactor = ( 1.0 - surf.transmission );
+	float rr = 0.5 + 2.0 * surf.roughness * fl * fl;
+    float retro = rr * ( fl + fv + fl * fv * ( rr - 1.0f ) );
+	float lambert = ( 1.0f - 0.5f * fl ) * ( 1.0f - 0.5f * fv );
+
+	// TODO: subsurface approx?
+
+    color = transFactor * metalFactor * normalize( wi ).z * surf.color * ( retro + lambert ) / PI;
+	return wi.z / PI;
 
 }
 

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -340,13 +340,13 @@ void getLobeWeights( vec3 wo, vec3 clearcoatWo, SurfaceRec surf, out float[ 4 ] 
 
 	}
 
-	float transSpecularProb = mix( reflectance, 1.0, metalness );
-	float diffSpecularProb = 0.5 + 0.5 * metalness;
+	float diffuseLuminance = luminance( surf.color );
+	float specularLuminance = luminance( surf.specularColor );
 
+	float diffuseWeight = diffuseLuminance * ( 1.0 - transmission ) * ( 1.0 - metalness );
+	float specularWeight = mix( mix( specularLuminance, 1.0, reflectance ), 1.0, metalness );
+	float transmissionWeight = diffuseLuminance * transmission * ( 1.0 - reflectance ) * ( 1.0 - metalness );
 	float clearcoatWeight = surf.clearcoat * schlickFresnel( clearcoatWo.z, 0.04 );
-	float diffuseWeight = ( 1.0 - transmission ) * ( 1.0 - diffSpecularProb ) * ( 1.0 - clearcoatWeight );
-	float specularWeight = transmission * transSpecularProb + ( 1.0 - transmission ) * diffSpecularProb * ( 1.0 - clearcoatWeight );
-	float transmissionWeight = transmission * ( 1.0 - transSpecularProb ) * ( 1.0 - clearcoatWeight );
 
 	float totalWeight = diffuseWeight + specularWeight + transmissionWeight + clearcoatWeight;
 	weights[ DIFF_WEIGHT ] = diffuseWeight / totalWeight;

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -56,6 +56,24 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	vec3 getHalfVector( vec3 wi, vec3 wo, float eta ) {
+
+		vec3 h;
+		if ( wi.z < 0.0 ) {
+
+			h = normalize( wi + wo );
+
+		} else {
+
+			h = normalize( wi + wo * eta );
+
+		}
+
+		h *= sign( h.z );
+		return h;
+
+	}
+
 	vec3 getHalfVector( vec3 a, vec3 b ) {
 
 		return normalize( a + b );

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -39,8 +39,8 @@ export const shaderUtils = /* glsl */`
 
 		float cosThetaT = sqrt( max( 0.0, 1.0f - sinThetaT * sinThetaT ) );
 		float rParallel = ( ( nt * cosThetaI ) - ( ni * cosThetaT ) ) / ( ( nt * cosThetaI ) + ( ni * cosThetaT ) );
-		float rPerpendicuar = ( ( ni * cosThetaI ) - ( nt * cosThetaT ) ) / ( ( ni * cosThetaI ) + ( nt * cosThetaT ) );
-		return ( rParallel * rParallel + rPerpendicuar * rPerpendicuar ) / 2.0;
+		float rPerpendicular = ( ( ni * cosThetaI ) - ( nt * cosThetaT ) ) / ( ( ni * cosThetaI ) + ( nt * cosThetaT ) );
+		return ( rParallel * rParallel + rPerpendicular * rPerpendicular ) / 2.0;
 
 	}
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -52,14 +52,6 @@ export const shaderUtils = /* glsl */`
 
 	}
 
-	float schlickFresnelFromIor( float cosine, float iorRatio ) {
-
-		// Schlick approximation
-		float r_0 = iorRatioToF0( iorRatio );
-		return schlickFresnel( cosine, r_0 );
-
-	}
-
 	// forms a basis with the normal vector as Z
 	mat3 getBasisFromNormal( vec3 normal ) {
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -21,6 +21,29 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	float dielectricFresnel( float cosThetaI, float eta ) {
+
+		// TODO: simplify
+		float ni = eta;
+		float nt = 1.0;
+
+		float sinThetaI = sqrt( 1.0f - cosThetaI * cosThetaI );
+		float sinThetaT = ni / nt * sinThetaI;
+
+		// Check for total internal reflection
+		if( sinThetaT >= 1.0 ) {
+
+			return 1.0;
+
+		}
+
+		float cosThetaT = sqrt( max( 0.0, 1.0f - sinThetaT * sinThetaT ) );
+		float rParallel = ( ( nt * cosThetaI ) - ( ni * cosThetaT ) ) / ( ( nt * cosThetaI ) + ( ni * cosThetaT ) );
+		float rPerpendicuar = ( ( ni * cosThetaI ) - ( nt * cosThetaT ) ) / ( ( ni * cosThetaI ) + ( nt * cosThetaT ) );
+		return ( rParallel * rParallel + rPerpendicuar * rPerpendicuar ) / 2.0;
+
+	}
+
 	// https://raytracing.github.io/books/RayTracingInOneWeekend.html#dielectrics/schlickapproximation
 	float iorRatioToF0( float iorRatio ) {
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -23,7 +23,6 @@ export const shaderUtils = /* glsl */`
 
 	float dielectricFresnel( float cosThetaI, float eta ) {
 
-		// TODO: simplify
 		float ni = eta;
 		float nt = 1.0;
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -27,20 +27,27 @@ export const shaderUtils = /* glsl */`
 		float ni = eta;
 		float nt = 1.0;
 
-		float sinThetaI = sqrt( 1.0f - cosThetaI * cosThetaI );
-		float sinThetaT = ni / nt * sinThetaI;
-
 		// Check for total internal reflection
-		if( sinThetaT >= 1.0 ) {
+		float sinThetaISq = 1.0f - cosThetaI * cosThetaI;
+		float sinThetaTSq = eta * eta * sinThetaISq;
+		if( sinThetaTSq >= 1.0 ) {
 
 			return 1.0;
 
 		}
 
+		float sinThetaT = sqrt( sinThetaTSq );
+
 		float cosThetaT = sqrt( max( 0.0, 1.0f - sinThetaT * sinThetaT ) );
 		float rParallel = ( ( nt * cosThetaI ) - ( ni * cosThetaT ) ) / ( ( nt * cosThetaI ) + ( ni * cosThetaT ) );
 		float rPerpendicular = ( ( ni * cosThetaI ) - ( nt * cosThetaT ) ) / ( ( ni * cosThetaI ) + ( nt * cosThetaT ) );
 		return ( rParallel * rParallel + rPerpendicular * rPerpendicular ) / 2.0;
+
+	}
+
+	luminance( vec3 color ) {
+
+		return dot( color, vec3( 0.2125, 0.7154, 0.0721 ) );
 
 	}
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -73,13 +73,17 @@ export const shaderUtils = /* glsl */`
 
 	vec3 getHalfVector( vec3 wi, vec3 wo, float eta ) {
 
+		// get the half vector - assuming if the light incident vector is on the other side
+		// of the that it's transmissive.
 		vec3 h;
-		if ( wi.z < 0.0 ) {
+		if ( wi.z > 0.0 ) {
 
 			h = normalize( wi + wo );
 
 		} else {
 
+			// Scale by the ior ratio to retrieve the appropriate half vector
+			// TODO: verify this?
 			h = normalize( wi + wo * eta );
 
 		}

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -23,6 +23,7 @@ export const shaderUtils = /* glsl */`
 
 	float dielectricFresnel( float cosThetaI, float eta ) {
 
+		// https://schuttejoe.github.io/post/disneybsdf/
 		float ni = eta;
 		float nt = 1.0;
 
@@ -83,6 +84,7 @@ export const shaderUtils = /* glsl */`
 		} else {
 
 			// Scale by the ior ratio to retrieve the appropriate half vector
+			// TODO: from knightcrawler/glsl-pathtracer
 			// TODO: verify this?
 			h = normalize( wi + wo * eta );
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -45,12 +45,6 @@ export const shaderUtils = /* glsl */`
 
 	}
 
-	luminance( vec3 color ) {
-
-		return dot( color, vec3( 0.2125, 0.7154, 0.0721 ) );
-
-	}
-
 	// https://raytracing.github.io/books/RayTracingInOneWeekend.html#dielectrics/schlickapproximation
 	float iorRatioToF0( float iorRatio ) {
 


### PR DESCRIPTION
**TODO**
- [x] consider changing "iorRatio" to "eta" since that's used in multiple resources
- [x] Use fresnel and spec color to adjust sampling probabilities and weights
- [x] Update fresnel function computation
- [x] ~Determine if diffuse function update is correct / is causing diffuse sparkles~ the new probabilities seem to be causing this
- [ ] Precompute GGX half vector for sampling
- [ ] Verify transmission, specular functions against joe schutte's implementation
- [ ] Improve fresnel function application
- [ ] https://schuttejoe.github.io/post/disneybsdf/
- [ ] https://seblagarde.wordpress.com/2013/04/29/memo-on-fresnel-equations/