### PR TITLE
Use float buffers in BlurredEnvMapGenerator

### DIFF
--- a/src/utils/BlurredEnvMapGenerator.js
+++ b/src/utils/BlurredEnvMapGenerator.js
@@ -1,4 +1,4 @@
-import { WebGLRenderTarget, RGBAFormat, HalfFloatType, PMREMGenerator, DataTexture, EquirectangularReflectionMapping } from 'three';
+import { WebGLRenderTarget, RGBAFormat, HalfFloatType, PMREMGenerator, DataTexture, EquirectangularReflectionMapping, FloatType, DataUtils } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { MaterialBase } from '../materials/MaterialBase.js';
 import * as CommonGLSL from '../shader/common/index.js';
@@ -58,7 +58,7 @@ export class BlurredEnvMapGenerator {
 		this.renderer = renderer;
 		this.pmremGenerator = new PMREMGenerator( renderer );
 		this.copyQuad = new FullScreenQuad( new PMREMCopyMaterial() );
-		this.renderTarget = new WebGLRenderTarget( 1, 1, { type: HalfFloatType, format: RGBAFormat } );
+		this.renderTarget = new WebGLRenderTarget( 1, 1, { type: FloatType, format: RGBAFormat } );
 
 	}
 
@@ -96,7 +96,14 @@ export class BlurredEnvMapGenerator {
 
 		// read the data back
 		const buffer = new Uint16Array( width * height * 4 );
-		renderer.readRenderTargetPixels( renderTarget, 0, 0, width, height, buffer );
+		const readBuffer = new Float32Array( width * height * 4 );
+		renderer.readRenderTargetPixels( renderTarget, 0, 0, width, height, readBuffer );
+
+		for ( let i = 0, l = readBuffer.length; i < l; i ++ ) {
+
+			buffer[ i ] = DataUtils.toHalfFloat( readBuffer[ i ] );
+
+		}
 
 		const result = new DataTexture( buffer, width, height, RGBAFormat, HalfFloatType );
 		result.minFilter = texture.minFilter;


### PR DESCRIPTION
Fix #588 

It seems that firefox does not support reading half float buffers back to the CPU.