### PR TITLE
iOS modifications

### DIFF
--- a/example/aoRender.js
+++ b/example/aoRender.js
@@ -49,10 +49,13 @@ async function init() {
 
 	samplesEl = document.getElementById( 'samples' );
 
-	// initialize render targs
-	target1 = new THREE.WebGLRenderTarget( 1, 1, { type: THREE.HalfFloatType, encoding: THREE.LinearEncoding } );
+	// will be null if extension not supported
+	const floatLinearExtensionSupported = renderer.extensions.get( 'OES_texture_float_linear' );
 
-	target2 = new THREE.WebGLRenderTarget( 1, 1, { type: THREE.HalfFloatType, encoding: THREE.LinearEncoding } );
+	// initialize render targs
+	target1 = new THREE.WebGLRenderTarget( 1, 1, { type: floatLinearExtensionSupported ? THREE.FloatType : THREE.HalfFloatType, encoding: THREE.LinearEncoding } );
+
+	target2 = new THREE.WebGLRenderTarget( 1, 1, { type: floatLinearExtensionSupported ? THREE.FloatType : THREE.HalfFloatType, encoding: THREE.LinearEncoding } );
 
 	materials = [];
 

--- a/example/aoRender.js
+++ b/example/aoRender.js
@@ -50,9 +50,9 @@ async function init() {
 	samplesEl = document.getElementById( 'samples' );
 
 	// initialize render targs
-	target1 = new THREE.WebGLRenderTarget( 1, 1, { type: THREE.FloatType, encoding: THREE.LinearEncoding } );
+	target1 = new THREE.WebGLRenderTarget( 1, 1, { type: THREE.HalfFloatType, encoding: THREE.LinearEncoding } );
 
-	target2 = new THREE.WebGLRenderTarget( 1, 1, { type: THREE.FloatType, encoding: THREE.LinearEncoding } );
+	target2 = new THREE.WebGLRenderTarget( 1, 1, { type: THREE.HalfFloatType, encoding: THREE.LinearEncoding } );
 
 	materials = [];
 

--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -95,7 +95,7 @@ async function init() {
 	samplesEl = document.getElementById( 'samples' );
 	loadingEl = document.getElementById( 'loading' );
 
-	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
+	const envMapPromise = new RGBELoader()
 		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/master/hdri/leadenhall_market_1k.hdr' )
 		.then( texture => {
 

--- a/example/basic.js
+++ b/example/basic.js
@@ -63,7 +63,7 @@ async function init() {
 	} );
 
 	// load the envmap and model
-	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
+	const envMapPromise = new RGBELoader()
 		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/master/hdri/chinese_garden_1k.hdr' )
 		.then( texture => {
 
@@ -143,16 +143,18 @@ function animate() {
 	camera.updateMatrixWorld();
 	pathTracer.update();
 
-	if ( pathTracer.samples < 1 ) {
+	if (pathTracer.samples < 1) {
 
-		renderer.render( scene, camera );
+		renderer.render(scene, camera);
 
+	} else {
+
+		renderer.autoClear = false;
+		blitQuad.material.map = pathTracer.target.texture;
+		blitQuad.render(renderer);
+		renderer.autoClear = true;
+		
 	}
-
-	renderer.autoClear = false;
-	blitQuad.material.map = pathTracer.target.texture;
-	blitQuad.render( renderer );
-	renderer.autoClear = true;
 
 	samplesEl.innerText = `Samples: ${ Math.floor( pathTracer.samples ) }`;
 

--- a/example/basic.js
+++ b/example/basic.js
@@ -143,18 +143,16 @@ function animate() {
 	camera.updateMatrixWorld();
 	pathTracer.update();
 
-	if (pathTracer.samples < 1) {
+	if ( pathTracer.samples < 1 ) {
 
-		renderer.render(scene, camera);
+		renderer.render( scene, camera );
 
-	} else {
-
-		renderer.autoClear = false;
-		blitQuad.material.map = pathTracer.target.texture;
-		blitQuad.render(renderer);
-		renderer.autoClear = true;
-		
 	}
+
+	renderer.autoClear = false;
+	blitQuad.material.map = pathTracer.target.texture;
+	blitQuad.render( renderer );
+	renderer.autoClear = true;
 
 	samplesEl.innerText = `Samples: ${ Math.floor( pathTracer.samples ) }`;
 

--- a/example/depthOfField.js
+++ b/example/depthOfField.js
@@ -80,7 +80,7 @@ async function init() {
 
 	samplesEl = document.getElementById( 'samples' );
 
-	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
+	const envMapPromise = new RGBELoader()
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/example/index.js
+++ b/example/index.js
@@ -16,7 +16,7 @@ import {
 	OrthographicCamera,
 	MeshBasicMaterial,
 	sRGBEncoding,
-	CustomBlending,
+	CustomBlending
 } from 'three';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';

--- a/example/index.js
+++ b/example/index.js
@@ -17,7 +17,6 @@ import {
 	MeshBasicMaterial,
 	sRGBEncoding,
 	CustomBlending,
-	FloatType
 } from 'three';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
@@ -467,7 +466,7 @@ function buildGui() {
 
 function updateEnvMap() {
 
-	new RGBELoader().setDataType( FloatType )
+	new RGBELoader()
 		.load( params.envMap, texture => {
 
 			if ( scene.environmentMap ) {

--- a/example/interior.js
+++ b/example/interior.js
@@ -98,7 +98,7 @@ async function init() {
 
 	samplesEl = document.getElementById( 'samples' );
 
-	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
+	const envMapPromise = new RGBELoader()
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/example/iridescenceTest.js
+++ b/example/iridescenceTest.js
@@ -78,7 +78,7 @@ async function init() {
 	const BASE_URL = 'https://raw.githubusercontent.com/google/model-viewer/master/packages/render-fidelity-tools/test/config/';
 	const envUrl = new URL( '../../../shared-assets/environments/lightroom_14b.hdr', BASE_URL ).toString();
 
-	await new RGBELoader().setDataType( THREE.FloatType )
+	await new RGBELoader()
 		.loadAsync( envUrl )
 		.then( texture => {
 

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -166,7 +166,7 @@ async function init() {
 	} );
 
 	// load the environment map
-	new RGBELoader().setDataType( FloatType )
+	new RGBELoader()
 		.load( ENVMAP_URL, texture => {
 
 			texture.mapping = EquirectangularReflectionMapping;

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -16,8 +16,7 @@ import {
 	CustomBlending,
 	EquirectangularReflectionMapping,
 	MathUtils,
-	Vector4,
-	FloatType
+	Vector4
 } from 'three';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { LDrawLoader } from 'three/examples/jsm/loaders/LDrawLoader.js';

--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -202,7 +202,7 @@ async function init() {
 
 	envMapGenerator = new BlurredEnvMapGenerator( renderer );
 
-	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
+	const envMapPromise = new RGBELoader()
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/example/materialDatabase.js
+++ b/example/materialDatabase.js
@@ -83,7 +83,7 @@ async function init() {
 
 	envMapGenerator = new BlurredEnvMapGenerator( renderer );
 
-	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
+	const envMapPromise = new RGBELoader()
 		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/master/hdri/autoshop_01_1k.hdr' )
 		.then( texture => {
 

--- a/example/renderVideo.js
+++ b/example/renderVideo.js
@@ -126,7 +126,7 @@ async function init() {
 	videoEl.style.display = 'none';
 
 	// model models and environment map
-	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
+	const envMapPromise = new RGBELoader()
 		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/master/hdri/phalzer_forest_01_1k.hdr' )
 		.then( texture => {
 

--- a/example/skinnedMesh.js
+++ b/example/skinnedMesh.js
@@ -76,7 +76,7 @@ async function init() {
 	clock = new THREE.Clock();
 
 	// loading the
-	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
+	const envMapPromise = new RGBELoader()
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -112,7 +112,7 @@ async function init() {
 	samplesEl = document.getElementById( 'samples' );
 
 	// load the env map
-	const envMapPromise = new RGBELoader().setDataType( THREE.FloatType )
+	const envMapPromise = new RGBELoader()
 		.loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/textures/equirectangular/royal_esplanade_1k.hdr' )
 		.then( texture => {
 

--- a/src/core/PathTracingRenderer.js
+++ b/src/core/PathTracingRenderer.js
@@ -1,4 +1,4 @@
-import { RGBAFormat, FloatType, Color, Vector2, WebGLRenderTarget, NoBlending, NormalBlending, Vector4 } from 'three';
+import { RGBAFormat, HalfFloatType, Color, Vector2, WebGLRenderTarget, NoBlending, NormalBlending, Vector4 } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { BlendMaterial } from '../materials/fullscreen/BlendMaterial.js';
 import { SobolNumberMapGenerator } from '../utils/SobolNumberMapGenerator.js';
@@ -252,16 +252,16 @@ export class PathTracingRenderer {
 		this._sobolTarget = new SobolNumberMapGenerator().generate( renderer );
 		this._primaryTarget = new WebGLRenderTarget( 1, 1, {
 			format: RGBAFormat,
-			type: FloatType,
+			type: HalfFloatType,
 		} );
 		this._blendTargets = [
 			new WebGLRenderTarget( 1, 1, {
 				format: RGBAFormat,
-				type: FloatType,
+				type: HalfFloatType,
 			} ),
 			new WebGLRenderTarget( 1, 1, {
 				format: RGBAFormat,
-				type: FloatType,
+				type: HalfFloatType,
 			} ),
 		];
 

--- a/src/core/PathTracingRenderer.js
+++ b/src/core/PathTracingRenderer.js
@@ -1,4 +1,4 @@
-import { RGBAFormat, HalfFloatType, Color, Vector2, WebGLRenderTarget, NoBlending, NormalBlending, Vector4 } from 'three';
+import { RGBAFormat, FloatType, HalfFloatType, Color, Vector2, WebGLRenderTarget, NoBlending, NormalBlending, Vector4 } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { BlendMaterial } from '../materials/fullscreen/BlendMaterial.js';
 import { SobolNumberMapGenerator } from '../utils/SobolNumberMapGenerator.js';
@@ -250,18 +250,22 @@ export class PathTracingRenderer {
 		this._currentTile = 0;
 
 		this._sobolTarget = new SobolNumberMapGenerator().generate( renderer );
+
+		// will be null if extension not supported
+		const floatLinearExtensionSupported = renderer.extensions.get( 'OES_texture_float_linear' );
+
 		this._primaryTarget = new WebGLRenderTarget( 1, 1, {
 			format: RGBAFormat,
-			type: HalfFloatType,
+			type: floatLinearExtensionSupported ? FloatType : HalfFloatType,
 		} );
 		this._blendTargets = [
 			new WebGLRenderTarget( 1, 1, {
 				format: RGBAFormat,
-				type: HalfFloatType,
+				type: floatLinearExtensionSupported ? FloatType : HalfFloatType,
 			} ),
 			new WebGLRenderTarget( 1, 1, {
 				format: RGBAFormat,
-				type: HalfFloatType,
+				type: floatLinearExtensionSupported ? FloatType : HalfFloatType,
 			} ),
 		];
 

--- a/src/textures/ProceduralEquirectTexture.js
+++ b/src/textures/ProceduralEquirectTexture.js
@@ -54,10 +54,10 @@ export class ProceduralEquirectTexture extends DataTexture {
 
 				const i = y * width + x;
 				const i4 = 4 * i;
-				data[ i4 + 0 ] = DataUtils.toHalfFloat(_color.r);
-				data[ i4 + 1 ] = DataUtils.toHalfFloat(_color.g);
-				data[ i4 + 2 ] = DataUtils.toHalfFloat(_color.b);
-				data[ i4 + 3 ] = DataUtils.toHalfFloat(1.0);
+				data[ i4 + 0 ] = DataUtils.toHalfFloat( _color.r );
+				data[ i4 + 1 ] = DataUtils.toHalfFloat( _color.g );
+				data[ i4 + 2 ] = DataUtils.toHalfFloat( _color.b );
+				data[ i4 + 3 ] = DataUtils.toHalfFloat( 1.0 );
 
 			}
 

--- a/src/textures/ProceduralEquirectTexture.js
+++ b/src/textures/ProceduralEquirectTexture.js
@@ -2,8 +2,9 @@ import {
 	ClampToEdgeWrapping,
 	Color,
 	DataTexture,
+	DataUtils,
 	EquirectangularReflectionMapping,
-	FloatType,
+	HalfFloatType,
 	LinearFilter,
 	RepeatWrapping,
 	RGBAFormat,
@@ -20,8 +21,8 @@ export class ProceduralEquirectTexture extends DataTexture {
 	constructor( width = 512, height = 512 ) {
 
 		super(
-			new Float32Array( width * height * 4 ),
-			width, height, RGBAFormat, FloatType, EquirectangularReflectionMapping,
+			new Uint16Array( width * height * 4 ),
+			width, height, RGBAFormat, HalfFloatType, EquirectangularReflectionMapping,
 			RepeatWrapping, ClampToEdgeWrapping, LinearFilter, LinearFilter,
 		);
 
@@ -53,10 +54,10 @@ export class ProceduralEquirectTexture extends DataTexture {
 
 				const i = y * width + x;
 				const i4 = 4 * i;
-				data[ i4 + 0 ] = _color.r;
-				data[ i4 + 1 ] = _color.g;
-				data[ i4 + 2 ] = _color.b;
-				data[ i4 + 3 ] = 1.0;
+				data[ i4 + 0 ] = DataUtils.toHalfFloat(_color.r);
+				data[ i4 + 1 ] = DataUtils.toHalfFloat(_color.g);
+				data[ i4 + 2 ] = DataUtils.toHalfFloat(_color.b);
+				data[ i4 + 3 ] = DataUtils.toHalfFloat(1.0);
 
 			}
 

--- a/src/uniforms/EquirectHdrInfoUniform.js
+++ b/src/uniforms/EquirectHdrInfoUniform.js
@@ -1,4 +1,5 @@
 import { DataTexture, RedFormat, LinearFilter, DataUtils, HalfFloatType, Source, RepeatWrapping, RGBAFormat } from 'three';
+import { toHalfFloatArray } from '../utils/TextureUtils.js';
 
 function binarySearchFindClosestIndexOf( array, targetValue, offset = 0, count = array.length ) {
 
@@ -89,19 +90,6 @@ function preprocessEnvMap( envMap ) {
 	}
 
 	return map;
-
-}
-
-function toHalfFloatArray( f32Array ) {
-
-	const f16Array = new Uint16Array( f32Array.length );
-	for ( let i = 0, n = f32Array.length; i < n; ++ i ) {
-
-		f16Array[ i ] = DataUtils.toHalfFloat( f32Array[ i ] );
-
-	}
-
-	return f16Array;
 
 }
 

--- a/src/uniforms/EquirectHdrInfoUniform.js
+++ b/src/uniforms/EquirectHdrInfoUniform.js
@@ -99,7 +99,7 @@ export class EquirectHdrInfoUniform {
 
 		// Default to a white texture and associated weights so we don't
 		// just render black initially.
-		const whiteTex = new DataTexture( toHalfFloatArray(new Float32Array( [ 1, 1, 1, 1 ] )), 1, 1 );
+		const whiteTex = new DataTexture( toHalfFloatArray( new Float32Array( [ 1, 1, 1, 1 ] ) ), 1, 1 );
 		whiteTex.type = HalfFloatType;
 		whiteTex.format = RGBAFormat;
 		whiteTex.minFilter = LinearFilter;
@@ -111,7 +111,7 @@ export class EquirectHdrInfoUniform {
 
 		// Stores a map of [0, 1] value -> cumulative importance row & pdf
 		// used to sampling a random value to a relevant row to sample from
-		const marginalWeights = new DataTexture( toHalfFloatArray(new Float32Array( [ 0, 1 ] )), 1, 2 );
+		const marginalWeights = new DataTexture( toHalfFloatArray( new Float32Array( [ 0, 1 ] ) ), 1, 2 );
 		marginalWeights.type = HalfFloatType;
 		marginalWeights.format = RedFormat;
 		marginalWeights.minFilter = LinearFilter;
@@ -121,7 +121,7 @@ export class EquirectHdrInfoUniform {
 
 		// Stores a map of [0, 1] value -> cumulative importance column & pdf
 		// used to sampling a random value to a relevant pixel to sample from
-		const conditionalWeights = new DataTexture( toHalfFloatArray(new Float32Array( [ 0, 0, 1, 1 ] )), 2, 2 );
+		const conditionalWeights = new DataTexture( toHalfFloatArray( new Float32Array( [ 0, 0, 1, 1 ] ) ), 2, 2 );
 		conditionalWeights.type = HalfFloatType;
 		conditionalWeights.format = RedFormat;
 		conditionalWeights.minFilter = LinearFilter;

--- a/src/uniforms/IESProfilesTexture.js
+++ b/src/uniforms/IESProfilesTexture.js
@@ -1,7 +1,7 @@
 import {
 	ClampToEdgeWrapping,
 	Color,
-	FloatType,
+	HalfFloatType,
 	LinearFilter,
 	MeshBasicMaterial,
 	NoToneMapping,
@@ -20,7 +20,7 @@ export class IESProfilesTexture extends WebGLArrayRenderTarget {
 
 		const tex = this.texture;
 		tex.format = RGBAFormat;
-		tex.type = FloatType;
+		tex.type = HalfFloatType;
 		tex.minFilter = LinearFilter;
 		tex.magFilter = LinearFilter;
 		tex.wrapS = ClampToEdgeWrapping;

--- a/src/uniforms/LightsInfoUniformStruct.js
+++ b/src/uniforms/LightsInfoUniformStruct.js
@@ -1,4 +1,4 @@
-import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, Vector3, Quaternion, Matrix4 } from 'three';
+import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, Vector3, Quaternion, Matrix4, NearestFilter } from 'three';
 
 const LIGHT_PIXELS = 6;
 const RECT_AREA_LIGHT = 0;
@@ -16,6 +16,8 @@ export class LightsInfoUniformStruct {
 		tex.wrapS = ClampToEdgeWrapping;
 		tex.wrapT = ClampToEdgeWrapping;
 		tex.generateMipmaps = false;
+		tex.minFilter = NearestFilter;
+		tex.magFilter = NearestFilter;
 
 		this.tex = tex;
 		this.count = 0;

--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -1,4 +1,4 @@
-import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, FrontSide, BackSide, DoubleSide } from 'three';
+import { DataTexture, RGBAFormat, ClampToEdgeWrapping, FloatType, FrontSide, BackSide, DoubleSide, NearestFilter } from 'three';
 import { reduceTexturesToUniqueSources, getTextureHash } from './utils.js';
 
 const MATERIAL_PIXELS = 45;
@@ -53,6 +53,8 @@ export class MaterialsTexture extends DataTexture {
 		this.type = FloatType;
 		this.wrapS = ClampToEdgeWrapping;
 		this.wrapT = ClampToEdgeWrapping;
+		this.minFilter = NearestFilter;
+		this.magFilter = NearestFilter;
 		this.generateMipmaps = false;
 		this.threeCompatibilityTransforms = false;
 		this.features = new MaterialFeatures();

--- a/src/utils/BlurredEnvMapGenerator.js
+++ b/src/utils/BlurredEnvMapGenerator.js
@@ -1,4 +1,4 @@
-import { WebGLRenderTarget, RGBAFormat, FloatType, PMREMGenerator, DataTexture, EquirectangularReflectionMapping } from 'three';
+import { WebGLRenderTarget, DataUtils, RGBAFormat, FloatType, HalfFloatType, PMREMGenerator, DataTexture, EquirectangularReflectionMapping } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { MaterialBase } from '../materials/MaterialBase.js';
 import { utilsGLSL } from '../shader/common/utils.glsl.js';
@@ -58,7 +58,7 @@ export class BlurredEnvMapGenerator {
 		this.renderer = renderer;
 		this.pmremGenerator = new PMREMGenerator( renderer );
 		this.copyQuad = new FullScreenQuad( new PMREMCopyMaterial() );
-		this.renderTarget = new WebGLRenderTarget( 1, 1, { type: FloatType, format: RGBAFormat } );
+		this.renderTarget = new WebGLRenderTarget( 1, 1, { type: HalfFloatType, format: RGBAFormat } );
 
 	}
 
@@ -95,10 +95,10 @@ export class BlurredEnvMapGenerator {
 		renderer.autoClear = prevClear;
 
 		// read the data back
-		const buffer = new Float32Array( width * height * 4 );
+		const buffer = new Uint16Array( width * height * 4 );
 		renderer.readRenderTargetPixels( renderTarget, 0, 0, width, height, buffer );
 
-		const result = new DataTexture( buffer, width, height, RGBAFormat, FloatType );
+		const result = new DataTexture( buffer, width, height, RGBAFormat, HalfFloatType );
 		result.minFilter = texture.minFilter;
 		result.magFilter = texture.magFilter;
 		result.wrapS = texture.wrapS;

--- a/src/utils/BlurredEnvMapGenerator.js
+++ b/src/utils/BlurredEnvMapGenerator.js
@@ -1,4 +1,4 @@
-import { WebGLRenderTarget, DataUtils, RGBAFormat, FloatType, HalfFloatType, PMREMGenerator, DataTexture, EquirectangularReflectionMapping } from 'three';
+import { WebGLRenderTarget, RGBAFormat, HalfFloatType, PMREMGenerator, DataTexture, EquirectangularReflectionMapping } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { MaterialBase } from '../materials/MaterialBase.js';
 import { utilsGLSL } from '../shader/common/utils.glsl.js';

--- a/src/utils/IESLoader.js
+++ b/src/utils/IESLoader.js
@@ -1,12 +1,14 @@
 import {
 	DataTexture,
 	FileLoader,
-	FloatType,
+	HalfFloatType,
 	LinearFilter,
 	RedFormat,
 	MathUtils,
 	Loader,
 } from 'three';
+
+import { toHalfFloatArray } from './TextureUtils.js';
 
 function IESLamp( text ) {
 
@@ -286,7 +288,7 @@ export class IESLoader extends Loader {
 		loader.setPath( this.path );
 		loader.setRequestHeader( this.requestHeader );
 
-		const texture = new DataTexture( null, 360, 180, RedFormat, FloatType );
+		const texture = new DataTexture( null, 360, 180, RedFormat, HalfFloatType );
 		texture.minFilter = LinearFilter;
 		texture.magFilter = LinearFilter;
 
@@ -294,7 +296,7 @@ export class IESLoader extends Loader {
 
 			const iesLamp = new IESLamp( text );
 
-			texture.image.data = this._getIESValues( iesLamp );
+			texture.image.data = toHalfFloatArray( this._getIESValues( iesLamp ) );
 			texture.needsUpdate = true;
 
 			if ( onLoad !== undefined ) {
@@ -312,10 +314,10 @@ export class IESLoader extends Loader {
 	parse( text ) {
 
 		const iesLamp = new IESLamp( text );
-		const texture = new DataTexture( null, 360, 180, RedFormat, FloatType );
+		const texture = new DataTexture( null, 360, 180, RedFormat, HalfFloatType );
 		texture.minFilter = LinearFilter;
 		texture.magFilter = LinearFilter;
-		texture.image.data = this._getIESValues( iesLamp );
+		texture.image.data = toHalfFloatArray( this._getIESValues( iesLamp ) );
 		texture.needsUpdate = true;
 
 		return texture;

--- a/src/utils/TextureUtils.js
+++ b/src/utils/TextureUtils.js
@@ -1,0 +1,15 @@
+import { DataUtils } from 'three';
+
+
+export function toHalfFloatArray( f32Array ) {
+
+	const f16Array = new Uint16Array( f32Array.length );
+	for ( let i = 0, n = f32Array.length; i < n; ++ i ) {
+
+		f16Array[ i ] = DataUtils.toHalfFloat( f32Array[ i ] );
+
+	}
+
+	return f16Array;
+
+}


### PR DESCRIPTION
This PR modifies the library so that it can render on iPadOS / iOS. More specifically:

  - it changes most Float32 textures / buffers to Float16 (i.e. Float to HalfFloat)
  - it removes .setDataType( THREE.FloatType ) from HDR loader in examples
  - it fixes a couple of examples animate loop (standard three.js rendering was not working on iOS)

*important*: these modifications, at present, require also to disable Multiple Importance Sampling (MIS), otherwise the browser crashes, or there are shader compilation errors. This is also needed for the library to work on macOS, but has not been done in this PR, to avoid disabling MIS for other systems. If you are on a Mac or iOS device, you can disable MIS globally by adding the following line:

`this.setDefine('FEATURE_MIS', 0);`

in the `onBeforeRender` function in `src/materials/pathtracing/PhysicalPathTracingMaterial.js`.

With these modifications, all examples work, except for:
- depthOfField (black screen, also on macOS)
- blur (black screen, also on macOS)
- materialBall (webgl error, also on macOS)
- spotLights.js (black screen, also on macOS)

Tested with iPad Pro M1 (iPadOS 17.0.3) and MacBook Pro M1 Max 32 giga (Sonoma 14.1)