### PR TITLE
Always use float buffers

### DIFF
--- a/src/core/PathTracingRenderer.js
+++ b/src/core/PathTracingRenderer.js
@@ -1,4 +1,4 @@
-import { RGBAFormat, FloatType, HalfFloatType, Color, Vector2, WebGLRenderTarget, NoBlending, NormalBlending, Vector4 } from 'three';
+import { RGBAFormat, FloatType, Color, Vector2, WebGLRenderTarget, NoBlending, NormalBlending, Vector4, NearestFilter } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { BlendMaterial } from '../materials/fullscreen/BlendMaterial.js';
 import { SobolNumberMapGenerator } from '../utils/SobolNumberMapGenerator.js';
@@ -221,21 +221,24 @@ export class PathTracingRenderer {
 
 		this._sobolTarget = new SobolNumberMapGenerator().generate( renderer );
 
-		// will be null if extension not supported
-		const floatLinearExtensionSupported = renderer.extensions.get( 'OES_texture_float_linear' );
-
 		this._primaryTarget = new WebGLRenderTarget( 1, 1, {
 			format: RGBAFormat,
-			type: floatLinearExtensionSupported ? FloatType : HalfFloatType,
+			type: FloatType,
+			magFilter: NearestFilter,
+			minFilter: NearestFilter,
 		} );
 		this._blendTargets = [
 			new WebGLRenderTarget( 1, 1, {
 				format: RGBAFormat,
-				type: floatLinearExtensionSupported ? FloatType : HalfFloatType,
+				type: FloatType,
+				magFilter: NearestFilter,
+				minFilter: NearestFilter,
 			} ),
 			new WebGLRenderTarget( 1, 1, {
 				format: RGBAFormat,
-				type: floatLinearExtensionSupported ? FloatType : HalfFloatType,
+				type: FloatType,
+				magFilter: NearestFilter,
+				minFilter: NearestFilter,
 			} ),
 		];
 

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -1,4 +1,4 @@
-import { PerspectiveCamera, Scene, Vector2, Clock, NormalBlending, NoBlending, AdditiveBlending, FloatType, HalfFloatType } from 'three';
+import { PerspectiveCamera, Scene, Vector2, Clock, NormalBlending, NoBlending, AdditiveBlending } from 'three';
 import { PathTracingSceneGenerator } from './PathTracingSceneGenerator.js';
 import { PathTracingRenderer } from './PathTracingRenderer.js';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';


### PR DESCRIPTION
Related to #466

Possibly related to #468, #481

The pathtracer no longer performs harding rendering of linear interpolation on the primary float buffers so the filtering is changed to "NEAREST" which addresses situations where `OES_texture_float_linear` is not supported.

To address issues of hardware blending into float buffers (`EXT_float_blend`) we force manual blending of textures in a custom shader.

cc @robertoranon this changes some of the logic from #466 and hopefully ensures more consistent behavior across platforms. It would be great if you could make sure ios rendering still works.