### PR TITLE
Faster env-map MIS calculation, use FloatType when loading env-maps with RGBELoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ ptMaterial.materials.updateFrom( materials, textures );
 ptMaterial.lights.updateFrom( lights );
 
 // set the environment map
-const texture = await new RGBELoader().loadAsync( envMapUrl );
+const texture = await new RGBELoader().setDataType(THREE.FloatType).loadAsync( envMapUrl );
 ptRenderer.material.envMapInfo.updateFrom( texture );
 
 animate();
@@ -166,7 +166,7 @@ import { BlurredEnvMapGenerator } from 'three-gpu-pathtracer';
 
 // ...
 
-const envMap = await new RGBELoader().loadAsync( envMapUrl );
+const envMap = await new RGBELoader().setDataType( THREE.FloatType ).loadAsync( envMapUrl ); 
 const generator = new BlurredEnvMapGenerator( renderer );
 const blurredEnvMap = generator.generate( envMap, 0.35 );
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ ptMaterial.materials.updateFrom( materials, textures );
 ptMaterial.lights.updateFrom( lights );
 
 // set the environment map
-const texture = await new RGBELoader().setDataType(THREE.FloatType).loadAsync( envMapUrl );
+const texture = await new RGBELoader().setDataType( THREE.FloatType ).loadAsync( envMapUrl );
 ptRenderer.material.envMapInfo.updateFrom( texture );
 
 animate();

--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -95,7 +95,7 @@ async function init() {
 	samplesEl = document.getElementById( 'samples' );
 	loadingEl = document.getElementById( 'loading' );
 
-	const envMapPromise = new RGBELoader()
+	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/master/hdri/leadenhall_market_1k.hdr' )
 		.then( texture => {
 

--- a/example/basic.js
+++ b/example/basic.js
@@ -63,7 +63,7 @@ async function init() {
 	} );
 
 	// load the envmap and model
-	const envMapPromise = new RGBELoader()
+	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/master/hdri/chinese_garden_1k.hdr' )
 		.then( texture => {
 

--- a/example/depthOfField.js
+++ b/example/depthOfField.js
@@ -80,7 +80,7 @@ async function init() {
 
 	samplesEl = document.getElementById( 'samples' );
 
-	const envMapPromise = new RGBELoader()
+	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/example/index.js
+++ b/example/index.js
@@ -30,6 +30,7 @@ import { PathTracingSceneWorker } from '../src/workers/PathTracingSceneWorker.js
 import { PhysicalPathTracingMaterial, PathTracingRenderer, MaterialReducer, BlurredEnvMapGenerator, GradientEquirectTexture } from '../src/index.js';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { FloatType } from 'three';
 
 const envMaps = {
 	'Royal Esplanade': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr',
@@ -466,7 +467,7 @@ function buildGui() {
 
 function updateEnvMap() {
 
-	new RGBELoader()
+	new RGBELoader().setDataType( FloatType )
 		.load( params.envMap, texture => {
 
 			if ( scene.environmentMap ) {

--- a/example/index.js
+++ b/example/index.js
@@ -17,6 +17,7 @@ import {
 	MeshBasicMaterial,
 	sRGBEncoding,
 	CustomBlending,
+	FloatType
 } from 'three';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
@@ -30,7 +31,6 @@ import { PathTracingSceneWorker } from '../src/workers/PathTracingSceneWorker.js
 import { PhysicalPathTracingMaterial, PathTracingRenderer, MaterialReducer, BlurredEnvMapGenerator, GradientEquirectTexture } from '../src/index.js';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { FloatType } from 'three';
 
 const envMaps = {
 	'Royal Esplanade': 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr',

--- a/example/interior.js
+++ b/example/interior.js
@@ -98,7 +98,7 @@ async function init() {
 
 	samplesEl = document.getElementById( 'samples' );
 
-	const envMapPromise = new RGBELoader()
+	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/example/iridescenceTest.js
+++ b/example/iridescenceTest.js
@@ -78,7 +78,7 @@ async function init() {
 	const BASE_URL = 'https://raw.githubusercontent.com/google/model-viewer/master/packages/render-fidelity-tools/test/config/';
 	const envUrl = new URL( '../../../shared-assets/environments/lightroom_14b.hdr', BASE_URL ).toString();
 
-	await new RGBELoader()
+	await new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( envUrl )
 		.then( texture => {
 

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -16,7 +16,8 @@ import {
 	CustomBlending,
 	EquirectangularReflectionMapping,
 	MathUtils,
-	Vector4
+	Vector4,
+	FloatType
 } from 'three';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { LDrawLoader } from 'three/examples/jsm/loaders/LDrawLoader.js';
@@ -32,7 +33,6 @@ import { QuiltPreviewMaterial } from './materials/QuiltPreviewMaterial.js';
 
 import { LookingGlassWebXRPolyfill, LookingGlassConfig } from '@lookingglass/webxr/dist/@lookingglass/webxr.js';
 import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
-import { FloatType } from 'three';
 
 // lkg display constants
 const LKG_WIDTH = 420;

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -32,6 +32,7 @@ import { QuiltPreviewMaterial } from './materials/QuiltPreviewMaterial.js';
 
 import { LookingGlassWebXRPolyfill, LookingGlassConfig } from '@lookingglass/webxr/dist/@lookingglass/webxr.js';
 import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+import { FloatType } from 'three';
 
 // lkg display constants
 const LKG_WIDTH = 420;
@@ -165,7 +166,7 @@ async function init() {
 	} );
 
 	// load the environment map
-	new RGBELoader()
+	new RGBELoader().setDataType( FloatType )
 		.load( ENVMAP_URL, texture => {
 
 			texture.mapping = EquirectangularReflectionMapping;

--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -202,7 +202,7 @@ async function init() {
 
 	envMapGenerator = new BlurredEnvMapGenerator( renderer );
 
-	const envMapPromise = new RGBELoader()
+	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/example/materialDatabase.js
+++ b/example/materialDatabase.js
@@ -83,7 +83,7 @@ async function init() {
 
 	envMapGenerator = new BlurredEnvMapGenerator( renderer );
 
-	const envMapPromise = new RGBELoader()
+	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/master/hdri/autoshop_01_1k.hdr' )
 		.then( texture => {
 

--- a/example/renderVideo.js
+++ b/example/renderVideo.js
@@ -126,7 +126,7 @@ async function init() {
 	videoEl.style.display = 'none';
 
 	// model models and environment map
-	const envMapPromise = new RGBELoader()
+	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/master/hdri/phalzer_forest_01_1k.hdr' )
 		.then( texture => {
 

--- a/example/skinnedMesh.js
+++ b/example/skinnedMesh.js
@@ -76,7 +76,7 @@ async function init() {
 	clock = new THREE.Clock();
 
 	// loading the
-	const envMapPromise = new RGBELoader()
+	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -112,7 +112,7 @@ async function init() {
 	samplesEl = document.getElementById( 'samples' );
 
 	// load the env map
-	const envMapPromise = new RGBELoader()
+	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/src/uniforms/EquirectHdrInfoUniform.js
+++ b/src/uniforms/EquirectHdrInfoUniform.js
@@ -2,15 +2,16 @@ import { DataTexture, FloatType, RedFormat, LinearFilter, DataUtils, HalfFloatTy
 
 function binarySearchFindClosestIndexOf( array, targetValue, offset = 0, count = array.length ) {
 
-	let lower = 0;
-	let upper = count - 1;
+	let lower = offset;
+	let upper = offset + count - 1;
+
 	while ( lower < upper ) {
 
-		const mid = ~ ~ ( 0.5 * upper + 0.5 * lower );
+		const mid = ( lower + upper ) >> 1;
 
 		// check if the middle array value is above or below the target and shift
 		// which half of the array we're looking at
-		if ( array[ offset + mid ] < targetValue ) {
+		if ( array[ mid ] < targetValue ) {
 
 			lower = mid + 1;
 
@@ -22,7 +23,7 @@ function binarySearchFindClosestIndexOf( array, targetValue, offset = 0, count =
 
 	}
 
-	return lower;
+	return lower - offset;
 
 }
 

--- a/src/uniforms/EquirectHdrInfoUniform.js
+++ b/src/uniforms/EquirectHdrInfoUniform.js
@@ -7,6 +7,9 @@ function binarySearchFindClosestIndexOf( array, targetValue, offset = 0, count =
 
 	while ( lower < upper ) {
 
+		// calculate the midpoint for this iteration using a bitwise shift right operator to save 1 floating point multiplication
+		// and 1 truncation from the double tilde operator to improve performance
+		// this results in much better performance over using standard "~ ~ ( (lower + upper) ) / 2" to calculate the midpoint
 		const mid = ( lower + upper ) >> 1;
 
 		// check if the middle array value is above or below the target and shift


### PR DESCRIPTION
By default, the RGBELoader uses `HalfFloatType` to load HDRs:
https://github.com/mrdoob/three.js/blob/dc9570226cf8e541cc71dfebf16f19935dabb74d/examples/jsm/loaders/RGBELoader.js#L19

The HDRs from polyhaven (which are used in the examples) have 32-bits per channel. This fixes the issue of losing precision when loading a 32-bit HDR with the RGBELoader by setting its data type to `FloatType`.

The other fix speeds up the `binarySearchFindClosestIndexOf` function in `EquirectHdrInfoUniform` by changing some offsets and using a different way to calculate the `mid` variable. The most significant optimization (thanks to ChatGPT 😄) is changing
```javascript
const mid = ~ ~ ( 0.5 * upper + 0.5 * lower );
```

to

```javascript
const mid = ( lower + upper ) >> 1;
```

For comparison, updating `EquirectHdrInfoUniform` for a 4096x2048 HDR on my CPU took ~900ms using the old method. With the new method it's ~400ms.

Besides that I could also move the calculation of the weights for MIS in `EquirectHdrInfoUniform` to a worker. For small environment maps (e.g. 1K) it doesn't seem to make sense because without workers I get ~30ms and with workers I get ~120ms. Looks like moving the env map image data as well as the weights arrays between threads is the bottleneck. For higher HDRs it would make sense since calculating the weights on the main thread would freeze the application for hundreds of ms.
Let me know what you'd think of using workers, I'd have a ready implementation.