### PR TITLE
add .js to glsl import path

### DIFF
--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -31,7 +31,7 @@ import { lightSamplingGLSL } from '../../shader/sampling/lightSampling.glsl.js';
 import { shapeSamplingGLSL } from '../../shader/sampling/shapeSampling.glsl.js';
 
 // common glsl
-import { intersectShapesGLSL } from '../../shader/common/intersectShapes.glsl';
+import { intersectShapesGLSL } from '../../shader/common/intersectShapes.glsl.js';
 import { mathGLSL } from '../../shader/common/math.glsl.js';
 import { utilsGLSL } from '../../shader/common/utils.glsl.js';
 import { fresnelGLSL } from '../../shader/common/fresnel.glsl.js';


### PR DESCRIPTION
Hi Garrett,

I'm upgrading three-gpu-pathtracer in polygonjs, and got an error where a .glsl file import path was not found. I believe this is due because my webpack config is set to import `.glsl` files as raw, and it will therefore not try and find a matching `.glsl.js` file.

So this PR adds the `.js` suffix to match with the other import statements.