### PR TITLE
Fix to only render objects with visible true

### DIFF
--- a/src/core/utils/StaticGeometryGenerator.js
+++ b/src/core/utils/StaticGeometryGenerator.js
@@ -13,7 +13,7 @@ function flatTraverseMeshes( objects, cb ) {
 	for ( let i = 0, l = objects.length; i < l; i ++ ) {
 
 		const object = objects[ i ];
-		object.traverse( o => {
+		object.traverseVisible( o => {
 
 			if ( o.isMesh ) {
 


### PR DESCRIPTION
It makes sense that only objects with visible true are rendered.

The old code used traverseVisible when generating the mesh list, but it was missing in the newer code.