### PR TITLE
Use Scrambled Owen Sobol sampling

### DIFF
--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -9,7 +9,7 @@ import { TransformControls } from 'three/examples/jsm/controls/TransformControls
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 
-let renderer, controls, transformControls, transformControlsScene, areaLights, sceneInfo, ptRenderer, camera, fsQuad;
+let renderer, controls, transformControls, transformControlsScene, areaLights, sceneInfo, ptRenderer, camera, fsQuad, enabledLights;
 let samplesEl, loadingEl;
 const params = {
 
@@ -126,7 +126,7 @@ async function init() {
 
 	group.add( scene );
 
-	const floorGeom = new THREE.CylinderBufferGeometry( 3.5, 3.5, 0.05, 60 );
+	const floorGeom = new THREE.CylinderGeometry( 3.5, 3.5, 0.05, 60 );
 	const floorMat = new THREE.MeshPhysicalMaterial( { color: new THREE.Color( 0x999999 ), metalness: 0.2, roughness: 0.02 } );
 	const floor = new THREE.Mesh( floorGeom, floorMat );
 	floor.position.y = - 0.025;
@@ -315,7 +315,7 @@ function updateLights() {
 	areaLights[ 1 ].height = params.areaLight2Height;
 	areaLights[ 1 ].color.set( params.areaLight2Color ).convertSRGBToLinear();
 
-	const enabledLights = [];
+	enabledLights = [];
 	if ( params.areaLight1Enabled ) enabledLights.push( areaLights[ 0 ] );
 	if ( params.areaLight2Enabled ) enabledLights.push( areaLights[ 1 ] );
 
@@ -346,7 +346,7 @@ function animate() {
 	requestAnimationFrame( animate );
 
 	ptRenderer.material.materials.updateFrom( sceneInfo.materials, sceneInfo.textures );
-	ptRenderer.material.lights.updateFrom( areaLights );
+	ptRenderer.material.lights.updateFrom( enabledLights );
 
 	ptRenderer.material.filterGlossyFactor = params.filterGlossyFactor;
 	ptRenderer.material.environmentIntensity = params.environmentIntensity;

--- a/example/index.js
+++ b/example/index.js
@@ -7,7 +7,7 @@ import {
 	DoubleSide,
 	Mesh,
 	MeshStandardMaterial,
-	PlaneBufferGeometry,
+	PlaneGeometry,
 	Group,
 	MeshPhysicalMaterial,
 	WebGLRenderer,
@@ -158,7 +158,7 @@ async function init() {
 
 	const floorTex = generateRadialFloorTexture( 2048 );
 	floorPlane = new Mesh(
-		new PlaneBufferGeometry(),
+		new PlaneGeometry(),
 		new MeshStandardMaterial( {
 			map: floorTex,
 			transparent: true,

--- a/src/core/PathTracingRenderer.js
+++ b/src/core/PathTracingRenderer.js
@@ -1,6 +1,7 @@
 import { RGBAFormat, FloatType, Color, Vector2, WebGLRenderTarget, NoBlending, NormalBlending } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { BlendMaterial } from '../materials/BlendMaterial.js';
+import { SobolNumberMapGenerator } from '../utils/SobolNumberMapGenerator.js';
 
 function* renderTask() {
 
@@ -10,6 +11,7 @@ function* renderTask() {
 		_blendQuad,
 		_primaryTarget,
 		_blendTargets,
+		_sobolTarget,
 		alpha,
 		camera,
 		material,
@@ -36,6 +38,7 @@ function* renderTask() {
 		const w = _primaryTarget.width;
 		const h = _primaryTarget.height;
 		material.resolution.set( w, h );
+		material.sobolTexture = _sobolTarget.texture;
 		material.seed ++;
 
 		const tilesX = this.tiles.x || 1;
@@ -184,6 +187,7 @@ export class PathTracingRenderer {
 		this._task = null;
 		this._currentTile = 0;
 
+		this._sobolTarget = new SobolNumberMapGenerator().generate( renderer );
 		this._primaryTarget = new WebGLRenderTarget( 1, 1, {
 			format: RGBAFormat,
 			type: FloatType,
@@ -215,6 +219,7 @@ export class PathTracingRenderer {
 		this._primaryTarget.dispose();
 		this._blendTargets[ 0 ].dispose();
 		this._blendTargets[ 1 ].dispose();
+		this._sobolTarget.dispose();
 
 		this._fsQuad.dispose();
 		this._blendQuad.dispose();

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -10,6 +10,7 @@ import { RenderTarget2DArray } from '../uniforms/RenderTarget2DArray.js';
 import { shaderMaterialSampling } from '../shader/shaderMaterialSampling.js';
 import { shaderEnvMapSampling } from '../shader/shaderEnvMapSampling.js';
 import { shaderLightSampling } from '../shader/shaderLightSampling.js';
+import { shaderSobolSampling } from '../shader/shaderSobolSampling.js';
 import { shaderUtils } from '../shader/shaderUtils.js';
 import { shaderLayerTexelFetchFunctions } from '../shader/shaderLayerTexelFetchFunctions.js';
 import { PhysicalCameraUniform } from '../uniforms/PhysicalCameraUniform.js';
@@ -102,6 +103,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				vec4 envMapTexelToLinear( vec4 a ) { return a; }
 				#include <common>
 
+				${ shaderSobolSampling }
 				${ shaderStructs }
 				${ shaderIntersectFunction }
 				${ shaderMaterialStructs }

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -196,6 +196,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 					color = vec3( 1.0 );
 
+					// TODO: we should be using sobol sampling here instead of rand but the sobol bounce and path indices need to be incremented
+					// and then reset.
 					for ( int i = 0; i < traversals; i ++ ) {
 
 						if ( bvhIntersectFirstHit( bvh, rayOrigin, rayDirection, faceIndices, faceNormal, barycoord, side, dist ) ) {

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -78,6 +78,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				filterGlossyFactor: { value: 0.0 },
 
 				backgroundAlpha: { value: 1.0 },
+				sobolTexture: { value: null },
 			},
 
 			vertexShader: /* glsl */`

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -357,14 +357,12 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						#if CAMERA_TYPE == 1
 
 							// Orthographic projection
-
 							rayDirection = ( cameraWorldMatrix * vec4( 0.0, 0.0, - 1.0, 0.0 ) ).xyz;
 							rayDirection = normalize( rayDirection );
 
 						#else
 
 							// Perspective projection
-
 							rayDirection = normalize( mat3(cameraWorldMatrix) * ( invProjectionMatrix * vec4( ndc, 0.0, 1.0 ) ).xyz );
 
 						#endif
@@ -381,18 +379,14 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						// if blades === 0 then we assume a circle
 						vec3 shapeUVW = rand3();
 						int blades = physicalCamera.apertureBlades;
+						float anamorphicRatio = physicalCamera.anamorphicRatio;
 						vec2 apertureSample = blades == 0 ? sampleCircle( shapeUVW.xy ) : sampleRegularNGon( blades, shapeUVW );
 						apertureSample *= physicalCamera.bokehSize * 0.5 * 1e-3;
 
 						// rotate the aperture shape
-						float ac = cos( physicalCamera.apertureRotation );
-						float as = sin( physicalCamera.apertureRotation );
-						apertureSample = vec2(
-							apertureSample.x * ac - apertureSample.y * as,
-							apertureSample.x * as + apertureSample.y * ac
-						);
-						apertureSample.x *= saturate( physicalCamera.anamorphicRatio );
-						apertureSample.y *= saturate( 1.0 / physicalCamera.anamorphicRatio );
+						apertureSample =
+							rotateVector( apertureSample, physicalCamera.apertureRotation ) *
+							saturate( vec2( anamorphicRatio, 1.0 / anamorphicRatio ) );
 
 						// create the new ray
 						rayOrigin += ( cameraWorldMatrix * vec4( apertureSample, 0.0, 0.0 ) ).xyz;

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -326,13 +326,14 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 					return rayOrigin4.xyz / rayOrigin4.w;
 				}
 
-				void getCameraRay( vec2 uv, out vec3 rayDirection, out vec3 rayOrigin ) {
+				void getCameraRay( out vec3 rayDirection, out vec3 rayOrigin ) {
 
 					vec2 ssd = vec2( 1.0 ) / resolution;
 
 					// Jitter the camera ray by finding a uv coordinate at a random sample
-					// around this pixel's UV coordinate
-					vec2 jitteredUv = vUv + vec2( tentFilter( uv.x ) * ssd.x, tentFilter( uv.y ) * ssd.y );
+					// around this pixel's UV coordinate for AA
+					vec2 ruv = rand2();
+					vec2 jitteredUv = vUv + vec2( tentFilter( ruv.x ) * ssd.x, tentFilter( ruv.y ) * ssd.y );
 
 					#if CAMERA_TYPE == 2
 
@@ -404,7 +405,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 					vec3 rayDirection;
 					vec3 rayOrigin;
 
-					getCameraRay( rand2(), rayDirection, rayOrigin );
+					getCameraRay( rayDirection, rayOrigin );
 
 					// inverse environment rotation
 					mat3 envRotation3x3 = mat3( environmentRotation );

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -379,9 +379,9 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 						// get the aperture sample
 						// if blades === 0 then we assume a circle
-						vec3 ar = rand3();
+						vec3 shapeUVW = rand3();
 						int blades = physicalCamera.apertureBlades;
-						vec2 apertureSample = blades == 0 ? sampleCircle( ar.xy ) : sampleRegularNGon( blades, ar );
+						vec2 apertureSample = blades == 0 ? sampleCircle( shapeUVW.xy ) : sampleRegularNGon( blades, shapeUVW );
 						apertureSample *= physicalCamera.bokehSize * 0.5 * 1e-3;
 
 						// rotate the aperture shape

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -487,7 +487,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 								// get the PDF of the hit envmap point
 								vec3 envColor;
-								float envPdf = envMapSample( envRotation3x3 * rayDirection, envMapInfo, envColor );
+								float envPdf = sampleEnvMap( envMapInfo, envRotation3x3 * rayDirection, envColor );
 								envPdf /= float( lights.count + 1u );
 
 								// and weight the contribution
@@ -879,7 +879,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							// find a sample in the environment map to include in the contribution
 							vec3 envColor, envDirection;
-							float envPdf = randomEnvMapSample( envMapInfo, envColor, envDirection );
+							float envPdf = sampleEnvMapProbability( envMapInfo, rand2(), envColor, envDirection );
 							envDirection = invEnvRotation3x3 * envDirection;
 
 							// this env sampling is not set up for transmissive sampling and yields overly bright

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -334,7 +334,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 					// Jitter the camera ray by finding a uv coordinate at a random sample
 					// around this pixel's UV coordinate for AA
-					vec2 ruv = sobol2( 0, 1 );
+					vec2 ruv = sobol2( 0 );
 					vec2 jitteredUv = vUv + vec2( tentFilter( ruv.x ) * ssd.x, tentFilter( ruv.y ) * ssd.y );
 
 					#if CAMERA_TYPE == 2
@@ -378,7 +378,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 						// get the aperture sample
 						// if blades === 0 then we assume a circle
-						vec3 shapeUVW= sobol3( 0, 0 );
+						vec3 shapeUVW= sobol3( 1 );
 						int blades = physicalCamera.apertureBlades;
 						float anamorphicRatio = physicalCamera.anamorphicRatio;
 						vec2 apertureSample = blades == 0 ? sampleCircle( shapeUVW.xy ) : sampleRegularNGon( blades, shapeUVW );
@@ -403,8 +403,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				void main() {
 
 					rng_initialize( gl_FragCoord.xy, seed );
-					path_idx = uint( seed );
-					pixel_idx = ( uint( gl_FragCoord.x ) << 16 ) | ( uint( gl_FragCoord.y ) );
+					sobolPixelIndex = ( uint( gl_FragCoord.x ) << 16 ) | ( uint( gl_FragCoord.y ) );
+					sobolPathIndex = uint( seed );
 
 					vec3 rayDirection;
 					vec3 rayOrigin;
@@ -437,6 +437,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 					bool isShadowRay = false;
 
 					for ( i = 0; i < bounces; i ++ ) {
+
+						sobolBounceIndex = uint( i );
 
 						bool hit = bvhIntersectFirstHit( bvh, rayOrigin, rayDirection, faceIndices, faceNormal, barycoord, side, dist );
 

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -269,7 +269,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 							bool useAlphaTest = alphaTest != 0.0;
 							float transmissionFactor = ( 1.0 - metalness ) * transmission;
 							if (
-								transmissionFactor < rand() && ! (
+								transmissionFactor < sobol( 8 ) && ! (
 									// material sidedness
 									material.side != 0.0 && side == material.side
 
@@ -277,7 +277,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 									|| useAlphaTest && albedo.a < alphaTest
 
 									// opacity
-									|| material.transparent && ! useAlphaTest && albedo.a < rand()
+									|| material.transparent && ! useAlphaTest && albedo.a < sobol( 9 )
 								)
 							) {
 
@@ -482,7 +482,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							if ( i == 0 || transmissiveRay ) {
 
-								gl_FragColor.rgb += sampleBackground( envRotation3x3 * rayDirection, rand2() ) * throughputColor;
+								gl_FragColor.rgb += sampleBackground( envRotation3x3 * rayDirection, sobol2( 2 ) ) * throughputColor;
 								gl_FragColor.a = backgroundAlpha;
 
 							} else {
@@ -576,7 +576,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 							|| useAlphaTest && albedo.a < alphaTest
 
 							// opacity
-							|| material.transparent && ! useAlphaTest && albedo.a < rand()
+							|| material.transparent && ! useAlphaTest && albedo.a < sobol( 3 )
 						) {
 
 							vec3 point = rayOrigin + rayDirection * dist;
@@ -828,7 +828,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						vec3 clearcoatOutgoing = - normalize( clearcoatInvBasis * rayDirection );
 						sampleRec = bsdfSample( outgoing, clearcoatOutgoing, normalBasis, invBasis, clearcoatNormalBasis, clearcoatInvBasis, surfaceRec );
 
-						isShadowRay = sampleRec.specularPdf < rand();
+						isShadowRay = sampleRec.specularPdf < sobol( 4 );
 
 						// adjust the hit point by the surface normal by a factor of some offset and the
 						// maximum component-wise value of the current point to accommodate floating point
@@ -845,10 +845,10 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						#if FEATURE_MIS
 
 						// uniformly pick a light or environment map
-						if( rand() > 1.0 / float( lights.count + 1u ) ) {
+						if( sobol( 5 ) > 1.0 / float( lights.count + 1u ) ) {
 
 							// sample a light or environment
-							LightSampleRec lightSampleRec = randomLightSample( lights.tex, iesProfiles, lights.count, rayOrigin, rand3() );
+							LightSampleRec lightSampleRec = randomLightSample( lights.tex, iesProfiles, lights.count, rayOrigin, sobol3( 6 ) );
 
 							bool isSampleBelowSurface = dot( faceNormal, lightSampleRec.direction ) < 0.0;
 							if ( isSampleBelowSurface ) {
@@ -883,7 +883,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							// find a sample in the environment map to include in the contribution
 							vec3 envColor, envDirection;
-							float envPdf = sampleEnvMapProbability( envMapInfo, rand2(), envColor, envDirection );
+							float envPdf = sampleEnvMapProbability( envMapInfo, sobol2( 7 ), envColor, envDirection );
 							envDirection = invEnvRotation3x3 * envDirection;
 
 							// this env sampling is not set up for transmissive sampling and yields overly bright

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -269,7 +269,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 							bool useAlphaTest = alphaTest != 0.0;
 							float transmissionFactor = ( 1.0 - metalness ) * transmission;
 							if (
-								transmissionFactor < sobol( 8 ) && ! (
+								transmissionFactor < rand() && ! (
 									// material sidedness
 									material.side != 0.0 && side == material.side
 
@@ -277,7 +277,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 									|| useAlphaTest && albedo.a < alphaTest
 
 									// opacity
-									|| material.transparent && ! useAlphaTest && albedo.a < sobol( 9 )
+									|| material.transparent && ! useAlphaTest && albedo.a < rand()
 								)
 							) {
 
@@ -576,7 +576,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 							|| useAlphaTest && albedo.a < alphaTest
 
 							// opacity
-							|| material.transparent && ! useAlphaTest && albedo.a < sobol( 3 )
+							|| material.transparent && ! useAlphaTest && albedo.a < rand()
 						) {
 
 							vec3 point = rayOrigin + rayDirection * dist;
@@ -828,7 +828,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						vec3 clearcoatOutgoing = - normalize( clearcoatInvBasis * rayDirection );
 						sampleRec = bsdfSample( outgoing, clearcoatOutgoing, normalBasis, invBasis, clearcoatNormalBasis, clearcoatInvBasis, surfaceRec );
 
-						isShadowRay = sampleRec.specularPdf < sobol( 4 );
+						isShadowRay = sampleRec.specularPdf < rand();
 
 						// adjust the hit point by the surface normal by a factor of some offset and the
 						// maximum component-wise value of the current point to accommodate floating point

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -334,7 +334,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 					// Jitter the camera ray by finding a uv coordinate at a random sample
 					// around this pixel's UV coordinate for AA
-					vec2 ruv = rand2();
+					vec2 ruv = sobol2( 0, 1 );
 					vec2 jitteredUv = vUv + vec2( tentFilter( ruv.x ) * ssd.x, tentFilter( ruv.y ) * ssd.y );
 
 					#if CAMERA_TYPE == 2
@@ -378,7 +378,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 						// get the aperture sample
 						// if blades === 0 then we assume a circle
-						vec3 shapeUVW = rand3();
+						vec3 shapeUVW= sobol3( 0, 0 );
 						int blades = physicalCamera.apertureBlades;
 						float anamorphicRatio = physicalCamera.anamorphicRatio;
 						vec2 apertureSample = blades == 0 ? sampleCircle( shapeUVW.xy ) : sampleRegularNGon( blades, shapeUVW );
@@ -403,6 +403,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				void main() {
 
 					rng_initialize( gl_FragCoord.xy, seed );
+					path_idx = uint( seed );
+					pixel_idx = ( uint( gl_FragCoord.x ) << 16 ) | ( uint( gl_FragCoord.y ) );
 
 					vec3 rayDirection;
 					vec3 rayOrigin;

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -438,7 +438,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 					for ( i = 0; i < bounces; i ++ ) {
 
-						sobolBounceIndex = uint( i );
+						sobolBounceIndex ++;
 
 						bool hit = bvhIntersectFirstHit( bvh, rayOrigin, rayDirection, faceIndices, faceNormal, barycoord, side, dist );
 
@@ -576,7 +576,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 							|| useAlphaTest && albedo.a < alphaTest
 
 							// opacity
-							|| material.transparent && ! useAlphaTest && albedo.a < rand()
+							|| material.transparent && ! useAlphaTest && albedo.a < sobol( 3 )
 						) {
 
 							vec3 point = rayOrigin + rayDirection * dist;
@@ -828,7 +828,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						vec3 clearcoatOutgoing = - normalize( clearcoatInvBasis * rayDirection );
 						sampleRec = bsdfSample( outgoing, clearcoatOutgoing, normalBasis, invBasis, clearcoatNormalBasis, clearcoatInvBasis, surfaceRec );
 
-						isShadowRay = sampleRec.specularPdf < rand();
+						isShadowRay = sampleRec.specularPdf < sobol( 4 );
 
 						// adjust the hit point by the surface normal by a factor of some offset and the
 						// maximum component-wise value of the current point to accommodate floating point

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -841,7 +841,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						if( rand() > 1.0 / float( lights.count + 1u ) ) {
 
 							// sample a light or environment
-							LightSampleRec lightSampleRec = randomLightSample( lights.tex, iesProfiles, lights.count, rayOrigin );
+							LightSampleRec lightSampleRec = randomLightSample( lights.tex, iesProfiles, lights.count, rayOrigin, rand3() );
 
 							bool isSampleBelowSurface = dot( faceNormal, lightSampleRec.direction ) < 0.0;
 							if ( isSampleBelowSurface ) {

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -378,7 +378,11 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						vec3 focalPoint = rayOrigin + normalize( rayDirection ) * physicalCamera.focusDistance;
 
 						// get the aperture sample
-						vec2 apertureSample = sampleAperture( physicalCamera.apertureBlades, rand3() ) * physicalCamera.bokehSize * 0.5 * 1e-3;
+						// if blades === 0 then we assume a circle
+						vec3 ar = rand3();
+						int blades = physicalCamera.apertureBlades;
+						vec2 apertureSample = blades == 0 ? sampleCircle( ar.xy ) : sampleRegularNGon( blades, ar );
+						apertureSample *= physicalCamera.bokehSize * 0.5 * 1e-3;
 
 						// rotate the aperture shape
 						float ac = cos( physicalCamera.apertureRotation );

--- a/src/materials/PhysicalPathTracingMaterial.js
+++ b/src/materials/PhysicalPathTracingMaterial.js
@@ -10,7 +10,7 @@ import { RenderTarget2DArray } from '../uniforms/RenderTarget2DArray.js';
 import { shaderMaterialSampling } from '../shader/shaderMaterialSampling.js';
 import { shaderEnvMapSampling } from '../shader/shaderEnvMapSampling.js';
 import { shaderLightSampling } from '../shader/shaderLightSampling.js';
-import { shaderSobolSampling } from '../shader/shaderSobolSampling.js';
+import { shaderSobolCommon, shaderSobolSampling } from '../shader/shaderSobolSampling.js';
 import { shaderUtils } from '../shader/shaderUtils.js';
 import { shaderLayerTexelFetchFunctions } from '../shader/shaderLayerTexelFetchFunctions.js';
 import { shaderRandFunctions } from '../shader/shaderRandFunctions.js';
@@ -104,8 +104,9 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				vec4 envMapTexelToLinear( vec4 a ) { return a; }
 				#include <common>
 
-				${ shaderSobolSampling }
 				${ shaderRandFunctions }
+				${ shaderSobolCommon }
+				${ shaderSobolSampling }
 				${ shaderStructs }
 				${ shaderIntersectFunction }
 				${ shaderMaterialStructs }

--- a/src/shader/shaderEnvMapSampling.js
+++ b/src/shader/shaderEnvMapSampling.js
@@ -21,7 +21,7 @@ float envMapDirectionPdf( vec3 direction ) {
 
 }
 
-float envMapSample( vec3 direction, EquirectHdrInfo info, out vec3 color ) {
+float sampleEnvMap( EquirectHdrInfo info, vec3 direction, out vec3 color ) {
 
 	vec2 uv = equirectDirectionToUv( direction );
 	color = texture2D( info.map, uv ).rgb;
@@ -35,10 +35,9 @@ float envMapSample( vec3 direction, EquirectHdrInfo info, out vec3 color ) {
 
 }
 
-float randomEnvMapSample( EquirectHdrInfo info, out vec3 color, out vec3 direction ) {
+float sampleEnvMapProbability( EquirectHdrInfo info, vec2 r, out vec3 color, out vec3 direction ) {
 
 	// sample env map cdf
-	vec2 r = rand2();
 	float v = texture2D( info.marginalWeights, vec2( r.x, 0.0 ) ).x;
 	float u = texture2D( info.conditionalWeights, vec2( r.y, v ) ).x;
 	vec2 uv = vec2( u, v );

--- a/src/shader/shaderGGXFunctions.js
+++ b/src/shader/shaderGGXFunctions.js
@@ -8,14 +8,14 @@ export const shaderGGXFunctions = /* glsl */`
 
 // trowbridge-reitz === GGX === GTR
 
-vec3 ggxDirection( vec3 incidentDir, float roughnessX, float roughnessY, float random1, float random2 ) {
+vec3 ggxDirection( vec3 incidentDir, vec2 roughness, vec2 uv ) {
 
 	// TODO: try GGXVNDF implementation from reference [2], here. Needs to update ggxDistribution
 	// function below, as well
 
 	// Implementation from reference [1]
 	// stretch view
-	vec3 V = normalize( vec3( roughnessX * incidentDir.x, roughnessY * incidentDir.y, incidentDir.z ) );
+	vec3 V = normalize( vec3( roughness * incidentDir.xy, incidentDir.z ) );
 
 	// orthonormal basis
 	vec3 T1 = ( V.z < 0.9999 ) ? normalize( cross( V, vec3( 0.0, 0.0, 1.0 ) ) ) : vec3( 1.0, 0.0, 0.0 );
@@ -23,16 +23,16 @@ vec3 ggxDirection( vec3 incidentDir, float roughnessX, float roughnessY, float r
 
 	// sample point with polar coordinates (r, phi)
 	float a = 1.0 / ( 1.0 + V.z );
-	float r = sqrt( random1 );
-	float phi = ( random2 < a ) ? random2 / a * PI : PI + ( random2 - a ) / ( 1.0 - a ) * PI;
+	float r = sqrt( uv.x );
+	float phi = ( uv.y < a ) ? uv.y / a * PI : PI + ( uv.y - a ) / ( 1.0 - a ) * PI;
 	float P1 = r * cos( phi );
-	float P2 = r * sin( phi ) * ( ( random2 < a ) ? 1.0 : V.z );
+	float P2 = r * sin( phi ) * ( ( uv.y < a ) ? 1.0 : V.z );
 
 	// compute normal
 	vec3 N = P1 * T1 + P2 * T2 + V * sqrt( max( 0.0, 1.0 - P1 * P1 - P2 * P2 ) );
 
 	// unstretch
-	N = normalize( vec3( roughnessX * N.x, roughnessY * N.y, max( 0.0, N.z ) ) );
+	N = normalize( vec3( roughness * N.xy, max( 0.0, N.z ) ) );
 
 	return N;
 

--- a/src/shader/shaderLightSampling.js
+++ b/src/shader/shaderLightSampling.js
@@ -133,17 +133,18 @@ LightSampleRec randomAreaLightSample( Light light, vec3 rayOrigin ) {
 
 	lightSampleRec.emission = light.color * light.intensity;
 
+	vec2 ruv = rand2();
 	vec3 randomPos;
 	if( light.type == RECT_AREA_LIGHT_TYPE ) {
 
 		// rectangular area light
-		randomPos = light.position + light.u * ( rand() - 0.5 ) + light.v * ( rand() - 0.5 );
+		randomPos = light.position + light.u * ( ruv.x - 0.5 ) + light.v * ( ruv.y - 0.5 );
 
 	} else if( light.type == 1 ) {
 
 		// circular area light
-		float r = 0.5 * sqrt( rand() );
-		float theta = rand() * 2.0 * PI;
+		float r = 0.5 * sqrt( ruv.x );
+		float theta = ruv.y * 2.0 * PI;
 		float x = r * cos( theta );
 		float y = r * sin( theta );
 
@@ -167,8 +168,9 @@ LightSampleRec randomAreaLightSample( Light light, vec3 rayOrigin ) {
 
 LightSampleRec randomSpotLightSample( Light light, sampler2DArray iesProfiles, vec3 rayOrigin ) {
 
-	float radius = light.radius * sqrt( rand() );
-	float theta = rand() * 2.0 * PI;
+	vec2 ruv = rand2();
+	float radius = light.radius * sqrt( ruv.x );
+	float theta = ruv.y * 2.0 * PI;
 	float x = radius * cos( theta );
 	float y = radius * sin( theta );
 
@@ -212,7 +214,8 @@ LightSampleRec randomSpotLightSample( Light light, sampler2DArray iesProfiles, v
 LightSampleRec randomLightSample( sampler2D lights, sampler2DArray iesProfiles, uint lightCount, vec3 rayOrigin ) {
 
 	// pick a random light
-	uint l = uint( rand() * float( lightCount ) );
+	float r = rand();
+	uint l = uint( r * float( lightCount ) );
 	Light light = readLightInfo( lights, l );
 
 	if ( light.type == SPOT_LIGHT_TYPE ) {

--- a/src/shader/shaderLightSampling.js
+++ b/src/shader/shaderLightSampling.js
@@ -94,7 +94,7 @@ LightSampleRec lightsClosestHit( sampler2D lights, uint lightCount, vec3 rayOrig
 
 }
 
-LightSampleRec randomAreaLightSample( Light light, vec3 rayOrigin ) {
+LightSampleRec randomAreaLightSample( Light light, vec3 rayOrigin, vec2 ruv ) {
 
 	LightSampleRec lightSampleRec;
 	lightSampleRec.hit = true;
@@ -102,7 +102,6 @@ LightSampleRec randomAreaLightSample( Light light, vec3 rayOrigin ) {
 
 	lightSampleRec.emission = light.color * light.intensity;
 
-	vec2 ruv = rand2();
 	vec3 randomPos;
 	if( light.type == RECT_AREA_LIGHT_TYPE ) {
 
@@ -135,9 +134,8 @@ LightSampleRec randomAreaLightSample( Light light, vec3 rayOrigin ) {
 
 }
 
-LightSampleRec randomSpotLightSample( Light light, sampler2DArray iesProfiles, vec3 rayOrigin ) {
+LightSampleRec randomSpotLightSample( Light light, sampler2DArray iesProfiles, vec3 rayOrigin, vec2 ruv ) {
 
-	vec2 ruv = rand2();
 	float radius = light.radius * sqrt( ruv.x );
 	float theta = ruv.y * 2.0 * PI;
 	float x = radius * cos( theta );
@@ -176,21 +174,20 @@ LightSampleRec randomSpotLightSample( Light light, sampler2DArray iesProfiles, v
 
 }
 
-LightSampleRec randomLightSample( sampler2D lights, sampler2DArray iesProfiles, uint lightCount, vec3 rayOrigin ) {
+LightSampleRec randomLightSample( sampler2D lights, sampler2DArray iesProfiles, uint lightCount, vec3 rayOrigin, vec3 ruv ) {
 
 	// pick a random light
-	float r = rand();
-	uint l = uint( r * float( lightCount ) );
+	uint l = uint( ruv.x * float( lightCount ) );
 	Light light = readLightInfo( lights, l );
 
 	if ( light.type == SPOT_LIGHT_TYPE ) {
 
-		return randomSpotLightSample( light, iesProfiles, rayOrigin );
+		return randomSpotLightSample( light, iesProfiles, rayOrigin, ruv.yz );
 
 	} else {
 
 		// sample the light
-		return randomAreaLightSample( light, rayOrigin );
+		return randomAreaLightSample( light, rayOrigin, ruv.yz );
 
 	}
 

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -93,7 +93,7 @@ float diffuseEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, out vec3 color ) 
 
 vec3 diffuseDirection( vec3 wo, SurfaceRec surf ) {
 
-	vec3 lightDirection = randDirection();
+	vec3 lightDirection = sampleSphere( rand2() );
 	lightDirection.z += 1.0;
 	lightDirection = normalize( lightDirection );
 
@@ -226,7 +226,7 @@ vec3 transmissionDirection( vec3 wo, SurfaceRec surf ) {
 
 	float roughness = surf.roughness;
 	float eta = surf.eta;
-	vec3 halfVector = normalize( vec3( 0.0, 0.0, 1.0 ) + randDirection() * roughness );
+	vec3 halfVector = normalize( vec3( 0.0, 0.0, 1.0 ) + sampleSphere( rand2() ) * roughness );
 	vec3 lightDirection = refract( normalize( - wo ), halfVector, eta );
 
 	if ( surf.thinFilm ) {

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -93,7 +93,7 @@ float diffuseEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, out vec3 color ) 
 
 vec3 diffuseDirection( vec3 wo, SurfaceRec surf ) {
 
-	vec3 lightDirection = sampleSphere( rand2() );
+	vec3 lightDirection = sampleSphere( sobol2( 11 ) );
 	lightDirection.z += 1.0;
 	lightDirection = normalize( lightDirection );
 
@@ -148,7 +148,7 @@ vec3 specularDirection( vec3 wo, SurfaceRec surf ) {
 	vec3 halfVector = ggxDirection(
 		wo,
 		vec2( filteredRoughness ),
-		rand2()
+		sobol2( 12 )
 	);
 
 	// apply to new ray by reflecting off the new normal
@@ -186,7 +186,7 @@ vec3 transmissionDirection( vec3 wo, SurfaceRec surf ) {
 	vec3 halfVector = ggxDirection(
 		wo,
 		vec2( filteredRoughness ),
-		rand2()
+		sobol2( 13 )
 	);
 
 
@@ -226,7 +226,7 @@ vec3 transmissionDirection( vec3 wo, SurfaceRec surf ) {
 
 	float roughness = surf.roughness;
 	float eta = surf.eta;
-	vec3 halfVector = normalize( vec3( 0.0, 0.0, 1.0 ) + sampleSphere( rand2() ) * roughness );
+	vec3 halfVector = normalize( vec3( 0.0, 0.0, 1.0 ) + sampleSphere( sobol2( 13 ) ) * roughness );
 	vec3 lightDirection = refract( normalize( - wo ), halfVector, eta );
 
 	if ( surf.thinFilm ) {
@@ -275,7 +275,7 @@ vec3 clearcoatDirection( vec3 wo, SurfaceRec surf ) {
 	vec3 halfVector = ggxDirection(
 		wo,
 		vec2( filteredClearcoatRoughness ),
-		rand2()
+		sobol2( 14 )
 	);
 
 	// apply to new ray by reflecting off the new normal
@@ -464,7 +464,7 @@ SampleRec bsdfSample( vec3 wo, vec3 clearcoatWo, mat3 normalBasis, mat3 invBasis
 	vec3 wi;
 	vec3 clearcoatWi;
 
-	float r = rand();
+	float r = sobol( 15 );
 	if ( r <= cdf[0] ) { // diffuse
 
 		wi = diffuseDirection( wo, surf );

--- a/src/shader/shaderMaterialSampling.js
+++ b/src/shader/shaderMaterialSampling.js
@@ -147,10 +147,8 @@ vec3 specularDirection( vec3 wo, SurfaceRec surf ) {
 	float filteredRoughness = surf.filteredRoughness;
 	vec3 halfVector = ggxDirection(
 		wo,
-		filteredRoughness,
-		filteredRoughness,
-		rand(),
-		rand()
+		vec2( filteredRoughness ),
+		rand2()
 	);
 
 	// apply to new ray by reflecting off the new normal
@@ -187,10 +185,8 @@ vec3 transmissionDirection( vec3 wo, SurfaceRec surf ) {
 	// sample ggx vndf distribution which gives a new normal
 	vec3 halfVector = ggxDirection(
 		wo,
-		filteredRoughness,
-		filteredRoughness,
-		rand(),
-		rand()
+		vec2( filteredRoughness ),
+		rand2()
 	);
 
 
@@ -278,10 +274,8 @@ vec3 clearcoatDirection( vec3 wo, SurfaceRec surf ) {
 	float filteredClearcoatRoughness = surf.filteredClearcoatRoughness;
 	vec3 halfVector = ggxDirection(
 		wo,
-		filteredClearcoatRoughness,
-		filteredClearcoatRoughness,
-		rand(),
-		rand()
+		vec2( filteredClearcoatRoughness ),
+		rand2()
 	);
 
 	// apply to new ray by reflecting off the new normal

--- a/src/shader/shaderRandFunctions.js
+++ b/src/shader/shaderRandFunctions.js
@@ -54,16 +54,4 @@ export const shaderRandFunctions = /* glsl */`
 		return vec4(WHITE_NOISE_SEED)/float(0xffffffffu);
 
 	}
-
-	// https://github.com/mrdoob/three.js/blob/dev/src/math/Vector3.js#L724
-	vec3 randDirection() {
-
-		vec2 r = rand2();
-		float u = ( r.x - 0.5 ) * 2.0;
-		float t = r.y * PI * 2.0;
-		float f = sqrt( 1.0 - u * u );
-
-		return vec3( f * cos( t ), f * sin( t ), u );
-
-	}
 `;

--- a/src/shader/shaderRandFunctions.js
+++ b/src/shader/shaderRandFunctions.js
@@ -51,7 +51,7 @@ export const shaderRandFunctions = /* glsl */`
 	vec4 rand4() {
 
 		pcg4d( WHITE_NOISE_SEED );
-		return vec4(WHITE_NOISE_SEED)/float(0xffffffffu);
+		return vec4( WHITE_NOISE_SEED ) / float( 0xffffffffu );
 
 	}
 `;

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -81,8 +81,8 @@ export const shaderSobolSampling = /* glsl */`
 	}
 
 	vec2 get_sobol_pt(uint index) {
-		uint x = reverse_bits(index) >> 8;
-		uint y = sobol(index) >> 8;
+		uint x = index & 0x00ffffffu;
+    	uint y = reverse_bits(sobol(index)) & 0x00ffffffu;
 
 		float r = float(x) * SOBOL_FACTOR;
 		float g = float(y) * SOBOL_FACTOR;

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -1,0 +1,113 @@
+export const shaderSobolSampling = /* glsl */`
+
+// References
+// - https://jcgt.org/published/0009/04/01/
+// - Code from https://www.shadertoy.com/view/WtGyDm
+
+/*
+ * This first buffer simply computes and store elements of the Sobol (0,2)
+ * sequence. This is a useful optimization for a ray tracer, because it
+ * avoids having to recompute these values for every sample, although it
+ * does cost a texture read.
+ *
+ * Code is mostly taken and adapted from the supplementary material
+ * for Practical Hash-Based Owen Scrambling (Burley, 2020):
+ *     http://www.jcgt.org/published/0009/04/01/
+ */
+
+const float SOBOL_FACTOR = 1.0 / 16777216.0;
+const uint SOBOL_DIRECTIONS[32] = uint[32](
+      0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
+      0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
+      0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
+      0x88880000u, 0xcccc0000u, 0xaaaa0000u, 0xffff0000u,
+      0x80008000u, 0xc000c000u, 0xa000a000u, 0xf000f000u,
+      0x88008800u, 0xcc00cc00u, 0xaa00aa00u, 0xff00ff00u,
+      0x80808080u, 0xc0c0c0c0u, 0xa0a0a0a0u, 0xf0f0f0f0u,
+      0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
+);
+
+uint reverse_bits(uint x) {
+    x = (((x & 0xaaaaaaaau) >> 1) | ((x & 0x55555555u) << 1));
+    x = (((x & 0xccccccccu) >> 2) | ((x & 0x33333333u) << 2));
+    x = (((x & 0xf0f0f0f0u) >> 4) | ((x & 0x0f0f0f0fu) << 4));
+    x = (((x & 0xff00ff00u) >> 8) | ((x & 0x00ff00ffu) << 8));
+    return ((x >> 16) | (x << 16));
+}
+
+uint sobol(uint index) {
+      uint X = 0u;
+      for (int bit = 0; bit < 32; bit++) {
+        uint mask = (index >> bit) & 1u;
+        X ^= mask * SOBOL_DIRECTIONS[bit];
+      }
+      return X;
+}
+
+vec2 sobolPoint(uint index) {
+	uint x = reverse_bits(index) >> 8;
+    uint y = sobol(index) >> 8;
+
+    float r = float(x) * SOBOL_FACTOR;
+    float g = float(y) * SOBOL_FACTOR;
+	return vec2( r, g );
+}
+
+
+
+
+/*
+ * Forked from https://www.shadertoy.com/view/4lfcDr. Adapted to use Owen
+ * scrambled and shuffled Sobol (0,2) sequences.
+ */
+
+uint pixel_idx;
+uint path_idx;
+
+
+vec2 get_sobol_pt(uint index) {
+  uint y = index / uint(iChannelResolution[0].x);
+  uint x = index - (y * uint(iChannelResolution[0].x));
+  vec2 uv = vec2(x, y) / iChannelResolution[0].xy;
+  return texture(iChannel0, uv).rg;
+}
+
+uint get_seed(uint bounce, uint effect) {
+    return hash(hash_combine(hash_combine(hash(bounce), pixel_idx), effect));
+}
+
+vec2 get_shuffled_scrambled_sobol_pt(uint index, uint seed) {
+  uint shuffle_seed = hash_combine(seed, 0u);
+  uint x_seed = hash_combine(seed, 1u);
+  uint y_seed = hash_combine(seed, 2u);
+
+  uint shuffled_index =
+      nested_uniform_scramble_base2(reverse_bits(index), shuffle_seed)
+      % uint(num_points);
+
+  vec2 sobol_pt = get_sobol_pt(shuffled_index);
+  uint x = uint(sobol_pt.x * 16777216.0);
+  uint y = uint(sobol_pt.y * 16777216.0);
+  x = nested_uniform_scramble_base2(x, x_seed);
+  y = nested_uniform_scramble_base2(y, y_seed);
+  return vec2(float(x >> 8) * SOBOL_FACTOR, float(y >> 8) * SOBOL_FACTOR);
+}
+
+vec2 get_pt(int bounce, int effect) {
+  return get_shuffled_scrambled_sobol_pt(
+      uint(path_idx),
+      get_seed(uint(bounce), uint(effect)));
+}
+
+
+
+
+
+
+
+
+
+
+
+
+`;

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -4,18 +4,7 @@ export const shaderSobolSampling = /* glsl */`
 // - https://jcgt.org/published/0009/04/01/
 // - Code from https://www.shadertoy.com/view/WtGyDm
 
-const float SOBOL_FACTOR = 1.0 / 16777216.0;
-const uint SOBOL_DIRECTIONS[32] = uint[32](
-	0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
-	0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
-	0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
-	0x88880000u, 0xcccc0000u, 0xaaaa0000u, 0xffff0000u,
-	0x80008000u, 0xc000c000u, 0xa000a000u, 0xf000f000u,
-	0x88008800u, 0xcc00cc00u, 0xaa00aa00u, 0xff00ff00u,
-	0x80808080u, 0xc0c0c0c0u, 0xa0a0a0a0u, 0xf0f0f0f0u,
-	0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
-);
-
+// Utils
 uint reverse_bits(uint x) {
 	x = (((x & 0xaaaaaaaau) >> 1) | ((x & 0x55555555u) << 1));
 	x = (((x & 0xccccccccu) >> 2) | ((x & 0x33333333u) << 2));
@@ -53,6 +42,35 @@ uint nested_uniform_scramble_base2(uint x, uint seed) {
 	return x;
 }
 
+// Seeds
+uint pixel_idx;
+uint path_idx;
+
+uint get_seed(uint bounce, uint effect) {
+	return hash(
+		hash_combine(
+			hash_combine(
+				hash(bounce),
+				pixel_idx
+			),
+			effect
+		)
+	);
+}
+
+// Sampling
+const float SOBOL_FACTOR = 1.0 / 16777216.0;
+const uint SOBOL_DIRECTIONS[32] = uint[32](
+	0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
+	0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
+	0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
+	0x88880000u, 0xcccc0000u, 0xaaaa0000u, 0xffff0000u,
+	0x80008000u, 0xc000c000u, 0xa000a000u, 0xf000f000u,
+	0x88008800u, 0xcc00cc00u, 0xaa00aa00u, 0xff00ff00u,
+	0x80808080u, 0xc0c0c0c0u, 0xa0a0a0a0u, 0xf0f0f0f0u,
+	0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
+);
+
 uint sobol(uint index) {
 	uint X = 0u;
 	for (int bit = 0; bit < 32; bit++) {
@@ -69,21 +87,6 @@ vec2 get_sobol_pt(uint index) {
 	float r = float(x) * SOBOL_FACTOR;
 	float g = float(y) * SOBOL_FACTOR;
 	return vec2( r, g );
-}
-
-uint pixel_idx;
-uint path_idx;
-
-uint get_seed(uint bounce, uint effect) {
-	return hash(
-		hash_combine(
-			hash_combine(
-				hash(bounce),
-				pixel_idx
-			),
-			effect
-		)
-	);
 }
 
 vec2 get_shuffled_scrambled_sobol_pt(uint index, uint seed) {

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -73,9 +73,21 @@ vec2 get_sobol_pt(uint index) {
 
 uint pixel_idx;
 uint path_idx;
+uint seed_idx;
 
 uint get_seed(uint bounce, uint effect) {
-	return hash(hash_combine(hash_combine(hash(bounce), pixel_idx), effect));
+	return hash(
+		hash_combine(
+			hash_combine(
+				hash_combine(
+					hash(bounce),
+					pixel_idx
+				),
+				effect
+			),
+			seed_idx
+		)
+	);
 }
 
 vec2 get_shuffled_scrambled_sobol_pt(uint index, uint seed) {

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -5,19 +5,24 @@ export const shaderSobolSampling = /* glsl */`
 	// - Code from https://www.shadertoy.com/view/WtGyDm
 
 	// Utils
-	uint reverse_bits(uint x) {
-		x = (((x & 0xaaaaaaaau) >> 1) | ((x & 0x55555555u) << 1));
-		x = (((x & 0xccccccccu) >> 2) | ((x & 0x33333333u) << 2));
-		x = (((x & 0xf0f0f0f0u) >> 4) | ((x & 0x0f0f0f0fu) << 4));
-		x = (((x & 0xff00ff00u) >> 8) | ((x & 0x00ff00ffu) << 8));
-		return ((x >> 16) | (x << 16));
+	uint reverse_bits( uint x ) {
+
+		x = ( ( ( x & 0xaaaaaaaau ) >> 1 ) | ( ( x & 0x55555555u ) << 1 ) );
+		x = ( ( ( x & 0xccccccccu ) >> 2 ) | ( ( x & 0x33333333u ) << 2 ) );
+		x = ( ( ( x & 0xf0f0f0f0u ) >> 4 ) | ( ( x & 0x0f0f0f0fu ) << 4 ) );
+		x = ( ( ( x & 0xff00ff00u ) >> 8 ) | ( ( x & 0x00ff00ffu ) << 8 ) );
+		return ( ( x >> 16 ) | ( x << 16 ) );
+
 	}
 
-	uint hash_combine(uint seed, uint v) {
-		return seed ^ (v + (seed << 6) + (seed >> 2));
+	uint hash_combine( uint seed, uint v ) {
+
+		return seed ^ ( v + ( seed << 6 ) + ( seed >> 2 ) );
+
 	}
 
-	uint hash(uint x) {
+	uint hash( uint x ) {
+
 		// finalizer from murmurhash3
 		x ^= x >> 16;
 		x *= 0x85ebca6bu;
@@ -25,42 +30,49 @@ export const shaderSobolSampling = /* glsl */`
 		x *= 0xc2b2ae35u;
 		x ^= x >> 16;
 		return x;
+
 	}
 
-	uint laine_karras_permutation(uint x, uint seed) {
+	uint laine_karras_permutation( uint x, uint seed ) {
+
 		x += seed;
 		x ^= x * 0x6c50b47cu;
 		x ^= x * 0xb82f1e52u;
 		x ^= x * 0xc7afe638u;
 		x ^= x * 0x8d22f6e6u;
 		return x;
+
 	}
 
-	uint nested_uniform_scramble_base2(uint x, uint seed) {
-		x = laine_karras_permutation(x, seed);
-		x = reverse_bits(x);
+	uint nested_uniform_scramble_base2( uint x, uint seed ) {
+
+		x = laine_karras_permutation( x, seed );
+		x = reverse_bits( x );
 		return x;
+
 	}
 
 	// Seeds
 	uint pixel_idx;
 	uint path_idx;
 
-	uint get_seed(uint bounce, uint effect) {
+	uint get_seed( uint bounce, uint effect ) {
+
 		return hash(
 			hash_combine(
 				hash_combine(
-					hash(bounce),
+					hash( bounce ),
 					pixel_idx
 				),
 				effect
 			)
 		);
+
 	}
 
 	// Sampling
 	const float SOBOL_FACTOR = 1.0 / 16777216.0;
-	const uint SOBOL_DIRECTIONS[32] = uint[32](
+	const uint SOBOL_DIRECTIONS[ 32 ] = uint[ 32 ](
 		0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
 		0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
 		0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
@@ -71,45 +83,54 @@ export const shaderSobolSampling = /* glsl */`
 		0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
 	);
 
-	uint sobol(uint index) {
+	uint sobol( uint index ) {
+
 		uint X = 0u;
-		for (int bit = 0; bit < 32; bit++) {
-			uint mask = (index >> bit) & 1u;
-			X ^= mask * SOBOL_DIRECTIONS[bit];
+		for ( int bit = 0; bit < 32; bit ++ ) {
+
+			uint mask = ( index >> bit ) & 1u;
+			X ^= mask * SOBOL_DIRECTIONS[ bit ];
+
 		}
 		return X;
+
 	}
 
-	vec2 get_sobol_pt(uint index) {
+	vec2 get_sobol_pt( uint index ) {
+
 		uint x = index & 0x00ffffffu;
-    	uint y = reverse_bits(sobol(index)) & 0x00ffffffu;
+    	uint y = reverse_bits( sobol( index ) ) & 0x00ffffffu;
 
-		float r = float(x) * SOBOL_FACTOR;
-		float g = float(y) * SOBOL_FACTOR;
+		float r = float( x ) * SOBOL_FACTOR;
+		float g = float( y ) * SOBOL_FACTOR;
 		return vec2( r, g );
+
 	}
 
-	vec2 get_shuffled_scrambled_sobol_pt(uint index, uint seed) {
-		uint shuffle_seed = hash_combine(seed, 0u);
-		uint x_seed = hash_combine(seed, 1u);
-		uint y_seed = hash_combine(seed, 2u);
+	vec2 get_shuffled_scrambled_sobol_pt( uint index, uint seed ) {
+
+		uint shuffle_seed = hash_combine( seed, 0u );
+		uint x_seed = hash_combine( seed, 1u );
+		uint y_seed = hash_combine( seed, 2u );
 
 		// TODO: modulus is required if we pre compute a limited number of points
-		uint shuffled_index = nested_uniform_scramble_base2(reverse_bits(index), shuffle_seed);
+		uint shuffled_index = nested_uniform_scramble_base2( reverse_bits( index ), shuffle_seed );
 		// shuffled_index = shuffled_index % uint(num_points);
 
-		vec2 sobol_pt = get_sobol_pt(shuffled_index);
-		uint x = uint(sobol_pt.x * 16777216.0);
-		uint y = uint(sobol_pt.y * 16777216.0);
-		x = nested_uniform_scramble_base2(x, x_seed);
-		y = nested_uniform_scramble_base2(y, y_seed);
-		return vec2(float(x >> 8) * SOBOL_FACTOR, float(y >> 8) * SOBOL_FACTOR);
+		vec2 sobol_pt = get_sobol_pt( shuffled_index );
+		uint x = uint( sobol_pt.x * 16777216.0 );
+		uint y = uint( sobol_pt.y * 16777216.0 );
+		x = nested_uniform_scramble_base2( x, x_seed );
+		y = nested_uniform_scramble_base2( y, y_seed );
+		return vec2( float( x >> 8 ) * SOBOL_FACTOR, float( y >> 8 ) * SOBOL_FACTOR );
+
 	}
 
-	vec2 get_pt(int bounce, int effect) {
-		return get_shuffled_scrambled_sobol_pt(
-			uint(path_idx),
-			get_seed(uint(bounce), uint(effect)));
+	vec2 get_pt( int bounce, int effect ) {
+
+		uint seed = get_seed( uint( bounce ), uint( effect ) );
+		return get_shuffled_scrambled_sobol_pt( path_idx, seed );
+
 	}
 
 `;

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -73,19 +73,15 @@ vec2 get_sobol_pt(uint index) {
 
 uint pixel_idx;
 uint path_idx;
-uint seed_idx;
 
 uint get_seed(uint bounce, uint effect) {
 	return hash(
 		hash_combine(
 			hash_combine(
-				hash_combine(
-					hash(bounce),
-					pixel_idx
-				),
-				effect
+				hash(bounce),
+				pixel_idx
 			),
-			seed_idx
+			effect
 		)
 	);
 }

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -5,6 +5,7 @@ export const shaderSobolCommon = /* glsl */`
 
 	// Utils
 	const float SOBOL_FACTOR = 1.0 / 16777216.0;
+	const uint SOBOL_MAX_POINTS = 256u * 256u;
 
 	uint reverse_bits( uint x ) {
 
@@ -116,7 +117,11 @@ export const shaderSobolGeneration = /* glsl */`
 
 	vec4 generateSobolPoint( uint index ) {
 
-		if ( int( index ) > num_points ) return vec4( 0.0 );
+		if ( index >= SOBOL_MAX_POINTS ) {
+
+			return vec4( 0.0 );
+
+		}
 
 		// uint x = index & 0x00ffffffu;
 		uint x = reverse_bits( sobolHash( index, SOBOL_DIRECTIONS1 ) ) & 0x00ffffffu;
@@ -133,6 +138,7 @@ export const shaderSobolGeneration = /* glsl */`
 export const shaderSobolSampling = /* glsl */`
 
 	// Seeds
+	uniform sampler2D sobolTexture;
 	uint pixel_idx;
 	uint path_idx;
 
@@ -150,39 +156,19 @@ export const shaderSobolSampling = /* glsl */`
 
 	}
 
-	// Sampling
-	const uint SOBOL_DIRECTIONS[ 32 ] = uint[ 32 ](
-		0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
-		0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
-		0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
-		0x88880000u, 0xcccc0000u, 0xaaaa0000u, 0xffff0000u,
-		0x80008000u, 0xc000c000u, 0xa000a000u, 0xf000f000u,
-		0x88008800u, 0xcc00cc00u, 0xaa00aa00u, 0xff00ff00u,
-		0x80808080u, 0xc0c0c0c0u, 0xa0a0a0a0u, 0xf0f0f0f0u,
-		0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
-	);
-
-	uint sobol( uint index ) {
-
-		uint X = 0u;
-		for ( int bit = 0; bit < 32; bit ++ ) {
-
-			uint mask = ( index >> bit ) & 1u;
-			X ^= mask * SOBOL_DIRECTIONS[ bit ];
-
-		}
-		return X;
-
-	}
-
 	vec2 get_sobol_pt( uint index ) {
 
-		uint x = index & 0x00ffffffu;
-    	uint y = reverse_bits( sobol( index ) ) & 0x00ffffffu;
+		if ( index >= SOBOL_MAX_POINTS ) {
 
-		float r = float( x ) * SOBOL_FACTOR;
-		float g = float( y ) * SOBOL_FACTOR;
-		return vec2( r, g );
+			index = index % SOBOL_MAX_POINTS;
+
+		}
+
+		uvec2 dim = uvec2( textureSize( sobolTexture, 0 ).xy );
+		uint y = index / dim.x;
+		uint x = index - y * dim.x;
+		vec2 uv = vec2( x, y ) / vec2( dim );
+		return texture( sobolTexture, uv ).rg;
 
 	}
 
@@ -192,10 +178,7 @@ export const shaderSobolSampling = /* glsl */`
 		uint x_seed = hash_combine( seed, 1u );
 		uint y_seed = hash_combine( seed, 2u );
 
-		// TODO: modulus is required if we pre compute a limited number of points
 		uint shuffled_index = nested_uniform_scramble_base2( reverse_bits( index ), shuffle_seed );
-		// shuffled_index = shuffled_index % uint(num_points);
-
 		vec2 sobol_pt = get_sobol_pt( shuffled_index );
 		uint x = uint( sobol_pt.x * 16777216.0 );
 		uint y = uint( sobol_pt.y * 16777216.0 );

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -116,7 +116,7 @@ export const shaderSobolCommon = /* glsl */`
 	${ generateSobolFunctionVariants( 3 ) }
 	${ generateSobolFunctionVariants( 4 ) }
 
-	uint hash( uint x ) {
+	uint sobolHash( uint x ) {
 
 		// finalizer from murmurhash3
 		x ^= x >> 16;
@@ -219,10 +219,10 @@ export const shaderSobolSampling = /* glsl */`
 
 	uint sobolGetSeed( uint bounce, uint effect ) {
 
-		return hash(
+		return sobolHash(
 			sobolHashCombine(
 				sobolHashCombine(
-					hash( bounce ),
+					sobolHash( bounce ),
 					pixel_idx
 				),
 				effect

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -85,10 +85,10 @@ function generateSobolSampleFunctions( dim = 1 ) {
 
 	return /* glsl */`
 
-		${ vtype } sobol${ num }( int bounce, int effect ) {
+		${ vtype } sobol${ num }( int effect ) {
 
-			uint seed = sobolGetSeed( uint( bounce ), uint( effect ) );
-			uint index = path_idx;
+			uint seed = sobolGetSeed( sobolBounceIndex, uint( effect ) );
+			uint index = sobolPathIndex;
 
 			uint shuffle_seed = sobolHashCombine( seed, 0u );
 			uint shuffled_index = nestedUniformScrambleBase2( sobolReverseBits( index ), shuffle_seed );
@@ -214,8 +214,9 @@ export const shaderSobolSampling = /* glsl */`
 
 	// Seeds
 	uniform sampler2D sobolTexture;
-	uint pixel_idx;
-	uint path_idx;
+	uint sobolPixelIndex;
+	uint sobolPathIndex;
+	uint sobolBounceIndex;
 
 	uint sobolGetSeed( uint bounce, uint effect ) {
 
@@ -223,7 +224,7 @@ export const shaderSobolSampling = /* glsl */`
 			sobolHashCombine(
 				sobolHashCombine(
 					sobolHash( bounce ),
-					pixel_idx
+					sobolPixelIndex
 				),
 				effect
 			)

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -4,99 +4,101 @@ export const shaderSobolSampling = /* glsl */`
 // - https://jcgt.org/published/0009/04/01/
 // - Code from https://www.shadertoy.com/view/WtGyDm
 
-/*
- * This first buffer simply computes and store elements of the Sobol (0,2)
- * sequence. This is a useful optimization for a ray tracer, because it
- * avoids having to recompute these values for every sample, although it
- * does cost a texture read.
- *
- * Code is mostly taken and adapted from the supplementary material
- * for Practical Hash-Based Owen Scrambling (Burley, 2020):
- *     http://www.jcgt.org/published/0009/04/01/
- */
-
 const float SOBOL_FACTOR = 1.0 / 16777216.0;
 const uint SOBOL_DIRECTIONS[32] = uint[32](
-      0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
-      0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
-      0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
-      0x88880000u, 0xcccc0000u, 0xaaaa0000u, 0xffff0000u,
-      0x80008000u, 0xc000c000u, 0xa000a000u, 0xf000f000u,
-      0x88008800u, 0xcc00cc00u, 0xaa00aa00u, 0xff00ff00u,
-      0x80808080u, 0xc0c0c0c0u, 0xa0a0a0a0u, 0xf0f0f0f0u,
-      0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
+	0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
+	0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
+	0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
+	0x88880000u, 0xcccc0000u, 0xaaaa0000u, 0xffff0000u,
+	0x80008000u, 0xc000c000u, 0xa000a000u, 0xf000f000u,
+	0x88008800u, 0xcc00cc00u, 0xaa00aa00u, 0xff00ff00u,
+	0x80808080u, 0xc0c0c0c0u, 0xa0a0a0a0u, 0xf0f0f0f0u,
+	0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
 );
 
 uint reverse_bits(uint x) {
-    x = (((x & 0xaaaaaaaau) >> 1) | ((x & 0x55555555u) << 1));
-    x = (((x & 0xccccccccu) >> 2) | ((x & 0x33333333u) << 2));
-    x = (((x & 0xf0f0f0f0u) >> 4) | ((x & 0x0f0f0f0fu) << 4));
-    x = (((x & 0xff00ff00u) >> 8) | ((x & 0x00ff00ffu) << 8));
-    return ((x >> 16) | (x << 16));
+	x = (((x & 0xaaaaaaaau) >> 1) | ((x & 0x55555555u) << 1));
+	x = (((x & 0xccccccccu) >> 2) | ((x & 0x33333333u) << 2));
+	x = (((x & 0xf0f0f0f0u) >> 4) | ((x & 0x0f0f0f0fu) << 4));
+	x = (((x & 0xff00ff00u) >> 8) | ((x & 0x00ff00ffu) << 8));
+	return ((x >> 16) | (x << 16));
+}
+
+uint hash_combine(uint seed, uint v) {
+	return seed ^ (v + (seed << 6) + (seed >> 2));
+}
+
+uint hash(uint x) {
+	// finalizer from murmurhash3
+	x ^= x >> 16;
+	x *= 0x85ebca6bu;
+	x ^= x >> 13;
+	x *= 0xc2b2ae35u;
+	x ^= x >> 16;
+	return x;
+}
+
+uint laine_karras_permutation(uint x, uint seed) {
+	x += seed;
+	x ^= x * 0x6c50b47cu;
+	x ^= x * 0xb82f1e52u;
+	x ^= x * 0xc7afe638u;
+	x ^= x * 0x8d22f6e6u;
+	return x;
+}
+
+uint nested_uniform_scramble_base2(uint x, uint seed) {
+	x = laine_karras_permutation(x, seed);
+	x = reverse_bits(x);
+	return x;
 }
 
 uint sobol(uint index) {
-      uint X = 0u;
-      for (int bit = 0; bit < 32; bit++) {
-        uint mask = (index >> bit) & 1u;
-        X ^= mask * SOBOL_DIRECTIONS[bit];
-      }
-      return X;
+	uint X = 0u;
+	for (int bit = 0; bit < 32; bit++) {
+		uint mask = (index >> bit) & 1u;
+		X ^= mask * SOBOL_DIRECTIONS[bit];
+	}
+	return X;
 }
 
-vec2 sobolPoint(uint index) {
+vec2 get_sobol_pt(uint index) {
 	uint x = reverse_bits(index) >> 8;
-    uint y = sobol(index) >> 8;
+	uint y = sobol(index) >> 8;
 
-    float r = float(x) * SOBOL_FACTOR;
-    float g = float(y) * SOBOL_FACTOR;
+	float r = float(x) * SOBOL_FACTOR;
+	float g = float(y) * SOBOL_FACTOR;
 	return vec2( r, g );
 }
-
-
-
-
-/*
- * Forked from https://www.shadertoy.com/view/4lfcDr. Adapted to use Owen
- * scrambled and shuffled Sobol (0,2) sequences.
- */
 
 uint pixel_idx;
 uint path_idx;
 
-
-vec2 get_sobol_pt(uint index) {
-  uint y = index / uint(iChannelResolution[0].x);
-  uint x = index - (y * uint(iChannelResolution[0].x));
-  vec2 uv = vec2(x, y) / iChannelResolution[0].xy;
-  return texture(iChannel0, uv).rg;
-}
-
 uint get_seed(uint bounce, uint effect) {
-    return hash(hash_combine(hash_combine(hash(bounce), pixel_idx), effect));
+	return hash(hash_combine(hash_combine(hash(bounce), pixel_idx), effect));
 }
 
 vec2 get_shuffled_scrambled_sobol_pt(uint index, uint seed) {
-  uint shuffle_seed = hash_combine(seed, 0u);
-  uint x_seed = hash_combine(seed, 1u);
-  uint y_seed = hash_combine(seed, 2u);
+	uint shuffle_seed = hash_combine(seed, 0u);
+	uint x_seed = hash_combine(seed, 1u);
+	uint y_seed = hash_combine(seed, 2u);
 
-  uint shuffled_index =
-      nested_uniform_scramble_base2(reverse_bits(index), shuffle_seed)
-      % uint(num_points);
+	// TODO: modulus is required if we pre compute a limited number of points
+	uint shuffled_index = nested_uniform_scramble_base2(reverse_bits(index), shuffle_seed);
+	// shuffled_index = shuffled_index % uint(num_points);
 
-  vec2 sobol_pt = get_sobol_pt(shuffled_index);
-  uint x = uint(sobol_pt.x * 16777216.0);
-  uint y = uint(sobol_pt.y * 16777216.0);
-  x = nested_uniform_scramble_base2(x, x_seed);
-  y = nested_uniform_scramble_base2(y, y_seed);
-  return vec2(float(x >> 8) * SOBOL_FACTOR, float(y >> 8) * SOBOL_FACTOR);
+	vec2 sobol_pt = get_sobol_pt(shuffled_index);
+	uint x = uint(sobol_pt.x * 16777216.0);
+	uint y = uint(sobol_pt.y * 16777216.0);
+	x = nested_uniform_scramble_base2(x, x_seed);
+	y = nested_uniform_scramble_base2(y, y_seed);
+	return vec2(float(x >> 8) * SOBOL_FACTOR, float(y >> 8) * SOBOL_FACTOR);
 }
 
 vec2 get_pt(int bounce, int effect) {
-  return get_shuffled_scrambled_sobol_pt(
-      uint(path_idx),
-      get_seed(uint(bounce), uint(effect)));
+	return get_shuffled_scrambled_sobol_pt(
+		uint(path_idx),
+		get_seed(uint(bounce), uint(effect)));
 }
 
 

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -1,126 +1,115 @@
 export const shaderSobolSampling = /* glsl */`
 
-// References
-// - https://jcgt.org/published/0009/04/01/
-// - Code from https://www.shadertoy.com/view/WtGyDm
+	// References
+	// - https://jcgt.org/published/0009/04/01/
+	// - Code from https://www.shadertoy.com/view/WtGyDm
 
-// Utils
-uint reverse_bits(uint x) {
-	x = (((x & 0xaaaaaaaau) >> 1) | ((x & 0x55555555u) << 1));
-	x = (((x & 0xccccccccu) >> 2) | ((x & 0x33333333u) << 2));
-	x = (((x & 0xf0f0f0f0u) >> 4) | ((x & 0x0f0f0f0fu) << 4));
-	x = (((x & 0xff00ff00u) >> 8) | ((x & 0x00ff00ffu) << 8));
-	return ((x >> 16) | (x << 16));
-}
-
-uint hash_combine(uint seed, uint v) {
-	return seed ^ (v + (seed << 6) + (seed >> 2));
-}
-
-uint hash(uint x) {
-	// finalizer from murmurhash3
-	x ^= x >> 16;
-	x *= 0x85ebca6bu;
-	x ^= x >> 13;
-	x *= 0xc2b2ae35u;
-	x ^= x >> 16;
-	return x;
-}
-
-uint laine_karras_permutation(uint x, uint seed) {
-	x += seed;
-	x ^= x * 0x6c50b47cu;
-	x ^= x * 0xb82f1e52u;
-	x ^= x * 0xc7afe638u;
-	x ^= x * 0x8d22f6e6u;
-	return x;
-}
-
-uint nested_uniform_scramble_base2(uint x, uint seed) {
-	x = laine_karras_permutation(x, seed);
-	x = reverse_bits(x);
-	return x;
-}
-
-// Seeds
-uint pixel_idx;
-uint path_idx;
-
-uint get_seed(uint bounce, uint effect) {
-	return hash(
-		hash_combine(
-			hash_combine(
-				hash(bounce),
-				pixel_idx
-			),
-			effect
-		)
-	);
-}
-
-// Sampling
-const float SOBOL_FACTOR = 1.0 / 16777216.0;
-const uint SOBOL_DIRECTIONS[32] = uint[32](
-	0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
-	0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
-	0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
-	0x88880000u, 0xcccc0000u, 0xaaaa0000u, 0xffff0000u,
-	0x80008000u, 0xc000c000u, 0xa000a000u, 0xf000f000u,
-	0x88008800u, 0xcc00cc00u, 0xaa00aa00u, 0xff00ff00u,
-	0x80808080u, 0xc0c0c0c0u, 0xa0a0a0a0u, 0xf0f0f0f0u,
-	0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
-);
-
-uint sobol(uint index) {
-	uint X = 0u;
-	for (int bit = 0; bit < 32; bit++) {
-		uint mask = (index >> bit) & 1u;
-		X ^= mask * SOBOL_DIRECTIONS[bit];
+	// Utils
+	uint reverse_bits(uint x) {
+		x = (((x & 0xaaaaaaaau) >> 1) | ((x & 0x55555555u) << 1));
+		x = (((x & 0xccccccccu) >> 2) | ((x & 0x33333333u) << 2));
+		x = (((x & 0xf0f0f0f0u) >> 4) | ((x & 0x0f0f0f0fu) << 4));
+		x = (((x & 0xff00ff00u) >> 8) | ((x & 0x00ff00ffu) << 8));
+		return ((x >> 16) | (x << 16));
 	}
-	return X;
-}
 
-vec2 get_sobol_pt(uint index) {
-	uint x = reverse_bits(index) >> 8;
-	uint y = sobol(index) >> 8;
+	uint hash_combine(uint seed, uint v) {
+		return seed ^ (v + (seed << 6) + (seed >> 2));
+	}
 
-	float r = float(x) * SOBOL_FACTOR;
-	float g = float(y) * SOBOL_FACTOR;
-	return vec2( r, g );
-}
+	uint hash(uint x) {
+		// finalizer from murmurhash3
+		x ^= x >> 16;
+		x *= 0x85ebca6bu;
+		x ^= x >> 13;
+		x *= 0xc2b2ae35u;
+		x ^= x >> 16;
+		return x;
+	}
 
-vec2 get_shuffled_scrambled_sobol_pt(uint index, uint seed) {
-	uint shuffle_seed = hash_combine(seed, 0u);
-	uint x_seed = hash_combine(seed, 1u);
-	uint y_seed = hash_combine(seed, 2u);
+	uint laine_karras_permutation(uint x, uint seed) {
+		x += seed;
+		x ^= x * 0x6c50b47cu;
+		x ^= x * 0xb82f1e52u;
+		x ^= x * 0xc7afe638u;
+		x ^= x * 0x8d22f6e6u;
+		return x;
+	}
 
-	// TODO: modulus is required if we pre compute a limited number of points
-	uint shuffled_index = nested_uniform_scramble_base2(reverse_bits(index), shuffle_seed);
-	// shuffled_index = shuffled_index % uint(num_points);
+	uint nested_uniform_scramble_base2(uint x, uint seed) {
+		x = laine_karras_permutation(x, seed);
+		x = reverse_bits(x);
+		return x;
+	}
 
-	vec2 sobol_pt = get_sobol_pt(shuffled_index);
-	uint x = uint(sobol_pt.x * 16777216.0);
-	uint y = uint(sobol_pt.y * 16777216.0);
-	x = nested_uniform_scramble_base2(x, x_seed);
-	y = nested_uniform_scramble_base2(y, y_seed);
-	return vec2(float(x >> 8) * SOBOL_FACTOR, float(y >> 8) * SOBOL_FACTOR);
-}
+	// Seeds
+	uint pixel_idx;
+	uint path_idx;
 
-vec2 get_pt(int bounce, int effect) {
-	return get_shuffled_scrambled_sobol_pt(
-		uint(path_idx),
-		get_seed(uint(bounce), uint(effect)));
-}
+	uint get_seed(uint bounce, uint effect) {
+		return hash(
+			hash_combine(
+				hash_combine(
+					hash(bounce),
+					pixel_idx
+				),
+				effect
+			)
+		);
+	}
 
+	// Sampling
+	const float SOBOL_FACTOR = 1.0 / 16777216.0;
+	const uint SOBOL_DIRECTIONS[32] = uint[32](
+		0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
+		0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
+		0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
+		0x88880000u, 0xcccc0000u, 0xaaaa0000u, 0xffff0000u,
+		0x80008000u, 0xc000c000u, 0xa000a000u, 0xf000f000u,
+		0x88008800u, 0xcc00cc00u, 0xaa00aa00u, 0xff00ff00u,
+		0x80808080u, 0xc0c0c0c0u, 0xa0a0a0a0u, 0xf0f0f0f0u,
+		0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
+	);
 
+	uint sobol(uint index) {
+		uint X = 0u;
+		for (int bit = 0; bit < 32; bit++) {
+			uint mask = (index >> bit) & 1u;
+			X ^= mask * SOBOL_DIRECTIONS[bit];
+		}
+		return X;
+	}
 
+	vec2 get_sobol_pt(uint index) {
+		uint x = reverse_bits(index) >> 8;
+		uint y = sobol(index) >> 8;
 
+		float r = float(x) * SOBOL_FACTOR;
+		float g = float(y) * SOBOL_FACTOR;
+		return vec2( r, g );
+	}
 
+	vec2 get_shuffled_scrambled_sobol_pt(uint index, uint seed) {
+		uint shuffle_seed = hash_combine(seed, 0u);
+		uint x_seed = hash_combine(seed, 1u);
+		uint y_seed = hash_combine(seed, 2u);
 
+		// TODO: modulus is required if we pre compute a limited number of points
+		uint shuffled_index = nested_uniform_scramble_base2(reverse_bits(index), shuffle_seed);
+		// shuffled_index = shuffled_index % uint(num_points);
 
+		vec2 sobol_pt = get_sobol_pt(shuffled_index);
+		uint x = uint(sobol_pt.x * 16777216.0);
+		uint y = uint(sobol_pt.y * 16777216.0);
+		x = nested_uniform_scramble_base2(x, x_seed);
+		y = nested_uniform_scramble_base2(y, y_seed);
+		return vec2(float(x >> 8) * SOBOL_FACTOR, float(y >> 8) * SOBOL_FACTOR);
+	}
 
-
-
-
+	vec2 get_pt(int bounce, int effect) {
+		return get_shuffled_scrambled_sobol_pt(
+			uint(path_idx),
+			get_seed(uint(bounce), uint(effect)));
+	}
 
 `;

--- a/src/shader/shaderSobolSampling.js
+++ b/src/shader/shaderSobolSampling.js
@@ -1,10 +1,11 @@
-export const shaderSobolSampling = /* glsl */`
-
-	// References
-	// - https://jcgt.org/published/0009/04/01/
-	// - Code from https://www.shadertoy.com/view/WtGyDm
+// References
+// - https://jcgt.org/published/0009/04/01/
+// - Code from https://www.shadertoy.com/view/WtGyDm
+export const shaderSobolCommon = /* glsl */`
 
 	// Utils
+	const float SOBOL_FACTOR = 1.0 / 16777216.0;
+
 	uint reverse_bits( uint x ) {
 
 		x = ( ( ( x & 0xaaaaaaaau ) >> 1 ) | ( ( x & 0x55555555u ) << 1 ) );
@@ -52,6 +53,85 @@ export const shaderSobolSampling = /* glsl */`
 
 	}
 
+`;
+
+export const shaderSobolGeneration = /* glsl */`
+
+	const uint SOBOL_DIRECTIONS1[ 32 ] = uint[ 32 ](
+		0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
+		0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,
+		0x80800000u, 0xc0c00000u, 0xa0a00000u, 0xf0f00000u,
+		0x88880000u, 0xcccc0000u, 0xaaaa0000u, 0xffff0000u,
+		0x80008000u, 0xc000c000u, 0xa000a000u, 0xf000f000u,
+		0x88008800u, 0xcc00cc00u, 0xaa00aa00u, 0xff00ff00u,
+		0x80808080u, 0xc0c0c0c0u, 0xa0a0a0a0u, 0xf0f0f0f0u,
+		0x88888888u, 0xccccccccu, 0xaaaaaaaau, 0xffffffffu
+	);
+
+	const uint SOBOL_DIRECTIONS2[ 32 ] = uint[ 32 ](
+		0x80000000u, 0xc0000000u, 0x60000000u, 0x90000000u,
+		0xe8000000u, 0x5c000000u, 0x8e000000u, 0xc5000000u,
+		0x68800000u, 0x9cc00000u, 0xee600000u, 0x55900000u,
+		0x80680000u, 0xc09c0000u, 0x60ee0000u, 0x90550000u,
+		0xe8808000u, 0x5cc0c000u, 0x8e606000u, 0xc5909000u,
+		0x6868e800u, 0x9c9c5c00u, 0xeeee8e00u, 0x5555c500u,
+		0x8000e880u, 0xc0005cc0u, 0x60008e60u, 0x9000c590u,
+		0xe8006868u, 0x5c009c9cu, 0x8e00eeeeu, 0xc5005555u
+	);
+
+	const uint SOBOL_DIRECTIONS3[ 32 ] = uint[ 32 ](
+		0x80000000u, 0xc0000000u, 0x20000000u, 0x50000000u,
+		0xf8000000u, 0x74000000u, 0xa2000000u, 0x93000000u,
+		0xd8800000u, 0x25400000u, 0x59e00000u, 0xe6d00000u,
+		0x78080000u, 0xb40c0000u, 0x82020000u, 0xc3050000u,
+		0x208f8000u, 0x51474000u, 0xfbea2000u, 0x75d93000u,
+		0xa0858800u, 0x914e5400u, 0xdbe79e00u, 0x25db6d00u,
+		0x58800080u, 0xe54000c0u, 0x79e00020u, 0xb6d00050u,
+		0x800800f8u, 0xc00c0074u, 0x200200a2u, 0x50050093u
+	);
+
+	const uint SOBOL_DIRECTIONS4[ 32 ] = uint[ 32 ](
+		0x80000000u, 0x40000000u, 0x20000000u, 0xb0000000u,
+		0xf8000000u, 0xdc000000u, 0x7a000000u, 0x9d000000u,
+		0x5a800000u, 0x2fc00000u, 0xa1600000u, 0xf0b00000u,
+		0xda880000u, 0x6fc40000u, 0x81620000u, 0x40bb0000u,
+		0x22878000u, 0xb3c9c000u, 0xfb65a000u, 0xddb2d000u,
+		0x78022800u, 0x9c0b3c00u, 0x5a0fb600u, 0x2d0ddb00u,
+		0xa2878080u, 0xf3c9c040u, 0xdb65a020u, 0x6db2d0b0u,
+		0x800228f8u, 0x400b3cdcu, 0x200fb67au, 0xb00ddb9du
+	);
+
+	uint sobolHash( uint index, uint directions[ 32 ] ) {
+
+		uint X = 0u;
+		for ( int bit = 0; bit < 32; bit ++ ) {
+
+			uint mask = ( index >> bit ) & 1u;
+			X ^= mask * directions[ bit ];
+
+		}
+		return X;
+
+	}
+
+	vec4 generateSobolPoint( uint index ) {
+
+		if ( int( index ) > num_points ) return vec4( 0.0 );
+
+		// uint x = index & 0x00ffffffu;
+		uint x = reverse_bits( sobolHash( index, SOBOL_DIRECTIONS1 ) ) & 0x00ffffffu;
+		uint y = reverse_bits( sobolHash( index, SOBOL_DIRECTIONS2 ) ) & 0x00ffffffu;
+		uint z = reverse_bits( sobolHash( index, SOBOL_DIRECTIONS3 ) ) & 0x00ffffffu;
+		uint w = reverse_bits( sobolHash( index, SOBOL_DIRECTIONS4 ) ) & 0x00ffffffu;
+
+		return vec4( x, y, z, w ) * SOBOL_FACTOR;
+
+	}
+
+`;
+
+export const shaderSobolSampling = /* glsl */`
+
 	// Seeds
 	uint pixel_idx;
 	uint path_idx;
@@ -71,7 +151,6 @@ export const shaderSobolSampling = /* glsl */`
 	}
 
 	// Sampling
-	const float SOBOL_FACTOR = 1.0 / 16777216.0;
 	const uint SOBOL_DIRECTIONS[ 32 ] = uint[ 32 ](
 		0x80000000u, 0xc0000000u, 0xa0000000u, 0xf0000000u,
 		0x88000000u, 0xcc000000u, 0xaa000000u, 0xff000000u,

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -262,6 +262,17 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	vec2 rotateVector( vec2 v, float t ) {
+
+		float ac = cos( t );
+		float as = sin( t );
+		return vec2(
+			v.x * ac - v.y * as,
+			v.x * as + v.y * ac
+		);
+
+	}
+
 	// Finds the point where the ray intersects the plane defined by u and v and checks if this point
 	// falls in the bounds of the rectangle on that same plane.
 	// Plane intersection: https://lousodrome.net/blog/light/2020/07/03/intersection-of-a-ray-and-a-plane/

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -139,7 +139,7 @@ export const shaderUtils = /* glsl */`
 		vec2 e2 = c - b;
 		vec2 diag = normalize( e1 + e2 );
 
-		// pick a random point in the parallelogram
+		// pick the point in the parallelogram
 		if ( r.x + r.y > 1.0 ) {
 
 			r = vec2( 1.0 ) - r;

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -150,32 +150,38 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	vec2 sampleCircle( vec2 uv ) {
+
+		float angle = 2.0 * PI * uv.x;
+		float radius = sqrt( uv.y );
+		return vec2( cos( angle ), sin( angle ) ) * radius;
+
+	}
+
+	vec2 sampleRegularNGon( int sides, vec3 uvw ) {
+
+		sides = max( sides, 3 );
+
+		vec3 r = uvw;
+		float anglePerSegment = 2.0 * PI / float( sides );
+		float segment = floor( float( sides ) * r.x );
+
+		float angle1 = anglePerSegment * segment;
+		float angle2 = angle1 + anglePerSegment;
+		vec2 a = vec2( sin( angle1 ), cos( angle1 ) );
+		vec2 b = vec2( 0.0, 0.0 );
+		vec2 c = vec2( sin( angle2 ), cos( angle2 ) );
+
+		return sampleTriangle( a, b, c, r.yz );
+
+	}
+
 	// samples an aperture shape with the given number of sides. 0 means circle
 	vec2 sampleAperture( int blades, vec3 uvw ) {
 
-		if ( blades == 0 ) {
-
-			float angle = 2.0 * PI * uvw.x;
-			float radius = sqrt( uvw.y );
-			return vec2( cos( angle ), sin( angle ) ) * radius;
-
-		} else {
-
-			blades = max( blades, 3 );
-
-			vec3 r = uvw;
-			float anglePerSegment = 2.0 * PI / float( blades );
-			float segment = floor( float( blades ) * r.x );
-
-			float angle1 = anglePerSegment * segment;
-			float angle2 = angle1 + anglePerSegment;
-			vec2 a = vec2( sin( angle1 ), cos( angle1 ) );
-			vec2 b = vec2( 0.0, 0.0 );
-			vec2 c = vec2( sin( angle2 ), cos( angle2 ) );
-
-			return sampleTriangle( a, b, c, r.yz );
-
-		}
+		return blades == 0 ?
+			sampleCircle( uvw.xy ) :
+			sampleRegularNGon( blades, uvw );
 
 	}
 

--- a/src/shader/shaderUtils.js
+++ b/src/shader/shaderUtils.js
@@ -158,6 +158,16 @@ export const shaderUtils = /* glsl */`
 
 	}
 
+	vec3 sampleSphere( vec2 uv ) {
+
+		float u = ( uv.x - 0.5 ) * 2.0;
+		float t = uv.y * PI * 2.0;
+		float f = sqrt( 1.0 - u * u );
+
+		return vec3( f * cos( t ), f * sin( t ), u );
+
+	}
+
 	vec2 sampleRegularNGon( int sides, vec3 uvw ) {
 
 		sides = max( sides, 3 );
@@ -348,5 +358,4 @@ export const shaderUtils = /* glsl */`
 		return x < 0.5 ? sqrt( 2.0 * x ) - 1.0 : 1.0 - sqrt( 2.0 - ( 2.0 * x ) );
 
 	}
-
 `;

--- a/src/utils/SobolNumberMapGenerator.js
+++ b/src/utils/SobolNumberMapGenerator.js
@@ -1,0 +1,73 @@
+import { FloatType, NearestFilter, NoBlending, RGBAFormat, WebGLRenderTarget } from 'three';
+import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass';
+import { MaterialBase } from '../materials/MaterialBase.js';
+import { shaderSobolCommon, shaderSobolGeneration } from '../shader/shaderSobolSampling.js';
+
+class SobolNumbersMaterial extends MaterialBase {
+
+	constructor() {
+
+		super( {
+
+			blending: NoBlending,
+
+			vertexShader: /* glsl */`
+
+				varying vec2 vUv;
+				void main() {
+
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+				}
+			`,
+
+			fragmentShader: /* glsl */`
+
+				${ shaderSobolCommon }
+				${ shaderSobolGeneration }
+
+				varying vec2 vUv;
+				void main() {
+
+					vec2 resolution = 1.0 / fwidth( vUv );
+					uint index = uint( gl_FragCoord.y ) * uint( resolution.x ) + uint( gl_FragCoord.x );
+					gl_FragColor = generateSobolPoint( index );
+
+				}
+			`,
+
+		} );
+
+	}
+
+}
+
+export class SobolNumberMapGenerator {
+
+	generate( renderer, dimensions = 256 ) {
+
+		const target = new WebGLRenderTarget( dimensions, dimensions, {
+
+			type: FloatType,
+			format: RGBAFormat,
+			minFilter: NearestFilter,
+			magFilter: NearestFilter,
+			generateMipmaps: false,
+
+		} );
+
+		const ogTarget = renderer.getRenderTarget();
+		renderer.setRenderTarget( target );
+
+		const quad = new FullScreenQuad( new SobolNumbersMaterial() );
+		quad.render( renderer );
+
+		renderer.setRenderTarget( ogTarget );
+		quad.dispose();
+
+		return target;
+
+	}
+
+}

--- a/src/utils/SobolNumberMapGenerator.js
+++ b/src/utils/SobolNumberMapGenerator.js
@@ -1,4 +1,4 @@
-import { FloatType, NearestFilter, NoBlending, RGBAFormat, WebGLRenderTarget } from 'three';
+import { FloatType, NearestFilter, NoBlending, RGBAFormat, Vector2, WebGLRenderTarget } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass';
 import { MaterialBase } from '../materials/MaterialBase.js';
 import { shaderSobolCommon, shaderSobolGeneration } from '../shader/shaderSobolSampling.js';
@@ -10,6 +10,12 @@ class SobolNumbersMaterial extends MaterialBase {
 		super( {
 
 			blending: NoBlending,
+
+			uniforms: {
+
+				resolution: { value: new Vector2() },
+
+			},
 
 			vertexShader: /* glsl */`
 
@@ -28,9 +34,9 @@ class SobolNumbersMaterial extends MaterialBase {
 				${ shaderSobolGeneration }
 
 				varying vec2 vUv;
+				uniform vec2 resolution;
 				void main() {
 
-					vec2 resolution = 1.0 / fwidth( vUv );
 					uint index = uint( gl_FragCoord.y ) * uint( resolution.x ) + uint( gl_FragCoord.x );
 					gl_FragColor = generateSobolPoint( index );
 
@@ -61,6 +67,7 @@ export class SobolNumberMapGenerator {
 		renderer.setRenderTarget( target );
 
 		const quad = new FullScreenQuad( new SobolNumbersMaterial() );
+		quad.material.resolution.set( dimensions, dimensions );
 		quad.render( renderer );
 
 		renderer.setRenderTarget( ogTarget );


### PR DESCRIPTION
Related to #59
Related to #34
Fix #58

**Random Function Calls**
- ~shaderEnvMapSampling.js~
- ~shaderLightSampling.js~
- shaderMaterialSampling.js

**TODO**
- [ ] Readd sobol everywhere (remove rand)
- [x] Use sobol sampling throughout and verify improvement / faster convergence.
- [x] Consolidate bounce and pixel index hash to a single hashed seed so sobol function only needs one "effect" field
- [x] Add at least 3 dimension sobol sampling for improved cases (aperture).
- [x] Add optimized sobol table texture
- [x] Verify sobol implementation.
- [x] Simplify reuse of random values throughout. Reuse where possible. Specify random values in as few places as possible, as high up as possible so they can be trickled down.
