### PR TITLE
Enabling MIS on macOS / iOS

### DIFF
--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -43,7 +43,7 @@ const params = {
 
 	enabled: true,
 	multipleImportanceSampling: true,
-	environmentIntensity: 0.1,
+	environmentIntensity: 1,
 	bounces: 3,
 	samplesPerFrame: 1,
 	resolutionScale: 1 / window.devicePixelRatio,

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -55,7 +55,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 		this.setDefine( 'FEATURE_DOF', this.physicalCamera.bokehSize === 0 ? 0 : 1 );
 		this.setDefine( 'FEATURE_BACKGROUND_MAP', this.backgroundMap ? 1 : 0 );
-		this.setDefine( 'FEATURE_FOG', this.materials.features.isUsed( 'FOG' ) ? 1 : 0 );
+		this.setDefine('FEATURE_FOG', this.materials.features.isUsed('FOG') ? 1 : 0);
+		this.setDefine('FEATURE_MIS', 0);
 
 	}
 

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -55,7 +55,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 		this.setDefine( 'FEATURE_DOF', this.physicalCamera.bokehSize === 0 ? 0 : 1 );
 		this.setDefine( 'FEATURE_BACKGROUND_MAP', this.backgroundMap ? 1 : 0 );
-		this.setDefine( 'FEATURE_FOG', this.materials.features.isUsed( 'FOG' ) ? 1 : 0 );
+		this.setDefine( 'FEATURE_FOG', 0 );
 
 	}
 

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -314,26 +314,26 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							} else {
 
-								// #if FEATURE_MIS
+								#if FEATURE_MIS
 
-								// // NOTE: we skip MIS for punctual lights since they are not supported in forward PT case
-								// if ( lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ) {
+								// NOTE: we skip MIS for punctual lights since they are not supported in forward PT case
+								if ( lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ) {
 
-								// 	gl_FragColor.rgb += lightRec.emission * state.throughputColor;
+									gl_FragColor.rgb += lightRec.emission * state.throughputColor;
 
-								// } else {
+								} else {
 
-								// 	// weight the contribution
-								// 	float misWeight = misHeuristic( scatterRec.pdf, lightRec.pdf / lightsDenom );
-								// 	gl_FragColor.rgb += lightRec.emission * state.throughputColor * misWeight;
+									// weight the contribution
+									float misWeight = misHeuristic( scatterRec.pdf, lightRec.pdf / lightsDenom );
+									gl_FragColor.rgb += lightRec.emission * state.throughputColor * misWeight;
 
-								// }
+								}
 
-								// #else
+								#else
 
 								gl_FragColor.rgb += lightRec.emission * state.throughputColor;
 
-								// #endif
+								#endif
 
 							}
 							break;
@@ -347,25 +347,25 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							} else {
 
-								// #if FEATURE_MIS
+								#if FEATURE_MIS
 
-								// // get the PDF of the hit envmap point
-								// vec3 envColor;
-								// float envPdf = sampleEquirect( envMapInfo, envRotation3x3 * ray.direction, envColor );
-								// envPdf /= lightsDenom;
+								// get the PDF of the hit envmap point
+								vec3 envColor;
+								float envPdf = sampleEquirect( envMapInfo, envRotation3x3 * ray.direction, envColor );
+								envPdf /= lightsDenom;
 
-								// // and weight the contribution
-								// float misWeight = misHeuristic( scatterRec.pdf, envPdf );
-								// gl_FragColor.rgb += environmentIntensity * envColor * state.throughputColor * misWeight;
+								// and weight the contribution
+								float misWeight = misHeuristic( scatterRec.pdf, envPdf );
+								gl_FragColor.rgb += environmentIntensity * envColor * state.throughputColor * misWeight;
 
-								// #else
+								#else
 
 								gl_FragColor.rgb +=
 									environmentIntensity *
 									sampleEquirectColor( envMapInfo.map, envRotation3x3 * ray.direction ) *
 									state.throughputColor;
 
-								// #endif
+								#endif
 
 							}
 							break;
@@ -439,11 +439,11 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						vec3 hitPoint = stepRayOrigin( ray.origin, ray.direction, isBelowSurface ? - surf.faceNormal : surf.faceNormal, surfaceHit.dist );
 
 						// next event estimation
-						// #if FEATURE_MIS
+						#if FEATURE_MIS
 
-						// gl_FragColor.rgb += directLightContribution( - ray.direction, surf, state, hitPoint );
+						gl_FragColor.rgb += directLightContribution( - ray.direction, surf, state, hitPoint );
 
-						// #endif
+						#endif
 
 						// accumulate a roughness value to offset diffuse, specular, diffuse rays that have high contribution
 						// to a single pixel resulting in fireflies

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -55,8 +55,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 		this.setDefine( 'FEATURE_DOF', this.physicalCamera.bokehSize === 0 ? 0 : 1 );
 		this.setDefine( 'FEATURE_BACKGROUND_MAP', this.backgroundMap ? 1 : 0 );
-		this.setDefine('FEATURE_FOG', this.materials.features.isUsed('FOG') ? 1 : 0);
-		this.setDefine('FEATURE_MIS', 0);
+		this.setDefine('FEATURE_FOG', 0 );
+		this.setDefine('FEATURE_MIS', 1);
 
 	}
 
@@ -314,26 +314,26 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							} else {
 
-								#if FEATURE_MIS
+								// #if FEATURE_MIS
 
-								// NOTE: we skip MIS for punctual lights since they are not supported in forward PT case
-								if ( lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ) {
+								// // NOTE: we skip MIS for punctual lights since they are not supported in forward PT case
+								// if ( lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ) {
 
-									gl_FragColor.rgb += lightRec.emission * state.throughputColor;
+								// 	gl_FragColor.rgb += lightRec.emission * state.throughputColor;
 
-								} else {
+								// } else {
 
-									// weight the contribution
-									float misWeight = misHeuristic( scatterRec.pdf, lightRec.pdf / lightsDenom );
-									gl_FragColor.rgb += lightRec.emission * state.throughputColor * misWeight;
+								// 	// weight the contribution
+								// 	float misWeight = misHeuristic( scatterRec.pdf, lightRec.pdf / lightsDenom );
+								// 	gl_FragColor.rgb += lightRec.emission * state.throughputColor * misWeight;
 
-								}
+								// }
 
-								#else
+								// #else
 
 								gl_FragColor.rgb += lightRec.emission * state.throughputColor;
 
-								#endif
+								// #endif
 
 							}
 							break;
@@ -347,25 +347,25 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 							} else {
 
-								#if FEATURE_MIS
+								// #if FEATURE_MIS
 
-								// get the PDF of the hit envmap point
-								vec3 envColor;
-								float envPdf = sampleEquirect( envMapInfo, envRotation3x3 * ray.direction, envColor );
-								envPdf /= lightsDenom;
+								// // get the PDF of the hit envmap point
+								// vec3 envColor;
+								// float envPdf = sampleEquirect( envMapInfo, envRotation3x3 * ray.direction, envColor );
+								// envPdf /= lightsDenom;
 
-								// and weight the contribution
-								float misWeight = misHeuristic( scatterRec.pdf, envPdf );
-								gl_FragColor.rgb += environmentIntensity * envColor * state.throughputColor * misWeight;
+								// // and weight the contribution
+								// float misWeight = misHeuristic( scatterRec.pdf, envPdf );
+								// gl_FragColor.rgb += environmentIntensity * envColor * state.throughputColor * misWeight;
 
-								#else
+								// #else
 
 								gl_FragColor.rgb +=
 									environmentIntensity *
 									sampleEquirectColor( envMapInfo.map, envRotation3x3 * ray.direction ) *
 									state.throughputColor;
 
-								#endif
+								// #endif
 
 							}
 							break;
@@ -439,11 +439,11 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 						vec3 hitPoint = stepRayOrigin( ray.origin, ray.direction, isBelowSurface ? - surf.faceNormal : surf.faceNormal, surfaceHit.dist );
 
 						// next event estimation
-						#if FEATURE_MIS
+						// #if FEATURE_MIS
 
-						gl_FragColor.rgb += directLightContribution( - ray.direction, surf, state, hitPoint );
+						// gl_FragColor.rgb += directLightContribution( - ray.direction, surf, state, hitPoint );
 
-						#endif
+						// #endif
 
 						// accumulate a roughness value to offset diffuse, specular, diffuse rays that have high contribution
 						// to a single pixel resulting in fireflies

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -55,7 +55,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 		this.setDefine( 'FEATURE_DOF', this.physicalCamera.bokehSize === 0 ? 0 : 1 );
 		this.setDefine( 'FEATURE_BACKGROUND_MAP', this.backgroundMap ? 1 : 0 );
-		this.setDefine('FEATURE_FOG', 0 );
+		this.setDefine( 'FEATURE_FOG', this.materials.features.isUsed( 'FOG' ) ? 1 : 0 );
 
 	}
 

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -56,7 +56,6 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 		this.setDefine( 'FEATURE_DOF', this.physicalCamera.bokehSize === 0 ? 0 : 1 );
 		this.setDefine( 'FEATURE_BACKGROUND_MAP', this.backgroundMap ? 1 : 0 );
 		this.setDefine('FEATURE_FOG', 0 );
-		this.setDefine('FEATURE_MIS', 1);
 
 	}
 

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -305,39 +305,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 							surfaceHit, lightRec
 						);
 
-						if ( hitType == LIGHT_HIT ) {
-
-							if ( state.firstRay || state.transmissiveRay ) {
-
-								gl_FragColor.rgb += lightRec.emission * state.throughputColor;
-
-							} else {
-
-								#if FEATURE_MIS
-
-								// NOTE: we skip MIS for punctual lights since they are not supported in forward PT case
-								if ( lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ) {
-
-									gl_FragColor.rgb += lightRec.emission * state.throughputColor;
-
-								} else {
-
-									// weight the contribution
-									float misWeight = misHeuristic( scatterRec.pdf, lightRec.pdf / lightsDenom );
-									gl_FragColor.rgb += lightRec.emission * state.throughputColor * misWeight;
-
-								}
-
-								#else
-
-								gl_FragColor.rgb += lightRec.emission * state.throughputColor;
-
-								#endif
-
-							}
-							break;
-
-						} else if ( hitType == NO_HIT ) {
+						if ( hitType == NO_HIT ) {
 
 							if ( state.firstRay || state.transmissiveRay ) {
 

--- a/src/materials/pathtracing/glsl/attenuateHit.glsl.js
+++ b/src/materials/pathtracing/glsl/attenuateHit.glsl.js
@@ -34,11 +34,6 @@ export const attenuateHitGLSL = /* glsl */`
 
 				return true;
 
-			} else if ( hitType == LIGHT_HIT ) {
-
-				float totalDist = distance( startPoint, ray.origin + ray.direction * lightRec.dist );
-				return totalDist < rayDist - max( totalDist, rayDist ) * 1e-4;
-
 			} else if ( hitType == SURFACE_HIT ) {
 
 				float totalDist = distance( startPoint, ray.origin + ray.direction * surfaceHit.dist );

--- a/src/materials/pathtracing/glsl/directLightContribution.glsl.js
+++ b/src/materials/pathtracing/glsl/directLightContribution.glsl.js
@@ -25,7 +25,7 @@ export const directLightContributionGLSL = /*glsl*/`
 			if (
 				lightRec.pdf > 0.0
 				&& isDirectionValid( lightRec.direction, surf.normal, surf.faceNormal ) 
-				//&& ! attenuateHit( bvh, state, lightRay, lightRec.dist, attenuatedColor )
+				&& ! attenuateHit( bvh, state, lightRay, lightRec.dist, attenuatedColor )
 			) {
 
 			 	// get the material pdf

--- a/src/materials/pathtracing/glsl/directLightContribution.glsl.js
+++ b/src/materials/pathtracing/glsl/directLightContribution.glsl.js
@@ -2,6 +2,8 @@ export const directLightContributionGLSL = /*glsl*/`
 
 	vec3 directLightContribution( vec3 worldWo, SurfaceRecord surf, RenderState state, vec3 rayOrigin ) {
 
+		vec3 result = vec3( 0.0 );
+
 		// uniformly pick a light or environment map
 		if( lightsDenom != 0.0 && sobol( 5 ) < float( lights.count ) / lightsDenom ) {
 
@@ -23,7 +25,7 @@ export const directLightContributionGLSL = /*glsl*/`
 			if (
 				lightRec.pdf > 0.0
 				&& isDirectionValid( lightRec.direction, surf.normal, surf.faceNormal ) 
-				// && ! attenuateHit( bvh, state, lightRay, lightRec.dist, attenuatedColor )
+				//&& ! attenuateHit( bvh, state, lightRay, lightRec.dist, attenuatedColor )
 			) {
 
 			 	// get the material pdf
@@ -35,7 +37,7 @@ export const directLightContributionGLSL = /*glsl*/`
 					// weight the direct light contribution
 					float lightPdf = lightRec.pdf / lightsDenom;
 					float misWeight = lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ? 1.0 : misHeuristic( lightPdf, lightMaterialPdf );
-				//	return attenuatedColor * lightRec.emission * state.throughputColor * sampleColor * misWeight / lightPdf;
+					result = attenuatedColor * lightRec.emission * state.throughputColor * sampleColor * misWeight / lightPdf;
 
 			 	}
 
@@ -80,7 +82,7 @@ export const directLightContributionGLSL = /*glsl*/`
 					// weight the direct light contribution
 					envPdf /= lightsDenom;
 					float misWeight = misHeuristic( envPdf, envMaterialPdf );
-					return attenuatedColor * environmentIntensity * envColor * state.throughputColor * sampleColor * misWeight / envPdf;
+					result = attenuatedColor * environmentIntensity * envColor * state.throughputColor * sampleColor * misWeight / envPdf;
 
 				}
 
@@ -88,7 +90,7 @@ export const directLightContributionGLSL = /*glsl*/`
 
 		}
 
-		return vec3( 0.0 );
+		return result;
 
 	}
 

--- a/src/materials/pathtracing/glsl/directLightContribution.glsl.js
+++ b/src/materials/pathtracing/glsl/directLightContribution.glsl.js
@@ -6,40 +6,40 @@ export const directLightContributionGLSL = /*glsl*/`
 		if( lightsDenom != 0.0 && sobol( 5 ) < float( lights.count ) / lightsDenom ) {
 
 			// // sample a light or environment
-			// LightRecord lightRec = randomLightSample( lights.tex, iesProfiles, lights.count, rayOrigin, sobol3( 6 ) );
+			LightRecord lightRec = randomLightSample( lights.tex, iesProfiles, lights.count, rayOrigin, sobol3( 6 ) );
 
-			// bool isSampleBelowSurface = ! surf.volumeParticle && dot( surf.faceNormal, lightRec.direction ) < 0.0;
-			// if ( isSampleBelowSurface ) {
+			bool isSampleBelowSurface = ! surf.volumeParticle && dot( surf.faceNormal, lightRec.direction ) < 0.0;
+			if ( isSampleBelowSurface ) {
 
-			// 	lightRec.pdf = 0.0;
+				lightRec.pdf = 0.0;
 
-			// }
+			}
 
 			// // check if a ray could even reach the light area
-			// Ray lightRay;
-			// lightRay.origin = rayOrigin;
-			// lightRay.direction = lightRec.direction;
-			// vec3 attenuatedColor;
-			// if (
-			// 	lightRec.pdf > 0.0 &&
-			// 	isDirectionValid( lightRec.direction, surf.normal, surf.faceNormal ) &&
-			// 	! attenuateHit( bvh, state, lightRay, lightRec.dist, attenuatedColor )
-			// ) {
+			Ray lightRay;
+			lightRay.origin = rayOrigin;
+			lightRay.direction = lightRec.direction;
+			vec3 attenuatedColor;
+			if (
+				lightRec.pdf > 0.0
+				&& isDirectionValid( lightRec.direction, surf.normal, surf.faceNormal ) 
+				// && ! attenuateHit( bvh, state, lightRay, lightRec.dist, attenuatedColor )
+			) {
 
-			// 	// get the material pdf
-			// 	vec3 sampleColor;
-			// 	float lightMaterialPdf = bsdfResult( worldWo, lightRec.direction, surf, sampleColor );
-			// 	bool isValidSampleColor = all( greaterThanEqual( sampleColor, vec3( 0.0 ) ) );
-			// 	if ( lightMaterialPdf > 0.0 && isValidSampleColor ) {
+			 	// get the material pdf
+				vec3 sampleColor;
+				float lightMaterialPdf = bsdfResult( worldWo, lightRec.direction, surf, sampleColor );
+				bool isValidSampleColor = all( greaterThanEqual( sampleColor, vec3( 0.0 ) ) );
+			 	if ( lightMaterialPdf > 0.0 && isValidSampleColor ) {
 
-			// 		// weight the direct light contribution
-			// 		float lightPdf = lightRec.pdf / lightsDenom;
-			// 		float misWeight = lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ? 1.0 : misHeuristic( lightPdf, lightMaterialPdf );
-			// 		return attenuatedColor * lightRec.emission * state.throughputColor * sampleColor * misWeight / lightPdf;
+					// weight the direct light contribution
+					float lightPdf = lightRec.pdf / lightsDenom;
+					float misWeight = lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ? 1.0 : misHeuristic( lightPdf, lightMaterialPdf );
+				//	return attenuatedColor * lightRec.emission * state.throughputColor * sampleColor * misWeight / lightPdf;
 
-			// 	}
+			 	}
 
-			// }
+			}
 
 		}
 		

--- a/src/materials/pathtracing/glsl/directLightContribution.glsl.js
+++ b/src/materials/pathtracing/glsl/directLightContribution.glsl.js
@@ -5,7 +5,7 @@ export const directLightContributionGLSL = /*glsl*/`
 		// uniformly pick a light or environment map
 		if( lightsDenom != 0.0 && sobol( 5 ) < float( lights.count ) / lightsDenom ) {
 
-			// // sample a light or environment
+			// sample a light or environment
 			LightRecord lightRec = randomLightSample( lights.tex, iesProfiles, lights.count, rayOrigin, sobol3( 6 ) );
 
 			bool isSampleBelowSurface = ! surf.volumeParticle && dot( surf.faceNormal, lightRec.direction ) < 0.0;
@@ -15,7 +15,7 @@ export const directLightContributionGLSL = /*glsl*/`
 
 			}
 
-			// // check if a ray could even reach the light area
+			// check if a ray could even reach the light area
 			Ray lightRay;
 			lightRay.origin = rayOrigin;
 			lightRay.direction = lightRec.direction;

--- a/src/materials/pathtracing/glsl/directLightContribution.glsl.js
+++ b/src/materials/pathtracing/glsl/directLightContribution.glsl.js
@@ -5,43 +5,45 @@ export const directLightContributionGLSL = /*glsl*/`
 		// uniformly pick a light or environment map
 		if( lightsDenom != 0.0 && sobol( 5 ) < float( lights.count ) / lightsDenom ) {
 
-			// sample a light or environment
-			LightRecord lightRec = randomLightSample( lights.tex, iesProfiles, lights.count, rayOrigin, sobol3( 6 ) );
+			// // sample a light or environment
+			// LightRecord lightRec = randomLightSample( lights.tex, iesProfiles, lights.count, rayOrigin, sobol3( 6 ) );
 
-			bool isSampleBelowSurface = ! surf.volumeParticle && dot( surf.faceNormal, lightRec.direction ) < 0.0;
-			if ( isSampleBelowSurface ) {
+			// bool isSampleBelowSurface = ! surf.volumeParticle && dot( surf.faceNormal, lightRec.direction ) < 0.0;
+			// if ( isSampleBelowSurface ) {
 
-				lightRec.pdf = 0.0;
+			// 	lightRec.pdf = 0.0;
 
-			}
+			// }
 
-			// check if a ray could even reach the light area
-			Ray lightRay;
-			lightRay.origin = rayOrigin;
-			lightRay.direction = lightRec.direction;
-			vec3 attenuatedColor;
-			if (
-				lightRec.pdf > 0.0 &&
-				isDirectionValid( lightRec.direction, surf.normal, surf.faceNormal ) &&
-				! attenuateHit( bvh, state, lightRay, lightRec.dist, attenuatedColor )
-			) {
+			// // check if a ray could even reach the light area
+			// Ray lightRay;
+			// lightRay.origin = rayOrigin;
+			// lightRay.direction = lightRec.direction;
+			// vec3 attenuatedColor;
+			// if (
+			// 	lightRec.pdf > 0.0 &&
+			// 	isDirectionValid( lightRec.direction, surf.normal, surf.faceNormal ) &&
+			// 	! attenuateHit( bvh, state, lightRay, lightRec.dist, attenuatedColor )
+			// ) {
 
-				// get the material pdf
-				vec3 sampleColor;
-				float lightMaterialPdf = bsdfResult( worldWo, lightRec.direction, surf, sampleColor );
-				bool isValidSampleColor = all( greaterThanEqual( sampleColor, vec3( 0.0 ) ) );
-				if ( lightMaterialPdf > 0.0 && isValidSampleColor ) {
+			// 	// get the material pdf
+			// 	vec3 sampleColor;
+			// 	float lightMaterialPdf = bsdfResult( worldWo, lightRec.direction, surf, sampleColor );
+			// 	bool isValidSampleColor = all( greaterThanEqual( sampleColor, vec3( 0.0 ) ) );
+			// 	if ( lightMaterialPdf > 0.0 && isValidSampleColor ) {
 
-					// weight the direct light contribution
-					float lightPdf = lightRec.pdf / lightsDenom;
-					float misWeight = lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ? 1.0 : misHeuristic( lightPdf, lightMaterialPdf );
-					return attenuatedColor * lightRec.emission * state.throughputColor * sampleColor * misWeight / lightPdf;
+			// 		// weight the direct light contribution
+			// 		float lightPdf = lightRec.pdf / lightsDenom;
+			// 		float misWeight = lightRec.type == SPOT_LIGHT_TYPE || lightRec.type == DIR_LIGHT_TYPE || lightRec.type == POINT_LIGHT_TYPE ? 1.0 : misHeuristic( lightPdf, lightMaterialPdf );
+			// 		return attenuatedColor * lightRec.emission * state.throughputColor * sampleColor * misWeight / lightPdf;
 
-				}
+			// 	}
 
-			}
+			// }
 
-		} else {
+		}
+		
+		else {
 
 			// find a sample in the environment map to include in the contribution
 			vec3 envColor, envDirection;

--- a/src/materials/pathtracing/glsl/traceScene.glsl.js
+++ b/src/materials/pathtracing/glsl/traceScene.glsl.js
@@ -15,6 +15,7 @@ export const traceSceneGLSL = /* glsl */`
 
 	) {
 
+		int result = NO_HIT;
 		bool hit = bvhIntersectFirstHit( bvh, ray.origin, ray.direction, surfaceHit.faceIndices, surfaceHit.faceNormal, surfaceHit.barycoord, surfaceHit.side, surfaceHit.dist );
 		bool lightHit = lightsClosestHit( lights.tex, lights.count, ray.origin, ray.direction, lightRec );
 
@@ -38,17 +39,15 @@ export const traceSceneGLSL = /* glsl */`
 
 		if ( lightHit && ( lightRec.dist < surfaceHit.dist || ! hit ) ) {
 
-			return LIGHT_HIT;
+			result = LIGHT_HIT;
+
+		} else if ( hit ) {
+
+			result = SURFACE_HIT;
 
 		}
 
-		if ( hit ) {
-
-			return SURFACE_HIT;
-
-		}
-
-		return NO_HIT;
+		return result;
 
 	}
 

--- a/src/materials/pathtracing/glsl/traceScene.glsl.js
+++ b/src/materials/pathtracing/glsl/traceScene.glsl.js
@@ -17,7 +17,6 @@ export const traceSceneGLSL = /* glsl */`
 
 		int result = NO_HIT;
 		bool hit = bvhIntersectFirstHit( bvh, ray.origin, ray.direction, surfaceHit.faceIndices, surfaceHit.faceNormal, surfaceHit.barycoord, surfaceHit.side, surfaceHit.dist );
-		bool lightHit = lightsClosestHit( lights.tex, lights.count, ray.origin, ray.direction, lightRec );
 
 		#if FEATURE_FOG
 
@@ -37,11 +36,7 @@ export const traceSceneGLSL = /* glsl */`
 
 		#endif
 
-		if ( lightHit && ( lightRec.dist < surfaceHit.dist || ! hit ) ) {
-
-			result = LIGHT_HIT;
-
-		} else if ( hit ) {
+		if ( hit ) {
 
 			result = SURFACE_HIT;
 


### PR DESCRIPTION
I've narrowed down the crash (WebGL context lost) on macOS (both Chrome and Safari) / iOS when MIS is enabled to two lines of code, which I have commented out in this PR. They are both in directLightContribution.glsl.js, lines 26 and 38.
If you uncomment either of them, the crash occurs again.

