### PR TITLE
Add debug mode flag to show expense of the material

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ export * from './utils/IESLoader.js';
 
 // materials
 export * from './materials/fullscreen/DenoiseMaterial.js';
+export * from './materials/fullscreen/GradientMapMaterial.js';
 export * from './materials/debug/GraphMaterial.js';
 export * from './materials/MaterialBase.js';
 export * from './materials/pathtracing/PhysicalPathTracingMaterial.js';

--- a/src/materials/fullscreen/GradientMapMaterial.js
+++ b/src/materials/fullscreen/GradientMapMaterial.js
@@ -7,6 +7,12 @@ export class GradientMapMaterial extends MaterialBase {
 
 		super( {
 
+			defines: {
+
+				FEATURE_BIN: 0,
+
+			},
+
 			uniforms: {
 
 				map: { value: null },
@@ -48,8 +54,14 @@ export class GradientMapMaterial extends MaterialBase {
 				void main() {
 
 					float value = texture( map, vUv )[ field ];
-					float t = smoothstep( minValue, maxValue, value );
 
+					#if FEATURE_BIN
+
+					value = ceil( value );
+
+					#endif
+
+					float t = smoothstep( minValue, maxValue, value );
 					gl_FragColor.rgb = vec3( mix( minColor, maxColor, t ) );
 					gl_FragColor.a = 1.0;
 

--- a/src/materials/fullscreen/GradientMapMaterial.js
+++ b/src/materials/fullscreen/GradientMapMaterial.js
@@ -1,7 +1,7 @@
-import { NoBlending } from 'three';
+import { Color, NoBlending } from 'three';
 import { MaterialBase } from '../MaterialBase.js';
 
-export class AlphaDisplayMaterial extends MaterialBase {
+export class GradientMapMaterial extends MaterialBase {
 
 	constructor( parameters ) {
 
@@ -10,6 +10,12 @@ export class AlphaDisplayMaterial extends MaterialBase {
 			uniforms: {
 
 				map: { value: null },
+
+				minColor: { value: new Color( 0 ) },
+				minValue: { value: 0 },
+
+				maxColor: { value: new Color( 0xffffff ) },
+				maxValue: { value: 10 },
 
 			},
 
@@ -29,12 +35,19 @@ export class AlphaDisplayMaterial extends MaterialBase {
 			fragmentShader: /* glsl */`
 
 				uniform sampler2D map;
+				uniform vec3 minColor;
+				uniform float minValue;
+				uniform vec3 maxColor;
+				uniform float maxValue;
 
 				varying vec2 vUv;
 
 				void main() {
 
-					gl_FragColor = vec4( texture( map, vUv ).a );
+					float value = texture( map, vUv ).r;
+					float t = smoothstep( minValue, maxValue, value );
+
+					gl_FragColor.rgb = vec3( mix( minColor, maxColor, t ) )x``;
 					gl_FragColor.a = 1.0;
 
 					#include <encodings_fragment>

--- a/src/materials/fullscreen/GradientMapMaterial.js
+++ b/src/materials/fullscreen/GradientMapMaterial.js
@@ -24,6 +24,7 @@ export class GradientMapMaterial extends MaterialBase {
 				maxValue: { value: 10 },
 
 				field: { value: 0 },
+				power: { value: 1 },
 
 			},
 
@@ -48,6 +49,7 @@ export class GradientMapMaterial extends MaterialBase {
 				uniform vec3 maxColor;
 				uniform float maxValue;
 				uniform int field;
+				uniform float power;
 
 				varying vec2 vUv;
 
@@ -62,6 +64,8 @@ export class GradientMapMaterial extends MaterialBase {
 					#endif
 
 					float t = smoothstep( minValue, maxValue, value );
+					t = pow( t, power );
+
 					gl_FragColor.rgb = vec3( mix( minColor, maxColor, t ) );
 					gl_FragColor.a = 1.0;
 

--- a/src/materials/fullscreen/GradientMapMaterial.js
+++ b/src/materials/fullscreen/GradientMapMaterial.js
@@ -17,6 +17,8 @@ export class GradientMapMaterial extends MaterialBase {
 				maxColor: { value: new Color( 0xffffff ) },
 				maxValue: { value: 10 },
 
+				field: { value: 0 },
+
 			},
 
 			blending: NoBlending,
@@ -39,20 +41,21 @@ export class GradientMapMaterial extends MaterialBase {
 				uniform float minValue;
 				uniform vec3 maxColor;
 				uniform float maxValue;
+				uniform int field;
 
 				varying vec2 vUv;
 
 				void main() {
 
-					float value = texture( map, vUv ).r;
+					float value = texture( map, vUv )[ field ];
 					float t = smoothstep( minValue, maxValue, value );
 
-					gl_FragColor.rgb = vec3( mix( minColor, maxColor, t ) )x``;
+					gl_FragColor.rgb = vec3( mix( minColor, maxColor, t ) );
 					gl_FragColor.a = 1.0;
 
 					#include <encodings_fragment>
 
-				}`
+				}`,
 
 		} );
 

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -609,7 +609,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 					gl_FragColor.a *= opacity;
 
-					#if DEBUG_MODE == 0
+					#if DEBUG_MODE == 1
 
 					// output the number of rays checked in the path and number of
 					// transmissive rays encountered.

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -76,6 +76,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				// 2 = Equirectangular
 				CAMERA_TYPE: 0,
 
+				DEBUG_MODE: 0,
+
 				ATTR_NORMAL: 0,
 				ATTR_TANGENT: 1,
 				ATTR_UV: 2,
@@ -273,6 +275,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 					// path tracing state
 					RenderState state = initRenderState();
+					state.transmissiveTraversals = transmissiveBounces;
 
 					Material fogMaterial;
 					#if FEATURE_FOG
@@ -605,6 +608,19 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 					}
 
 					gl_FragColor.a *= opacity;
+
+					#if DEBUG_MODE == 0
+
+					// output the number of rays checked in the path and number of
+					// transmissive rays encountered.
+					gl_FragColor.rgb = vec3(
+						float( state.depth ),
+						transmissiveBounces - state.transmissiveTraversals,
+						0.0
+					) * 0.1;
+					gl_FragColor.a = 1.0;
+
+					#endif
 
 				}
 

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -617,7 +617,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						float( state.depth ),
 						transmissiveBounces - state.transmissiveTraversals,
 						0.0
-					) * 0.1;
+					);
 					gl_FragColor.a = 1.0;
 
 					#endif

--- a/src/materials/pathtracing/glsl/traceScene.glsl.js
+++ b/src/materials/pathtracing/glsl/traceScene.glsl.js
@@ -22,9 +22,9 @@ export const traceSceneGLSL = /* glsl */`
 			float particleDist = intersectFogVolume( fogMaterial, sobol( 1 ) );
 			if ( particleDist + 1e-4 < geoHit.dist && ( particleDist + 1e-4 < lightSampleRec.dist || ! lightHit ) ) {
 
-				side = 1.0;
-				faceNormal = normalize( - rayDirection );
-				dist = particleDist;
+				geoHit.side = 1.0;
+				geoHit.faceNormal = normalize( - ray.direction );
+				geoHit.dist = particleDist;
 				return FOG_HIT;
 
 			}


### PR DESCRIPTION
**TODO**
- [x] Confirm the accumulated results (read back pixels)

Note it looks like sometimes the scatter ray is going below the surface with very rough materials:

<img width="616" alt="image" src="https://user-images.githubusercontent.com/734200/225313057-8f8293d6-b925-47c0-9366-97b12f728e56.png">
