### PR TITLE
Remove redundant total internal refraction logic

### DIFF
--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -32,6 +32,7 @@ import { shapeSamplingGLSL } from '../../shader/sampling/shapeSampling.glsl.js';
 import { intersectShapesGLSL } from '../../shader/common/intersectShapes.glsl';
 import { mathGLSL } from '../../shader/common/math.glsl.js';
 import { utilsGLSL } from '../../shader/common/utils.glsl.js';
+import { fresnelGLSL } from '../../shader/common/fresnel.glsl.js';
 import { arraySamplerTexelFetchGLSL } from '../../shader/common/arraySamplerTexelFetch.glsl.js';
 
 // random glsl
@@ -146,6 +147,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 				// common
 				${ arraySamplerTexelFetchGLSL }
+				${ fresnelGLSL }
 				${ utilsGLSL }
 				${ mathGLSL }
 				${ intersectShapesGLSL }

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -10,7 +10,7 @@ Eval   : Get the color and pdf for a direction
 Sample : Get the direction, color, and pdf for a sample
 eta    : Greek character used to denote the "ratio of ior"
 f0     : Amount of light reflected when looking at a surface head on - "fresnel 0"
-f90	   : Amount of light reflected at grazing angles
+f90    : Amount of light reflected at grazing angles
 */
 
 export const bsdfSamplingGLSL = /* glsl */`

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -79,8 +79,8 @@ export const bsdfSamplingGLSL = /* glsl */`
 
 		// TODO: some model-viewer test models look better when surf.eta is set to a non 1.5 eta here here?
 		// and the furnace test seems to pass when it === 1.0
-		// float dielectricFresnel = dielectricFresnel( abs( dotHV ), surf.eta );
-		float dielectricFresnel = dielectricFresnel( abs( dotHV ), 1.0 / 1.1 );
+		float dielectricFresnel = dielectricFresnel( abs( dotHV ), surf.eta );
+		// float dielectricFresnel = dielectricFresnel( abs( dotHV ), 1.0 / 1.1 );
 		float metallicFresnel = schlickFresnel( dotHL, surf.f0 );
 
 		return mix( dielectricFresnel, metallicFresnel, surf.metalness );
@@ -217,19 +217,14 @@ export const bsdfSamplingGLSL = /* glsl */`
 		color = surf.transmission * surf.color;
 
 		// PDF
-		float eta = surf.eta;
-		float f0 = surf.f0;
-		float cosTheta = min( wo.z, 1.0 );
-		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
-		float reflectance = schlickFresnel( cosTheta, f0 );
-		bool cannotRefract = eta * sinTheta > 1.0;
-		if ( cannotRefract ) {
+		float FM = disneyFresnel( surf, wo, wi, wh );
+		if ( FM >= 1.0 ) {
 
 			return 0.0;
 
 		}
 
-		return 1.0 / ( 1.0 - reflectance );
+		return 1.0 / ( 1.0 - FM );
 
 	}
 

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -86,13 +86,6 @@ export const bsdfSamplingGLSL = /* glsl */`
 
 	}
 
-	bool totalInternalReflection( float cosTheta, float eta ) {
-
-		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
-		return eta * sinTheta > 1.0;
-
-	}
-
 	vec3 evaluateFresnel( float cosTheta, float eta, vec3 f0, vec3 f90 ) {
 
 		if ( totalInternalReflection( cosTheta, eta ) ) {

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -313,20 +313,7 @@ export const bsdfSamplingGLSL = /* glsl */`
 
 		float metalness = surf.metalness;
 		float transmission = surf.transmission;
-
-		float eta = surf.eta;
-		float f0 = surf.f0;
-		float cosTheta = min( wo.z, 1.0 );
-		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
-
-		// TODO: does "cannot refract" belong in disney fresnel?
 		float reflectance = disneyFresnel( surf, wo, wi, wh );
-		bool cannotRefract = eta * sinTheta > 1.0;
-		if ( cannotRefract ) {
-
-			reflectance = 1.0;
-
-		}
 
 		float transSpecularProb = mix( max( 0.25, reflectance ), 1.0, metalness );
 		float diffSpecularProb = 0.5 + 0.5 * metalness;

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -118,9 +118,10 @@ export const bsdfSamplingGLSL = /* glsl */`
 
 		vec3 f0Specular = mix( f0 * surf.specularColor * surf.specularIntensity, surf.color, surf.metalness );
 		vec3 f90Specular = vec3( mix( surf.specularIntensity, 1.0, surf.metalness ) );
-
-		vec3 iridescenceFresnel = evalIridescence( 1.0, surf.iridescenceIor, dot( wi, wh ), surf.iridescenceThickness, f0Specular );
 		vec3 F = evaluateFresnel( dot( wo, wh ), eta, f0Specular, f90Specular );
+
+		vec3 iridescenceF = evalIridescence( 1.0, surf.iridescenceIor, dot( wi, wh ), surf.iridescenceThickness, f0Specular );
+		F = mix( F, iridescenceF,  surf.iridescence );
 
 		color = wi.z * F * G * D / ( 4.0 * abs( wi.z * wo.z ) );
 

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -131,14 +131,6 @@ export const bsdfSamplingGLSL = /* glsl */`
 		float G = ggxShadowMaskG2( wi, wo, roughness );
 		float D = ggxDistribution( wh, roughness );
 		float FM = disneyFresnel( surf, wo, wi, wh );
-		float cosTheta = min( wo.z, 1.0 );
-		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
-		bool cannotRefract = eta * sinTheta > 1.0;
-		if ( cannotRefract ) {
-
-			FM = 1.0;
-
-		}
 
 		vec3 baseColor = mix( f0 * surf.specularColor * surf.specularIntensity, surf.color, surf.metalness );
 		vec3 iridescenceFresnel = evalIridescence( 1.0, surf.iridescenceIor, dot( wi, wh ), surf.iridescenceThickness, baseColor );
@@ -269,14 +261,6 @@ export const bsdfSamplingGLSL = /* glsl */`
 		float G = ggxShadowMaskG2( wi, wo, roughness );
 		float D = ggxDistribution( wh, roughness );
 		float F = schlickFresnel( dot( wi, wh ), f0 );
-		float cosTheta = min( wo.z, 1.0 );
-		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
-		bool cannotRefract = eta * sinTheta > 1.0;
-		if ( cannotRefract ) {
-
-			F = 1.0;
-
-		}
 
 		float fClearcoat = F * D * G / ( 4.0 * abs( wi.z * wo.z ) );
 		color = color * ( 1.0 - surf.clearcoat * F ) + fClearcoat * surf.clearcoat * wi.z;

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -333,18 +333,6 @@ export const bsdfSamplingGLSL = /* glsl */`
 		float metalness = surf.metalness;
 		float transmission = surf.transmission;
 
-		float eta = surf.eta;
-		float f0 = surf.f0;
-		float cosTheta = min( wo.z, 1.0 );
-		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
-		float reflectance = schlickFresnel( cosTheta, f0 );
-		bool cannotRefract = eta * sinTheta > 1.0;
-		if ( cannotRefract ) {
-
-			reflectance = 1.0;
-
-		}
-
 		float spdf = 0.0;
 		float dpdf = 0.0;
 		float tpdf = 0.0;

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -86,6 +86,36 @@ export const bsdfSamplingGLSL = /* glsl */`
 
 	}
 
+	vec3 evaluateFresnel( float cosTheta, float eta, vec3 f0, vec3 f90 ) {
+
+		// total internal refraction
+		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
+		bool cannotRefract = eta * sinTheta > 1.0;
+		if ( cannotRefract ) {
+
+			return f90;
+
+		}
+
+		return schlickFresnel( cosTheta, f0, f90 );
+
+	}
+
+	float evaluateFresnelWeight( float cosTheta, float eta, float f0 ) {
+
+		// total internal refraction
+		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
+		bool cannotRefract = eta * sinTheta > 1.0;
+		if ( cannotRefract ) {
+
+			return 1.0;
+
+		}
+
+		return schlickFresnel( cosTheta, f0 );
+
+	}
+
 	// diffuse
 	float diffuseEval( vec3 wo, vec3 wi, vec3 wh, SurfaceRec surf, out vec3 color ) {
 
@@ -134,7 +164,7 @@ export const bsdfSamplingGLSL = /* glsl */`
 		vec3 f90Specular = vec3( mix( surf.specularIntensity, 1.0, surf.metalness ) );
 
 		vec3 iridescenceFresnel = evalIridescence( 1.0, surf.iridescenceIor, dot( wi, wh ), surf.iridescenceThickness, f0Specular );
-		vec3 F = schlickFresnel( dot( wi, wh ), f0Specular, f90Specular );
+		vec3 F = evaluateFresnel( dot( wo, wh ), eta, f0Specular, f90Specular );
 
 		color = wi.z * F * G * D / ( 4.0 * abs( wi.z * wo.z ) );
 

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -116,11 +116,11 @@ export const bsdfSamplingGLSL = /* glsl */`
 		float G = ggxShadowMaskG2( wi, wo, roughness );
 		float D = ggxDistribution( wh, roughness );
 
-		vec3 f0Specular = mix( f0 * surf.specularColor * surf.specularIntensity, surf.color, surf.metalness );
-		vec3 f90Specular = vec3( mix( surf.specularIntensity, 1.0, surf.metalness ) );
-		vec3 F = evaluateFresnel( dot( wo, wh ), eta, f0Specular, f90Specular );
+		vec3 f0Color = mix( f0 * surf.specularColor * surf.specularIntensity, surf.color, surf.metalness );
+		vec3 f90Color = vec3( mix( surf.specularIntensity, 1.0, surf.metalness ) );
+		vec3 F = evaluateFresnel( dot( wo, wh ), eta, f0Color, f90Color );
 
-		vec3 iridescenceF = evalIridescence( 1.0, surf.iridescenceIor, dot( wi, wh ), surf.iridescenceThickness, f0Specular );
+		vec3 iridescenceF = evalIridescence( 1.0, surf.iridescenceIor, dot( wi, wh ), surf.iridescenceThickness, f0Color );
 		F = mix( F, iridescenceF,  surf.iridescence );
 
 		color = wi.z * F * G * D / ( 4.0 * abs( wi.z * wo.z ) );

--- a/src/shader/bsdf/bsdfSampling.glsl.js
+++ b/src/shader/bsdf/bsdfSampling.glsl.js
@@ -86,12 +86,16 @@ export const bsdfSamplingGLSL = /* glsl */`
 
 	}
 
+	bool totalInternalReflection( float cosTheta, float eta ) {
+
+		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
+		return eta * sinTheta > 1.0;
+
+	}
+
 	vec3 evaluateFresnel( float cosTheta, float eta, vec3 f0, vec3 f90 ) {
 
-		// total internal refraction
-		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
-		bool cannotRefract = eta * sinTheta > 1.0;
-		if ( cannotRefract ) {
+		if ( totalInternalReflection( cosTheta, eta ) ) {
 
 			return f90;
 
@@ -103,10 +107,7 @@ export const bsdfSamplingGLSL = /* glsl */`
 
 	float evaluateFresnelWeight( float cosTheta, float eta, float f0 ) {
 
-		// total internal refraction
-		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
-		bool cannotRefract = eta * sinTheta > 1.0;
-		if ( cannotRefract ) {
+		if ( totalInternalReflection( cosTheta, eta ) ) {
 
 			return 1.0;
 

--- a/src/shader/common/fresnel.glsl.js
+++ b/src/shader/common/fresnel.glsl.js
@@ -1,0 +1,60 @@
+export const fresnelGLSL = /* glsl */`
+
+	bool totalInternalReflection( float cosTheta, float eta ) {
+
+		float sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
+		return eta * sinTheta > 1.0;
+
+	}
+
+	// https://google.github.io/filament/Filament.md.html#materialsystem/diffusebrdf
+	float schlickFresnel( float cosine, float f0 ) {
+
+		return f0 + ( 1.0 - f0 ) * pow( 1.0 - cosine, 5.0 );
+
+	}
+
+	vec3 schlickFresnel( float cosine, vec3 f0 ) {
+
+		return f0 + ( 1.0 - f0 ) * pow( 1.0 - cosine, 5.0 );
+
+	}
+
+	vec3 schlickFresnel( float cosine, vec3 f0, vec3 f90 ) {
+
+		return f0 + ( f90 - f0 ) * pow( 1.0 - cosine, 5.0 );
+
+	}
+
+	float dielectricFresnel( float cosThetaI, float eta ) {
+
+		// https://schuttejoe.github.io/post/disneybsdf/
+		float ni = eta;
+		float nt = 1.0;
+
+		// Check for total internal reflection
+		float sinThetaISq = 1.0f - cosThetaI * cosThetaI;
+		float sinThetaTSq = eta * eta * sinThetaISq;
+		if( sinThetaTSq >= 1.0 ) {
+
+			return 1.0;
+
+		}
+
+		float sinThetaT = sqrt( sinThetaTSq );
+
+		float cosThetaT = sqrt( max( 0.0, 1.0f - sinThetaT * sinThetaT ) );
+		float rParallel = ( ( nt * cosThetaI ) - ( ni * cosThetaT ) ) / ( ( nt * cosThetaI ) + ( ni * cosThetaT ) );
+		float rPerpendicular = ( ( ni * cosThetaI ) - ( nt * cosThetaT ) ) / ( ( ni * cosThetaI ) + ( nt * cosThetaT ) );
+		return ( rParallel * rParallel + rPerpendicular * rPerpendicular ) / 2.0;
+
+	}
+
+	// https://raytracing.github.io/books/RayTracingInOneWeekend.html#dielectrics/schlickapproximation
+	float iorRatioToF0( float eta ) {
+
+		return pow( ( 1.0 - eta ) / ( 1.0 + eta ), 2.0 );
+
+	}
+
+`;

--- a/src/shader/common/fresnel.glsl.js
+++ b/src/shader/common/fresnel.glsl.js
@@ -57,4 +57,42 @@ export const fresnelGLSL = /* glsl */`
 
 	}
 
+	vec3 evaluateFresnel( float cosTheta, float eta, vec3 f0, vec3 f90 ) {
+
+		if ( totalInternalReflection( cosTheta, eta ) ) {
+
+			return f90;
+
+		}
+
+		return schlickFresnel( cosTheta, f0, f90 );
+
+	}
+
+	float evaluateFresnelWeight( float cosTheta, float eta, float f0 ) {
+
+		if ( totalInternalReflection( cosTheta, eta ) ) {
+
+			return 1.0;
+
+		}
+
+		return schlickFresnel( cosTheta, f0 );
+
+	}
+
+	/*
+	// https://schuttejoe.github.io/post/disneybsdf/
+	float disneyFresnel( vec3 wo, vec3 wi, vec3 wh, float f0, float eta, float metalness ) {
+
+		float dotHV = dot( wo, wh );
+		float dotHL = dot( wi, wh );
+
+		float dielectricFresnel = dielectricFresnel( abs( dotHV ), eta );
+		float metallicFresnel = schlickFresnel( dotHL, f0 );
+
+		return mix( dielectricFresnel, metallicFresnel, metalness );
+
+	}
+	*/
 `;

--- a/src/shader/common/utils.glsl.js
+++ b/src/shader/common/utils.glsl.js
@@ -39,6 +39,12 @@ export const utilsGLSL = /* glsl */`
 
 	}
 
+	vec3 schlickFresnel( float cosine, vec3 f0, vec3 f90 ) {
+
+		return f0 + ( f90 - f0 ) * pow( 1.0 - cosine, 5.0 );
+
+	}
+
 	float dielectricFresnel( float cosThetaI, float eta ) {
 
 		// https://schuttejoe.github.io/post/disneybsdf/

--- a/src/shader/common/utils.glsl.js
+++ b/src/shader/common/utils.glsl.js
@@ -26,56 +26,6 @@ export const utilsGLSL = /* glsl */`
 
 	}
 
-	// https://google.github.io/filament/Filament.md.html#materialsystem/diffusebrdf
-	float schlickFresnel( float cosine, float f0 ) {
-
-		return f0 + ( 1.0 - f0 ) * pow( 1.0 - cosine, 5.0 );
-
-	}
-
-	vec3 schlickFresnel( float cosine, vec3 f0 ) {
-
-		return f0 + ( 1.0 - f0 ) * pow( 1.0 - cosine, 5.0 );
-
-	}
-
-	vec3 schlickFresnel( float cosine, vec3 f0, vec3 f90 ) {
-
-		return f0 + ( f90 - f0 ) * pow( 1.0 - cosine, 5.0 );
-
-	}
-
-	float dielectricFresnel( float cosThetaI, float eta ) {
-
-		// https://schuttejoe.github.io/post/disneybsdf/
-		float ni = eta;
-		float nt = 1.0;
-
-		// Check for total internal reflection
-		float sinThetaISq = 1.0f - cosThetaI * cosThetaI;
-		float sinThetaTSq = eta * eta * sinThetaISq;
-		if( sinThetaTSq >= 1.0 ) {
-
-			return 1.0;
-
-		}
-
-		float sinThetaT = sqrt( sinThetaTSq );
-
-		float cosThetaT = sqrt( max( 0.0, 1.0f - sinThetaT * sinThetaT ) );
-		float rParallel = ( ( nt * cosThetaI ) - ( ni * cosThetaT ) ) / ( ( nt * cosThetaI ) + ( ni * cosThetaT ) );
-		float rPerpendicular = ( ( ni * cosThetaI ) - ( nt * cosThetaT ) ) / ( ( ni * cosThetaI ) + ( nt * cosThetaT ) );
-		return ( rParallel * rParallel + rPerpendicular * rPerpendicular ) / 2.0;
-
-	}
-
-	// https://raytracing.github.io/books/RayTracingInOneWeekend.html#dielectrics/schlickapproximation
-	float iorRatioToF0( float eta ) {
-
-		return pow( ( 1.0 - eta ) / ( 1.0 + eta ), 2.0 );
-
-	}
-
 	vec3 getHalfVector( vec3 wi, vec3 wo, float eta ) {
 
 		// get the half vector - assuming if the light incident vector is on the other side


### PR DESCRIPTION
Fix #394 

**TODO**
- [x] Remove dielectric fresnel since gltf spec does not mention it and model parameterizations seem to expect schlick fresnel (or dielectric fresnel needs to be applied differently)
- [x] Remove Disney fresnel function
- [x] Clean up further
- [x] Create a "fresnel" file