### PR TITLE
Allow disabling jitter

### DIFF
--- a/src/core/PathTracingRenderer.js
+++ b/src/core/PathTracingRenderer.js
@@ -195,6 +195,18 @@ export class PathTracingRenderer {
 
 	}
 
+	set jitterEnabled( v ) {
+
+		this._ptMaterial.jitterEnabled = v;
+
+	};
+
+	get jitterEnabled() {
+
+		return this._ptMaterial.jitterEnabled;
+
+	};
+
 	constructor( renderer ) {
 
 		this.camera = null;
@@ -208,7 +220,8 @@ export class PathTracingRenderer {
 		this._opacityFactor = 1.0;
 		this._renderer = renderer;
 		this._alpha = false;
-		this._fsQuad = new FullScreenQuad( new PhysicalPathTracingMaterial() );
+		this._ptMaterial = new PhysicalPathTracingMaterial();
+		this._fsQuad = new FullScreenQuad( this._ptMaterial );
 		this._blendQuad = new FullScreenQuad( new BlendMaterial() );
 		this._task = null;
 		this._currentTile = 0;

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -81,6 +81,18 @@ export class WebGLPathTracer {
 
 	}
 
+	set jitterEnabled( v ) {
+
+		this._pathTracer.jitterEnabled = v;
+
+	};
+
+	get jitterEnabled() {
+
+		return this._pathTracer.jitterEnabled;
+		
+	}
+
 	constructor( renderer ) {
 
 		// members

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -132,6 +132,7 @@ export class WebGLPathTracer {
 	rasterizeScene: boolean;
 	renderToCanvas: boolean;
 	textureSize: Vector2;
+	jitterEnabled: boolean
 
 	rasterizeSceneCallback: ( scene: Scene, camera: Camera ) => void;
 	renderToCanvasCallback: ( target: WebGLRenderTarget, renderer: WebGLRenderer, quad: FullScreenQuad ) => void;

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -36,6 +36,18 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 	}
 
+	set( v ) {
+
+		this.uniforms.jitterEnabled.value = v ? 1 : 0;
+		
+	}
+
+	get() {
+
+		return this.uniforms.jitterEnabled.value > 1;
+		
+	}
+
 	constructor( parameters ) {
 
 		super( {
@@ -112,6 +124,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				sobolTexture: { value: null },
 				stratifiedTexture: { value: new StratifiedSamplesTexture() },
 				stratifiedOffsetTexture: { value: new BlueNoiseTexture( 64, 1 ) },
+				jitterEnabled: { value: 1 }
 			},
 
 			vertexShader: /* glsl */`
@@ -293,6 +306,8 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 				${ RenderGLSL.direct_light_contribution_function }
 				${ RenderGLSL.get_surface_record_function }
 
+				uniform float jitterEnabled;
+    
 				void main() {
 
 					// init

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -36,13 +36,13 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 
 	}
 
-	set( v ) {
+	set jitterEnabled( v ) {
 
 		this.uniforms.jitterEnabled.value = v ? 1 : 0;
 		
 	}
 
-	get() {
+	get jitterEnabled() {
 
 		return this.uniforms.jitterEnabled.value > 1;
 		

--- a/src/materials/pathtracing/glsl/camera_util_functions.glsl.js
+++ b/src/materials/pathtracing/glsl/camera_util_functions.glsl.js
@@ -13,7 +13,7 @@ export const camera_util_functions = /* glsl */`
 		// Jitter the camera ray by finding a uv coordinate at a random sample
 		// around this pixel's UV coordinate for AA
 		vec2 ruv = rand2( 0 );
-		vec2 jitteredUv = vUv + vec2( tentFilter( ruv.x ) * ssd.x, tentFilter( ruv.y ) * ssd.y );
+		vec2 jitteredUv = vUv + ( (jitterEnabled > 0.5) ? vec2( tentFilter( ruv.x ) * ssd.x, tentFilter( ruv.y ) * ssd.y ) : vec2(0.0, 0.0) );
 		Ray ray;
 
 		#if CAMERA_TYPE == 2


### PR DESCRIPTION
Jitter is what makes raytracers grainy, by shooting pixels at slightly different directions than normal. This allows disabling it, for tasks that don't need it.