### PR TITLE
add PhysicalCamera.copy

### DIFF
--- a/src/objects/EquirectCamera.js
+++ b/src/objects/EquirectCamera.js
@@ -10,11 +10,12 @@ export class EquirectCamera extends Camera {
 
 	}
 
-	copy(source, recursive) {
-		super.copy(source, recursive);
+	copy( source, recursive ) {
+		super.copy( source, recursive );
 
 		this.isEquirectCamera = source.isEquirectCamera;
 
 		return this;
 	}
+
 }

--- a/src/objects/EquirectCamera.js
+++ b/src/objects/EquirectCamera.js
@@ -11,11 +11,13 @@ export class EquirectCamera extends Camera {
 	}
 
 	copy( source, recursive ) {
+
 		super.copy( source, recursive );
 
 		this.isEquirectCamera = source.isEquirectCamera;
 
 		return this;
+
 	}
 
 }

--- a/src/objects/EquirectCamera.js
+++ b/src/objects/EquirectCamera.js
@@ -10,14 +10,4 @@ export class EquirectCamera extends Camera {
 
 	}
 
-	copy( source, recursive ) {
-
-		super.copy( source, recursive );
-
-		this.isEquirectCamera = source.isEquirectCamera;
-
-		return this;
-
-	}
-
 }

--- a/src/objects/EquirectCamera.js
+++ b/src/objects/EquirectCamera.js
@@ -10,4 +10,11 @@ export class EquirectCamera extends Camera {
 
 	}
 
+	copy(source, recursive) {
+		super.copy(source, recursive);
+
+		this.isEquirectCamera = source.isEquirectCamera;
+
+		return this;
+	}
 }

--- a/src/objects/PhysicalCamera.js
+++ b/src/objects/PhysicalCamera.js
@@ -25,8 +25,8 @@ export class PhysicalCamera extends PerspectiveCamera {
 
 	}
 
-	copy(source, recursive) {
-		super.copy(source, recursive);
+	copy( source, recursive ) {
+		super.copy( source, recursive );
 
 		this.fStop = source.fStop;
 		this.apertureBlades = source.apertureBlades;

--- a/src/objects/PhysicalCamera.js
+++ b/src/objects/PhysicalCamera.js
@@ -25,4 +25,16 @@ export class PhysicalCamera extends PerspectiveCamera {
 
 	}
 
+	copy(source, recursive) {
+		super.copy(source, recursive);
+
+		this.fStop = source.fStop;
+		this.apertureBlades = source.apertureBlades;
+		this.apertureRotation = source.apertureRotation;
+		this.focusDistance = source.focusDistance;
+		this.anamorphicRatio = source.anamorphicRatio;
+
+		return this;
+	}
+
 }

--- a/src/objects/PhysicalCamera.js
+++ b/src/objects/PhysicalCamera.js
@@ -26,6 +26,7 @@ export class PhysicalCamera extends PerspectiveCamera {
 	}
 
 	copy( source, recursive ) {
+
 		super.copy( source, recursive );
 
 		this.fStop = source.fStop;
@@ -35,6 +36,7 @@ export class PhysicalCamera extends PerspectiveCamera {
 		this.anamorphicRatio = source.anamorphicRatio;
 
 		return this;
+
 	}
 
 }

--- a/src/objects/PhysicalSpotLight.js
+++ b/src/objects/PhysicalSpotLight.js
@@ -11,4 +11,12 @@ export class PhysicalSpotLight extends SpotLight {
 
 	}
 
+	copy(source, recursive) {
+		super.copy(source, recursive);
+
+		this.iesTexture = source.iesTexture;
+		this.radius = source.radius;
+
+		return this;
+	}
 }

--- a/src/objects/PhysicalSpotLight.js
+++ b/src/objects/PhysicalSpotLight.js
@@ -12,12 +12,14 @@ export class PhysicalSpotLight extends SpotLight {
 	}
 
 	copy( source, recursive ) {
+
 		super.copy( source, recursive );
 
 		this.iesTexture = source.iesTexture;
 		this.radius = source.radius;
 
 		return this;
+
 	}
 
 }

--- a/src/objects/PhysicalSpotLight.js
+++ b/src/objects/PhysicalSpotLight.js
@@ -11,12 +11,13 @@ export class PhysicalSpotLight extends SpotLight {
 
 	}
 
-	copy(source, recursive) {
-		super.copy(source, recursive);
+	copy( source, recursive ) {
+		super.copy( source, recursive );
 
 		this.iesTexture = source.iesTexture;
 		this.radius = source.radius;
 
 		return this;
 	}
+
 }

--- a/src/objects/ShapedAreaLight.js
+++ b/src/objects/ShapedAreaLight.js
@@ -10,11 +10,13 @@ export class ShapedAreaLight extends RectAreaLight {
 	}
 
 	copy( source, recursive ) {
+
 		super.copy( source, recursive );
 
 		this.isCircular = source.isCircular;
 
 		return this;
+
 	}
 
 }

--- a/src/objects/ShapedAreaLight.js
+++ b/src/objects/ShapedAreaLight.js
@@ -9,8 +9,8 @@ export class ShapedAreaLight extends RectAreaLight {
 
 	}
 
-	copy(source, recursive) {
-		super.copy(source, recursive);
+	copy( source, recursive ) {
+		super.copy( source, recursive );
 
 		this.isCircular = source.isCircular;
 

--- a/src/objects/ShapedAreaLight.js
+++ b/src/objects/ShapedAreaLight.js
@@ -9,4 +9,12 @@ export class ShapedAreaLight extends RectAreaLight {
 
 	}
 
+	copy(source, recursive) {
+		super.copy(source, recursive);
+
+		this.isCircular = source.isCircular;
+
+		return this;
+	}
+
 }


### PR DESCRIPTION
Hi Garrett,

In Polygonjs I make heavy use of `Object3D.copy` when transferring objects between nodes. So in this case, I've added `.copy` on `PhysicalCamera` to make sure its properties are properly carried down the node tree.

Hope that doesn't had an unnecessary method for you.