### PR TITLE
Update deprecated three.js code

### DIFF
--- a/src/utils/GeometryPreparationUtils.js
+++ b/src/utils/GeometryPreparationUtils.js
@@ -1,5 +1,5 @@
 import { BufferAttribute } from 'three';
-import { mergeBufferGeometries, mergeVertices } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { mergeGeometries, mergeVertices } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 export function getGroupMaterialIndicesAttribute( geometry, materials, allMaterials ) {
 
 	const indexAttr = geometry.index;
@@ -213,7 +213,7 @@ export function mergeMeshes( meshes, options = {} ) {
 
 	} );
 
-	const geometry = mergeBufferGeometries( transformedGeometry, false );
+	const geometry = mergeGeometries( transformedGeometry, false );
 	const textures = Array.from( textureSet );
 	return { geometry, materials, textures };
 


### PR DESCRIPTION
`mergeBufferGeometries` was already deprecated in r151 (the current three.js dependency) and is removed in r161, now named `mergeGeometries`.

See https://github.com/mrdoob/three.js/pull/27467/files#diff-ed91371298bdcbc8aab7034f2ea13d1def23f69aca37a77aa7cf8fee9a4cb125L1350

Besides this the current branch is already compatible with r161 it seems 👍 
![image](https://github.com/gkjohnson/three-gpu-pathtracer/assets/2693840/facc0c9f-96dd-4a9a-894b-4a6d513dd68c)
