### PR TITLE
Add WebGLPathTracer convenience class

### DIFF
--- a/example/primitives.js
+++ b/example/primitives.js
@@ -56,7 +56,7 @@ camera.lookAt( 0, 0, 0 );
 const renderer = new WebGLPathTracer();
 document.body.appendChild( renderer.domElement );
 renderer.toneMapping = ACESFilmicToneMapping;
-renderer.tiles.set( 3 );
+renderer.tiles.set( 3, 3 );
 renderer.updateScene( camera, scene );
 
 onResize();

--- a/example/primitives.js
+++ b/example/primitives.js
@@ -1,11 +1,5 @@
 import * as THREE from 'three';
-import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
-import {
-	PathTracingSceneGenerator,
-	PathTracingRenderer,
-	PhysicalPathTracingMaterial,
-	GradientEquirectTexture,
-} from '..';
+import { WebGLPathTracer, GradientEquirectTexture } from '..';
 
 // init scene, renderer, camera, controls, etc
 const scene = new THREE.Scene();
@@ -54,54 +48,56 @@ camera.position.set( 0, 1, - 5 );
 camera.lookAt( 0, 0, 0 );
 camera.updateProjectionMatrix();
 
-const renderer = new THREE.WebGLRenderer();
+const renderer = new WebGLPathTracer();
 document.body.appendChild( renderer.domElement );
 renderer.toneMapping = THREE.ACESFilmicToneMapping;
 renderer.setPixelRatio( devicePixelRatio );
 renderer.setSize( innerWidth, innerHeight );
 renderer.setClearColor( 0xaaaaaa );
+renderer.updateScene( camera, scene );
 
-// initialize the path tracing material and renderer
-const ptMaterial = new PhysicalPathTracingMaterial();
-const ptRenderer = new PathTracingRenderer( renderer );
-ptRenderer.setSize( innerWidth * devicePixelRatio, innerHeight * devicePixelRatio );
-ptRenderer.tiles.setScalar( 3 );
-ptRenderer.camera = camera;
-ptRenderer.material = ptMaterial;
+// // initialize the path tracing material and renderer
+// const ptMaterial = new PhysicalPathTracingMaterial();
+// const ptRenderer = new PathTracingRenderer( renderer );
+// ptRenderer.setSize( innerWidth * devicePixelRatio, innerHeight * devicePixelRatio );
+// ptRenderer.tiles.setScalar( 3 );
+// ptRenderer.camera = camera;
+// ptRenderer.material = ptMaterial;
 
-// init quad for rendering to the canvas
-const fsQuad = new FullScreenQuad( new THREE.MeshBasicMaterial( {
-	map: ptRenderer.target.texture,
-	blending: THREE.CustomBlending,
-} ) );
+// // init quad for rendering to the canvas
+// const fsQuad = new FullScreenQuad( new THREE.MeshBasicMaterial( {
+// 	map: ptRenderer.target.texture,
+// 	blending: THREE.CustomBlending,
+// } ) );
 
-// initialize the scene and update the material properties with the bvh, materials, etc
-const generator = new PathTracingSceneGenerator();
-const { bvh, textures, materials, lights, geometry } = generator.generate( scene );
+// // initialize the scene and update the material properties with the bvh, materials, etc
+// const generator = new PathTracingSceneGenerator();
+// const { bvh, textures, materials, lights, geometry } = generator.generate( scene );
 
-// update bvh and geometry attribute textures
-ptMaterial.bvh.updateFrom( bvh );
-ptMaterial.attributesArray.updateFrom(
-	geometry.attributes.normal,
-	geometry.attributes.tangent,
-	geometry.attributes.uv,
-	geometry.attributes.color,
-);
+// // update bvh and geometry attribute textures
+// ptMaterial.bvh.updateFrom( bvh );
+// ptMaterial.attributesArray.updateFrom(
+// 	geometry.attributes.normal,
+// 	geometry.attributes.tangent,
+// 	geometry.attributes.uv,
+// 	geometry.attributes.color,
+// );
 
-// update materials and texture arrays
-ptMaterial.materialIndexAttribute.updateFrom( geometry.attributes.materialIndex );
-ptMaterial.textures.setTextures( renderer, 2048, 2048, textures );
-ptMaterial.materials.updateFrom( materials, textures );
+// // update materials and texture arrays
+// ptMaterial.materialIndexAttribute.updateFrom( geometry.attributes.materialIndex );
+// ptMaterial.textures.setTextures( renderer, 2048, 2048, textures );
+// ptMaterial.materials.updateFrom( materials, textures );
 
-// update the lights
-ptMaterial.lights.updateFrom( lights );
+// // update the lights
+// ptMaterial.lights.updateFrom( lights );
 
 // set the environment map
 const texture = new GradientEquirectTexture();
 texture.bottomColor.set( 0xffffff );
 texture.bottomColor.set( 0x666666 );
 texture.update();
-ptRenderer.material.envMapInfo.updateFrom( texture );
+scene.environment = texture;
+scene.background = texture;
 
 animate();
 
@@ -110,10 +106,6 @@ window.addEventListener( 'resize', () => {
 	// update rendering resolution
 	const w = window.innerWidth;
 	const h = window.innerHeight;
-	const dpr = window.devicePixelRatio;
-
-	ptRenderer.setSize( w * dpr, h * dpr );
-	ptRenderer.reset();
 
 	renderer.setSize( w, h );
 	renderer.setPixelRatio( window.devicePixelRatio );
@@ -131,13 +123,6 @@ function animate() {
 
 	// update the camera and render one sample
 	camera.updateMatrixWorld();
-	ptRenderer.update();
-
-	// if using alpha = true then the target texture will change every frame
-	// so we must retrieve it before render.
-	fsQuad.material.map = ptRenderer.target.texture;
-
-	// copy the current state of the path tracer to canvas to display
-	fsQuad.render( renderer );
+	renderer.renderSample();
 
 }

--- a/example/primitives.js
+++ b/example/primitives.js
@@ -1,36 +1,36 @@
-import * as THREE from 'three';
+import { Scene, SphereGeometry, MeshStandardMaterial, Mesh, BoxGeometry, PerspectiveCamera, ACESFilmicToneMapping } from 'three';
 import { WebGLPathTracer, GradientEquirectTexture } from '..';
 
 // init scene, renderer, camera, controls, etc
-const scene = new THREE.Scene();
-const sphereGeom = new THREE.SphereGeometry( 0.49, 64, 32 );
-const ball1 = new THREE.Mesh(
+const scene = new Scene();
+const sphereGeom = new SphereGeometry( 0.49, 64, 32 );
+const ball1 = new Mesh(
 	sphereGeom,
-	new THREE.MeshStandardMaterial( {
+	new MeshStandardMaterial( {
 		color: '#e91e63',
 		roughness: 0.25,
 		metalness: 1,
 	} )
 );
-const ball2 = new THREE.Mesh(
+const ball2 = new Mesh(
 	sphereGeom,
-	new THREE.MeshStandardMaterial( {
+	new MeshStandardMaterial( {
 		color: '#ff9800',
 		roughness: 0.1,
 		metalness: 1,
 	} )
 );
-const ball3 = new THREE.Mesh(
+const ball3 = new Mesh(
 	sphereGeom,
-	new THREE.MeshStandardMaterial( {
+	new MeshStandardMaterial( {
 		color: '#2196f3',
 		roughness: 0.2,
 		metalness: 1,
 	} )
 );
-const ground = new THREE.Mesh(
-	new THREE.BoxGeometry( 3.5, 0.1, 1.5 ),
-	new THREE.MeshStandardMaterial(),
+const ground = new Mesh(
+	new BoxGeometry( 3.5, 0.1, 1.5 ),
+	new MeshStandardMaterial(),
 );
 
 ball1.position.x = - 1;
@@ -49,60 +49,35 @@ scene.background = texture;
 // ensure scene matrices are up to date
 scene.updateMatrixWorld();
 
-const { innerWidth, innerHeight, devicePixelRatio } = window;
-const camera = new THREE.PerspectiveCamera();
-camera.aspect = innerWidth / innerHeight;
+const camera = new PerspectiveCamera();
 camera.position.set( 0, 1, - 5 );
 camera.lookAt( 0, 0, 0 );
-camera.updateProjectionMatrix();
 
 const renderer = new WebGLPathTracer();
 document.body.appendChild( renderer.domElement );
-renderer.toneMapping = THREE.ACESFilmicToneMapping;
-renderer.setPixelRatio( devicePixelRatio );
-renderer.setSize( innerWidth, innerHeight );
+renderer.toneMapping = ACESFilmicToneMapping;
 renderer.setClearColor( 0xaaaaaa );
 renderer.tiles.set( 3 );
 renderer.updateScene( camera, scene );
 
-// // initialize the path tracing material and renderer
-// const ptMaterial = new PhysicalPathTracingMaterial();
-// const ptRenderer = new PathTracingRenderer( renderer );
-// ptRenderer.setSize( innerWidth * devicePixelRatio, innerHeight * devicePixelRatio );
-// ptRenderer.tiles.setScalar( 3 );
-// ptRenderer.camera = camera;
-// ptRenderer.material = ptMaterial;
-
-// // init quad for rendering to the canvas
-// const fsQuad = new FullScreenQuad( new THREE.MeshBasicMaterial( {
-// 	map: ptRenderer.target.texture,
-// 	blending: THREE.CustomBlending,
-// } ) );
-
-// // initialize the scene and update the material properties with the bvh, materials, etc
-// const generator = new PathTracingSceneGenerator();
-// const { bvh, textures, materials, lights, geometry } = generator.generate( scene );
-
-// // update bvh and geometry attribute textures
-// ptMaterial.bvh.updateFrom( bvh );
-// ptMaterial.attributesArray.updateFrom(
-// 	geometry.attributes.normal,
-// 	geometry.attributes.tangent,
-// 	geometry.attributes.uv,
-// 	geometry.attributes.color,
-// );
-
-// // update materials and texture arrays
-// ptMaterial.materialIndexAttribute.updateFrom( geometry.attributes.materialIndex );
-// ptMaterial.textures.setTextures( renderer, 2048, 2048, textures );
-// ptMaterial.materials.updateFrom( materials, textures );
-
-// // update the lights
-// ptMaterial.lights.updateFrom( lights );
+onResize();
 
 animate();
 
-window.addEventListener( 'resize', () => {
+window.addEventListener( 'resize', onResize );
+
+function animate() {
+
+	// if the camera position changes call "ptRenderer.reset()"
+	requestAnimationFrame( animate );
+
+	// update the camera and render one sample
+	camera.updateMatrixWorld();
+	renderer.renderSample();
+
+}
+
+function onResize() {
 
 	// update rendering resolution
 	const w = window.innerWidth;
@@ -114,16 +89,5 @@ window.addEventListener( 'resize', () => {
 	const aspect = w / h;
 	camera.aspect = aspect;
 	camera.updateProjectionMatrix();
-
-} );
-
-function animate() {
-
-	// if the camera position changes call "ptRenderer.reset()"
-	requestAnimationFrame( animate );
-
-	// update the camera and render one sample
-	camera.updateMatrixWorld();
-	renderer.renderSample();
 
 }

--- a/example/primitives.js
+++ b/example/primitives.js
@@ -56,7 +56,6 @@ camera.lookAt( 0, 0, 0 );
 const renderer = new WebGLPathTracer();
 document.body.appendChild( renderer.domElement );
 renderer.toneMapping = ACESFilmicToneMapping;
-renderer.setClearColor( 0xaaaaaa );
 renderer.tiles.set( 3 );
 renderer.updateScene( camera, scene );
 

--- a/example/primitives.js
+++ b/example/primitives.js
@@ -38,6 +38,14 @@ ball3.position.x = 1;
 ground.position.y = - 0.54;
 scene.add( ball1, ball2, ball3, ground );
 
+// set the environment map
+const texture = new GradientEquirectTexture();
+texture.bottomColor.set( 0xffffff );
+texture.bottomColor.set( 0x666666 );
+texture.update();
+scene.environment = texture;
+scene.background = texture;
+
 // ensure scene matrices are up to date
 scene.updateMatrixWorld();
 
@@ -54,6 +62,7 @@ renderer.toneMapping = THREE.ACESFilmicToneMapping;
 renderer.setPixelRatio( devicePixelRatio );
 renderer.setSize( innerWidth, innerHeight );
 renderer.setClearColor( 0xaaaaaa );
+renderer.tiles.set( 3 );
 renderer.updateScene( camera, scene );
 
 // // initialize the path tracing material and renderer
@@ -90,14 +99,6 @@ renderer.updateScene( camera, scene );
 
 // // update the lights
 // ptMaterial.lights.updateFrom( lights );
-
-// set the environment map
-const texture = new GradientEquirectTexture();
-texture.bottomColor.set( 0xffffff );
-texture.bottomColor.set( 0x666666 );
-texture.update();
-scene.environment = texture;
-scene.background = texture;
 
 animate();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "puppeteer": "^15.4.0",
         "rollup": "^2.70.0",
         "simple-git": "^3.10.0",
-        "three": "^0.160.0",
+        "three": "^0.162.0",
         "three-mesh-bvh": "^0.7.3",
         "yargs": "^17.5.1"
       },
@@ -4187,9 +4187,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.160.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
-      "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng==",
+      "version": "0.162.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
+      "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==",
       "dev": true
     },
     "node_modules/three-mesh-bvh": {
@@ -7418,9 +7418,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.160.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
-      "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng==",
+      "version": "0.162.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
+      "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==",
       "dev": true
     },
     "three-mesh-bvh": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "puppeteer": "^15.4.0",
     "rollup": "^2.70.0",
     "simple-git": "^3.10.0",
-    "three": "^0.160.0",
+    "three": "^0.162.0",
     "three-mesh-bvh": "^0.7.3",
     "yargs": "^17.5.1"
   },

--- a/src/core/PathTracingRenderer.js
+++ b/src/core/PathTracingRenderer.js
@@ -2,6 +2,7 @@ import { RGBAFormat, FloatType, HalfFloatType, Color, Vector2, WebGLRenderTarget
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { BlendMaterial } from '../materials/fullscreen/BlendMaterial.js';
 import { SobolNumberMapGenerator } from '../utils/SobolNumberMapGenerator.js';
+import { PhysicalPathTracingMaterial } from '../materials/pathtracing/PhysicalPathTracingMaterial.js';
 
 function* renderTask() {
 
@@ -238,7 +239,7 @@ export class PathTracingRenderer {
 		this._opacityFactor = 1.0;
 		this._renderer = renderer;
 		this._alpha = false;
-		this._fsQuad = new FullScreenQuad( null );
+		this._fsQuad = new FullScreenQuad( new PhysicalPathTracingMaterial() );
 		this._blendQuad = new FullScreenQuad( new BlendMaterial() );
 		this._task = null;
 		this._currentTile = 0;
@@ -285,7 +286,8 @@ export class PathTracingRenderer {
 
 	getSize( target ) {
 
-		this._primaryTarget.getSize( target );
+		target.x = this._primaryTarget.width;
+		target.y = this._primaryTarget.height;
 
 	}
 

--- a/src/core/PathTracingRenderer.js
+++ b/src/core/PathTracingRenderer.js
@@ -283,6 +283,12 @@ export class PathTracingRenderer {
 
 	}
 
+	getSize( target ) {
+
+		this._primaryTarget.getSize( target );
+
+	}
+
 	dispose() {
 
 		this._primaryTarget.dispose();

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -81,17 +81,47 @@ export class WebGLPathTracer {
 
 		};
 
+		// pass through functions for the canvas
+		// TODO: how do we deal with setting the buffer size separately from the canvas?
+		[
+			'getPixelRatio',
+			'setPixelRatio',
+			'getSize',
+			'setSize',
+			'setViewport',
+			'getViewport',
+			'getScissor',
+			'setScissor',
+			'getScissorTest',
+			'setScissorTest',
+			'setDrawingBufferSize',
+			'getDrawingBufferSize',
+		].forEach( key => {
+
+		} );
+
+		// TODO: pass through fields for the path tracer
+		[
+			'filterGlossyFactor',
+			'alpha',
+			'tiles',
+		].forEach( key => {
+
+		} );
+
 	}
 
-	updateScene( camera, scene, {
+	updateScene( camera, scene, options = {} ) {
 
-		updateGeometry = true,
-		updateMaterials = true,
-		updateTextures = true,
-		updateLights = true,
-		updateCamera = true,
-
-	} ) {
+		options = {
+			updateGeometry: true,
+			updateMaterials: true,
+			updateTextures: true,
+			updateLights: true,
+			updateCamera: true,
+			updateEnvironment: true,
+			...options,
+		};
 
 		const generator = this._generator;
 		const pathTracer = this._pathTracer;
@@ -121,15 +151,11 @@ export class WebGLPathTracer {
 
 	}
 
-	setPixelRatio( ...args ) {
-
-		this._renderer.setPixelRatio( ...args );
-
-	}
-
 	dispose() {
 
 		this._renderQuad.dispose();
+		this._renderQuad.material.dispose();
+		this._pathTracer.dispose();
 
 		if ( this._ownRenderer ) {
 

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -106,6 +106,10 @@ export class WebGLPathTracer {
 			'setScissorTest',
 			'setDrawingBufferSize',
 			'getDrawingBufferSize',
+			'getClearAlpha',
+			'setClearAlpha',
+			'getClearColor',
+			'setClearColor',
 		].forEach( key => {
 
 			this[ key ] = ( ...args ) => this._renderer[ key ]( ...args );

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -58,6 +58,18 @@ export class WebGLPathTracer {
 
 	}
 
+	get toneMapping() {
+
+		return this._renderer.toneMapping;
+
+	}
+
+	set toneMapping( v ) {
+
+		this._renderer.toneMapping = v;
+
+	}
+
 	constructor( renderer = null ) {
 
 		// create a new renderer if one was not provided
@@ -74,7 +86,7 @@ export class WebGLPathTracer {
 
 		// members
 		this._renderer = renderer;
-		this._generator = new DynamicPathTracingSceneGenerator();
+		this._generator = null;
 		this._pathTracer = new PathTracingRenderer( renderer );
 		this._quad = new FullScreenQuad( new MeshBasicMaterial( {
 			map: null,
@@ -88,7 +100,7 @@ export class WebGLPathTracer {
 		this.textureSize = new Vector2( 1024, 1024 );
 		this.renderSceneCallback = () => {
 
-			this._renderer.render( this.camera, this.scene );
+			this._renderer.render( this.scene, this.camera );
 
 		};
 
@@ -195,7 +207,15 @@ export class WebGLPathTracer {
 		material.environmentRotation.makeRotationFromEuler( scene.environmentRotation ).multiply( _flipEnvMap );
 		if ( this._previousEnvironment !== scene.environment ) {
 
-			material.envMapInfo.updateFrom( scene.environment );
+			if ( scene.environment ) {
+
+				material.envMapInfo.updateFrom( scene.environment );
+
+			} else {
+
+				material.environmentIntensity = 0;
+
+			}
 
 		}
 
@@ -205,6 +225,8 @@ export class WebGLPathTracer {
 		// save previously used items
 		this._previousScene = scene;
 		this._previousEnvironment = scene.environment;
+		this.scene = scene;
+		this.camera = camera;
 
 		this.reset();
 
@@ -219,10 +241,12 @@ export class WebGLPathTracer {
 
 		if ( this.renderToCanvas ) {
 
-			const renderer = this._renderer;
-			const quad = this._renderQuad;
-			quad.material.map = pathTracer.target;
-			quad.render( renderer );
+			this.renderSceneCallback();
+
+			// const renderer = this._renderer;
+			// const quad = this._quad;
+			// quad.material.map = pathTracer.target.texture;
+			// quad.render( renderer );
 
 		}
 
@@ -255,7 +279,7 @@ export class WebGLPathTracer {
 			this._renderer.getDrawingBufferSize( _resolution );
 
 			const w = Math.floor( this.renderScale * _resolution.x );
-			const h = Math.floor( this.renderScale * _resolution.h );
+			const h = Math.floor( this.renderScale * _resolution.y );
 
 			this._pathTracer.getSize( _resolution );
 			if ( _resolution.x !== w || _resolution.y !== h ) {

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -241,7 +241,11 @@ export class WebGLPathTracer {
 
 		if ( this.renderToCanvas ) {
 
-			this.renderSceneCallback();
+			if ( this.samples < 1 ) {
+
+				this.renderSceneCallback();
+
+			}
 
 			const renderer = this._renderer;
 			const quad = this._quad;

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -250,7 +250,11 @@ export class WebGLPathTracer {
 			const renderer = this._renderer;
 			const quad = this._quad;
 			quad.material.map = pathTracer.target.texture;
+
+			const autoClear = renderer.autoClear;
+			renderer.autoClear = false;
 			quad.render( renderer );
+			renderer.autoClear = autoClear;
 
 		}
 

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -59,6 +59,7 @@ export class WebGLPathTracer {
 
 	constructor( renderer = null ) {
 
+		// create a new renderer if one was not provided
 		if ( renderer === null ) {
 
 			renderer = new WebGLRenderer( { alpha: true } );
@@ -70,6 +71,7 @@ export class WebGLPathTracer {
 
 		}
 
+		// members
 		this._renderer = renderer;
 		this._generator = new DynamicPathTracingSceneGenerator();
 		this._pathTracer = new PathTracingRenderer( renderer );
@@ -134,6 +136,7 @@ export class WebGLPathTracer {
 			bvh,
 		} = this.generator.generate();
 
+		// update scene information
 		material.lights.updateFrom( lights );
 		material.bvh.updateFrom( bvh );
 		material.attributesArray.updateFrom(
@@ -147,8 +150,6 @@ export class WebGLPathTracer {
 		material.materials.updateFrom( materials, textures );
 
 		// update scene background
-		// material.backgroundRotation
-		// material.backgroundIntensity
 		material.backgroundBlur = scene.backgroundBlurriness;
 		if ( scene.background && scene.background.isColor ) {
 
@@ -177,9 +178,8 @@ export class WebGLPathTracer {
 		// camera update
 		pathTracer.camera = camera;
 
-		// save
+		// save previously used items
 		this._previousScene = scene;
-		this._previousBackground = scene.background;
 		this._previousEnvironment = scene.environment;
 
 		this.reset();

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -1,0 +1,142 @@
+import { CustomBlending, MeshBasicMaterial, WebGLRenderer } from 'three';
+import { DynamicPathTracingSceneGenerator } from './DynamicPathTracingSceneGenerator.js';
+import { PathTracingRenderer } from './PathTracingRenderer.js';
+import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass';
+
+export class WebGLPathTracer {
+
+	get filterGlossyFactor() {
+
+		return this._pathTracer.filterGlossyFactor;
+
+	}
+
+	get filterGlossyFactor() {
+
+		return this._pathTracer.filterGlossyFactor;
+
+	}
+
+	get samples() {
+
+		return this._pathTracer.samples;
+
+	}
+
+	get target() {
+
+		return this._pathTracer.target;
+
+	}
+
+	get tiles() {
+
+		return this._pathTracer.tiles;
+
+	}
+
+	get domElement() {
+
+		return this._renderer.domElement;
+
+	}
+
+	get alpha() {
+
+		return this._pathTracer.alpha;
+
+	}
+
+	set alpha( v ) {
+
+		this._pathTracer.alpha = v;
+
+	}
+
+	constructor( renderer = null ) {
+
+		if ( renderer === null ) {
+
+			renderer = new WebGLRenderer( { alpha: true } );
+			this._ownRenderer = true;
+
+		} else {
+
+			this._ownRenderer = false;
+
+		}
+
+		this._renderer = renderer;
+		this._generator = new DynamicPathTracingSceneGenerator();
+		this._pathTracer = new PathTracingRenderer();
+		this._quad = new FullScreenQuad( new MeshBasicMaterial( {
+			map: null,
+			blending: CustomBlending,
+			premultipliedAlpha: renderer.getContextAttributes().premultipliedAlpha,
+		} ) );
+
+		this.renderSceneCallback = () => {
+
+			this._renderer.render( this.camera, this.scene );
+
+		};
+
+	}
+
+	updateScene( camera, scene, {
+
+		updateGeometry = true,
+		updateMaterials = true,
+		updateTextures = true,
+		updateLights = true,
+		updateCamera = true,
+
+	} ) {
+
+		const generator = this._generator;
+		const pathTracer = this._pathTracer;
+		const material = pathTracer.material;
+
+	}
+
+	renderSample() {
+
+		const pathTracer = this._pathTracer;
+		pathTracer.update();
+
+		if ( this.renderToCanvas ) {
+
+			const renderer = this._renderer;
+			const quad = this._renderQuad;
+			quad.material.map = pathTracer.target;
+			quad.render( renderer );
+
+		}
+
+	}
+
+	reset() {
+
+		this._pathTracer.reset();
+
+	}
+
+	setPixelRatio( ...args ) {
+
+		this._renderer.setPixelRatio( ...args );
+
+	}
+
+	dispose() {
+
+		this._renderQuad.dispose();
+
+		if ( this._ownRenderer ) {
+
+			this.renderer.dispose();
+
+		}
+
+	}
+
+}

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -96,9 +96,10 @@ export class WebGLPathTracer {
 
 		this.renderScale = 1;
 		this.synchronizeRenderSize = true;
+		this.rasterizeScene = true;
 		this.renderToCanvas = true;
 		this.textureSize = new Vector2( 1024, 1024 );
-		this.renderSceneCallback = () => {
+		this.rasterizeSceneCallback = () => {
 
 			this._renderer.render( this.scene, this.camera );
 
@@ -241,9 +242,9 @@ export class WebGLPathTracer {
 
 		if ( this.renderToCanvas ) {
 
-			if ( this.samples < 1 ) {
+			if ( this.samples < 1 && this.rasterizeScene ) {
 
-				this.renderSceneCallback();
+				this.rasterizeSceneCallback();
 
 			}
 

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -243,10 +243,10 @@ export class WebGLPathTracer {
 
 			this.renderSceneCallback();
 
-			// const renderer = this._renderer;
-			// const quad = this._quad;
-			// quad.material.map = pathTracer.target.texture;
-			// quad.render( renderer );
+			const renderer = this._renderer;
+			const quad = this._quad;
+			quad.material.map = pathTracer.target.texture;
+			quad.render( renderer );
 
 		}
 

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -150,7 +150,7 @@ export class WebGLPathTracer {
 		// material.backgroundRotation
 		// material.backgroundIntensity
 		material.backgroundBlur = scene.backgroundBlurriness;
-		if ( scene.background && ( scene.background.isColor || typeof scene.background === 'Number' ) ) {
+		if ( scene.background && scene.background.isColor ) {
 
 			this._colorBackground = this._colorBackground || new GradientEquirectTexture( 16 );
 			this._colorBackground.topColor.set( scene.background );

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -72,7 +72,7 @@ export class WebGLPathTracer {
 
 		this._renderer = renderer;
 		this._generator = new DynamicPathTracingSceneGenerator();
-		this._pathTracer = new PathTracingRenderer();
+		this._pathTracer = new PathTracingRenderer( renderer );
 		this._quad = new FullScreenQuad( new MeshBasicMaterial( {
 			map: null,
 			blending: CustomBlending,

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -193,12 +193,12 @@ export class WebGLPathTracer {
 			colorBackground.update();
 
 			// assign to material
-			material.background = colorBackground;
+			material.backgroundMap = colorBackground;
 			material.backgroundAlpha = alpha;
 
 		} else {
 
-			material.background = scene.background;
+			material.backgroundMap = scene.background;
 
 		}
 

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -11,13 +11,13 @@ export class WebGLPathTracer {
 
 	get filterGlossyFactor() {
 
-		return this._pathTracer.filterGlossyFactor;
+		return this._pathTracer.material.filterGlossyFactor;
 
 	}
 
-	get filterGlossyFactor() {
+	set filterGlossyFactor( v ) {
 
-		return this._pathTracer.filterGlossyFactor;
+		this._pathTracer.material.filterGlossyFactor = v;
 
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export * from './core/QuiltPathTracingRenderer.js';
 export * from './core/PathTracingSceneGenerator.js';
 export * from './core/DynamicPathTracingSceneGenerator.js';
 export * from './core/MaterialReducer.js';
+export * from './core/WebGLPathTracer.js';
 
 // objects
 export * from './objects/PhysicalCamera.js';

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -76,7 +76,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				opacity: { value: 1 },
 				bounces: { value: 10 },
 				transmissiveBounces: { value: 10 },
-				filterGlossyFactor: { value: 0.75 },
+				filterGlossyFactor: { value: 0 },
 
 				// camera uniforms
 				physicalCamera: { value: new PhysicalCameraUniform() },

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -76,7 +76,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				opacity: { value: 1 },
 				bounces: { value: 10 },
 				transmissiveBounces: { value: 10 },
-				filterGlossyFactor: { value: 0.0 },
+				filterGlossyFactor: { value: 0.75 },
 
 				// camera uniforms
 				physicalCamera: { value: new PhysicalCameraUniform() },

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -101,6 +101,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				backgroundBlur: { value: 0.0 },
 				backgroundMap: { value: null },
 				backgroundAlpha: { value: 1.0 },
+				// backgroundIntensity
+				// backgroundRotation
 
 				// randomness uniforms
 				seed: { value: 0 },


### PR DESCRIPTION
Related to #498 

**Next PRs**
- Update materials, textures, lights, material ids even when the bvh is refit.
- Add ability to generate meshes via worker.
- Adjust dynamic generator so that the geometry and bvh expands with a change in geometry count and size.
- Update docs with usage snippet
- Add fade in effect
- Add low-res fallback effect
