### PR TITLE
Replace 'lights' param with global uniform in 'traceScene'. Closes #456

### DIFF
--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -301,7 +301,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						state.firstRay = i == 0 && state.transmissiveTraversals == transmissiveBounces;
 
 						int hitType = traceScene(
-							ray, bvh, state.fogMaterial,
+							ray, state.fogMaterial,
 							surfaceHit, lightRec
 						);
 

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -301,7 +301,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						state.firstRay = i == 0 && state.transmissiveTraversals == transmissiveBounces;
 
 						int hitType = traceScene(
-							ray, bvh, lights, state.fogMaterial,
+							ray, bvh, state.fogMaterial,
 							surfaceHit, lightRec
 						);
 

--- a/src/materials/pathtracing/glsl/attenuateHit.glsl.js
+++ b/src/materials/pathtracing/glsl/attenuateHit.glsl.js
@@ -26,7 +26,7 @@ export const attenuateHitGLSL = /* glsl */`
 		for ( int i = 0; i < traversals; i ++ ) {
 
 			int hitType = traceScene(
-				ray, bvh, lights, fogMaterial,
+				ray, bvh, fogMaterial,
 				surfaceHit, lightRec
 			);
 

--- a/src/materials/pathtracing/glsl/attenuateHit.glsl.js
+++ b/src/materials/pathtracing/glsl/attenuateHit.glsl.js
@@ -26,7 +26,7 @@ export const attenuateHitGLSL = /* glsl */`
 		for ( int i = 0; i < traversals; i ++ ) {
 
 			int hitType = traceScene(
-				ray, bvh, fogMaterial,
+				ray, fogMaterial,
 				surfaceHit, lightRec
 			);
 

--- a/src/materials/pathtracing/glsl/traceScene.glsl.js
+++ b/src/materials/pathtracing/glsl/traceScene.glsl.js
@@ -5,9 +5,12 @@ export const traceSceneGLSL = /* glsl */`
 	#define LIGHT_HIT 2
 	#define FOG_HIT 3
 
+	// Passing the global variable 'lights' into this function caused shader program errors.
+	// So global variables like 'lights' and 'bvh' were moved out of the function parameters.
+	// For more information, refer to: https://github.com/gkjohnson/three-gpu-pathtracer/pull/457
 	int traceScene(
 
-		Ray ray, BVH bvh, Material fogMaterial,
+		Ray ray, Material fogMaterial,
 		out SurfaceHit surfaceHit, out LightRecord lightRec
 
 	) {

--- a/src/materials/pathtracing/glsl/traceScene.glsl.js
+++ b/src/materials/pathtracing/glsl/traceScene.glsl.js
@@ -7,7 +7,7 @@ export const traceSceneGLSL = /* glsl */`
 
 	int traceScene(
 
-		Ray ray, BVH bvh, LightsInfo lights, Material fogMaterial,
+		Ray ray, BVH bvh, Material fogMaterial,
 		out SurfaceHit surfaceHit, out LightRecord lightRec
 
 	) {


### PR DESCRIPTION
Seems weird, but I figured out the `lights` param in `traceScene` causes the error. (I've checked the shaders are compiled well, but after `gl.linkProgram()`, the `LINK_STATUS` is false. (As I reported to the linked issue, in my device Macbook Pro 13, 2020)

In the shader, only two functions call `traceScene()`. The one in `main` function works but when calling `traceScene()` in `attenuateHit()` with the `lights` param, the error occurs. Do you have any idea why this problem happens? I'm still wondering.

It's not a fundamental solution, but I tried removing the parameter and replace it with the global uniform `lights`. Then I could see finally it's working on my device, but I wonder if using the global uniform is fine. Please let me know if you expect any problem with this commit. I'll try to find another solution. Thank you.