### PR TITLE
fix StaticGeometryGenerator generate result wrong when specific condition

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -8,6 +8,7 @@ import {
 	Mesh,
 	MeshStandardMaterial,
 	PlaneGeometry,
+	BoxGeometry,
 	MeshPhysicalMaterial,
 	Scene,
 	PerspectiveCamera,
@@ -114,7 +115,7 @@ const params = {
 
 let floorPlane, gui, stats;
 let pathTracer, renderer, orthoCamera, perspectiveCamera, activeCamera;
-let controls, scene, model;
+let controls, scene, model, testMesh1, testMesh2, testMesh3, testMesh4;
 let gradientMap;
 let loader;
 
@@ -181,7 +182,31 @@ async function init() {
 	);
 	floorPlane.scale.setScalar( 5 );
 	floorPlane.rotation.x = - Math.PI / 2;
+	floorPlane.name = 'floor';
 	scene.add( floorPlane );
+
+	// initialize testMesh 1234 with small boxes
+	const boxGeometry = new BoxGeometry( 0.1, 0.1, 0.1 );
+	const boxMaterial = new MeshStandardMaterial( { color: 0xff0000 } );
+	testMesh1 = new Mesh( boxGeometry, boxMaterial );
+	testMesh1.position.set( - 0.5, 0.05, 0.5 );
+	testMesh1.name = 'testMesh1';
+	scene.add( testMesh1 );
+	const boxMaterial2 = new MeshStandardMaterial( { color: 0x00ff00 } );
+	testMesh2 = new Mesh( boxGeometry, boxMaterial2 );
+	testMesh2.position.set( - 0.5, 0.05, - 0.5 );
+	testMesh2.name = 'testMesh2';
+	scene.add( testMesh2 );
+	const boxMaterial3 = new MeshStandardMaterial( { color: 0x0000ff } );
+	testMesh3 = new Mesh( boxGeometry, boxMaterial3 );
+	testMesh3.position.set( 0.5, 0.05, - 0.5 );
+	testMesh3.name = 'testMesh3';
+	scene.add( testMesh3 );
+	const boxMaterial4 = new MeshStandardMaterial( { color: 0xffff00 } );
+	testMesh4 = new Mesh( boxGeometry, boxMaterial4 );
+	testMesh4.position.set( 0.5, 0.05, 0.5 );
+	testMesh4.name = 'testMesh4';
+	scene.add( testMesh4 );
 
 	stats = new Stats();
 	document.body.appendChild( stats.dom );
@@ -337,6 +362,40 @@ function buildGui() {
 
 	} );
 
+	const meshParams = {
+		mesh1Visible : true,
+		mesh2Visible : true,
+		mesh3Visible : true,
+		mesh4Visible : true,
+		floorVisible : true,
+	}
+	const meshFolder = gui.addFolder( 'Test Mesh' );
+	meshFolder.add(meshParams, 'mesh1Visible').onChange( v => {
+		testMesh1.visible = v;
+		pathTracer.setScene( scene, activeCamera );
+		pathTracer.reset();
+	});
+	meshFolder.add(meshParams, 'mesh2Visible').onChange( v => {
+		testMesh2.visible = v;
+		pathTracer.setScene( scene, activeCamera );
+		pathTracer.reset();
+	});
+	meshFolder.add(meshParams, 'mesh3Visible').onChange( v => {
+		testMesh3.visible = v;
+		pathTracer.setScene( scene, activeCamera );
+		pathTracer.reset();
+	});
+	meshFolder.add(meshParams, 'mesh4Visible').onChange( v => {
+		testMesh4.visible = v;
+		pathTracer.setScene( scene, activeCamera );
+		pathTracer.reset();
+	});
+	meshFolder.add(meshParams, 'floorVisible').onChange( v => {
+		floorPlane.visible = v;
+		pathTracer.setScene( scene, activeCamera );
+		pathTracer.reset();
+	});
+	
 	const pathTracingFolder = gui.addFolder( 'Path Tracer' );
 	pathTracingFolder.add( params, 'enable' );
 	pathTracingFolder.add( params, 'pause' );
@@ -615,13 +674,9 @@ async function updateModel() {
 	box.setFromObject( model );
 	floorPlane.position.y = box.min.y;
 
-	scene.add( model );
+	// scene.add( model );
 
-	await pathTracer.setSceneAsync( scene, activeCamera, {
-
-		onProgress: v => loader.setPercentage( 0.5 + 0.5 * v ),
-
-	} );
+	pathTracer.setSceneAsync( scene, activeCamera)
 
 	loader.setPercentage( 1 );
 	loader.setCredits( modelInfo.credit || '' );

--- a/example/index.js
+++ b/example/index.js
@@ -363,39 +363,49 @@ function buildGui() {
 	} );
 
 	const meshParams = {
-		mesh1Visible : true,
-		mesh2Visible : true,
-		mesh3Visible : true,
-		mesh4Visible : true,
-		floorVisible : true,
-	}
+		mesh1Visible: true,
+		mesh2Visible: true,
+		mesh3Visible: true,
+		mesh4Visible: true,
+		floorVisible: true,
+	};
 	const meshFolder = gui.addFolder( 'Test Mesh' );
-	meshFolder.add(meshParams, 'mesh1Visible').onChange( v => {
+	meshFolder.add( meshParams, 'mesh1Visible' ).onChange( v => {
+
 		testMesh1.visible = v;
 		pathTracer.setScene( scene, activeCamera );
 		pathTracer.reset();
-	});
-	meshFolder.add(meshParams, 'mesh2Visible').onChange( v => {
+
+	} );
+	meshFolder.add( meshParams, 'mesh2Visible' ).onChange( v => {
+
 		testMesh2.visible = v;
 		pathTracer.setScene( scene, activeCamera );
 		pathTracer.reset();
-	});
-	meshFolder.add(meshParams, 'mesh3Visible').onChange( v => {
+
+	} );
+	meshFolder.add( meshParams, 'mesh3Visible' ).onChange( v => {
+
 		testMesh3.visible = v;
 		pathTracer.setScene( scene, activeCamera );
 		pathTracer.reset();
-	});
-	meshFolder.add(meshParams, 'mesh4Visible').onChange( v => {
+
+	} );
+	meshFolder.add( meshParams, 'mesh4Visible' ).onChange( v => {
+
 		testMesh4.visible = v;
 		pathTracer.setScene( scene, activeCamera );
 		pathTracer.reset();
-	});
-	meshFolder.add(meshParams, 'floorVisible').onChange( v => {
+
+	} );
+	meshFolder.add( meshParams, 'floorVisible' ).onChange( v => {
+
 		floorPlane.visible = v;
 		pathTracer.setScene( scene, activeCamera );
 		pathTracer.reset();
-	});
-	
+
+	} );
+
 	const pathTracingFolder = gui.addFolder( 'Path Tracer' );
 	pathTracingFolder.add( params, 'enable' );
 	pathTracingFolder.add( params, 'pause' );
@@ -676,7 +686,7 @@ async function updateModel() {
 
 	// scene.add( model );
 
-	pathTracer.setSceneAsync( scene, activeCamera)
+	pathTracer.setSceneAsync( scene, activeCamera );
 
 	loader.setPercentage( 1 );
 	loader.setCredits( modelInfo.credit || '' );

--- a/example/index.js
+++ b/example/index.js
@@ -8,7 +8,6 @@ import {
 	Mesh,
 	MeshStandardMaterial,
 	PlaneGeometry,
-	BoxGeometry,
 	MeshPhysicalMaterial,
 	Scene,
 	PerspectiveCamera,
@@ -115,7 +114,7 @@ const params = {
 
 let floorPlane, gui, stats;
 let pathTracer, renderer, orthoCamera, perspectiveCamera, activeCamera;
-let controls, scene, model, testMesh1, testMesh2, testMesh3, testMesh4;
+let controls, scene, model;
 let gradientMap;
 let loader;
 
@@ -182,31 +181,7 @@ async function init() {
 	);
 	floorPlane.scale.setScalar( 5 );
 	floorPlane.rotation.x = - Math.PI / 2;
-	floorPlane.name = 'floor';
 	scene.add( floorPlane );
-
-	// initialize testMesh 1234 with small boxes
-	const boxGeometry = new BoxGeometry( 0.1, 0.1, 0.1 );
-	const boxMaterial = new MeshStandardMaterial( { color: 0xff0000 } );
-	testMesh1 = new Mesh( boxGeometry, boxMaterial );
-	testMesh1.position.set( - 0.5, 0.05, 0.5 );
-	testMesh1.name = 'testMesh1';
-	scene.add( testMesh1 );
-	const boxMaterial2 = new MeshStandardMaterial( { color: 0x00ff00 } );
-	testMesh2 = new Mesh( boxGeometry, boxMaterial2 );
-	testMesh2.position.set( - 0.5, 0.05, - 0.5 );
-	testMesh2.name = 'testMesh2';
-	scene.add( testMesh2 );
-	const boxMaterial3 = new MeshStandardMaterial( { color: 0x0000ff } );
-	testMesh3 = new Mesh( boxGeometry, boxMaterial3 );
-	testMesh3.position.set( 0.5, 0.05, - 0.5 );
-	testMesh3.name = 'testMesh3';
-	scene.add( testMesh3 );
-	const boxMaterial4 = new MeshStandardMaterial( { color: 0xffff00 } );
-	testMesh4 = new Mesh( boxGeometry, boxMaterial4 );
-	testMesh4.position.set( 0.5, 0.05, 0.5 );
-	testMesh4.name = 'testMesh4';
-	scene.add( testMesh4 );
 
 	stats = new Stats();
 	document.body.appendChild( stats.dom );
@@ -359,50 +334,6 @@ function buildGui() {
 	gui.add( params, 'model', Object.keys( models ).sort() ).onChange( v => {
 
 		window.location.hash = v;
-
-	} );
-
-	const meshParams = {
-		mesh1Visible: true,
-		mesh2Visible: true,
-		mesh3Visible: true,
-		mesh4Visible: true,
-		floorVisible: true,
-	};
-	const meshFolder = gui.addFolder( 'Test Mesh' );
-	meshFolder.add( meshParams, 'mesh1Visible' ).onChange( v => {
-
-		testMesh1.visible = v;
-		pathTracer.setScene( scene, activeCamera );
-		pathTracer.reset();
-
-	} );
-	meshFolder.add( meshParams, 'mesh2Visible' ).onChange( v => {
-
-		testMesh2.visible = v;
-		pathTracer.setScene( scene, activeCamera );
-		pathTracer.reset();
-
-	} );
-	meshFolder.add( meshParams, 'mesh3Visible' ).onChange( v => {
-
-		testMesh3.visible = v;
-		pathTracer.setScene( scene, activeCamera );
-		pathTracer.reset();
-
-	} );
-	meshFolder.add( meshParams, 'mesh4Visible' ).onChange( v => {
-
-		testMesh4.visible = v;
-		pathTracer.setScene( scene, activeCamera );
-		pathTracer.reset();
-
-	} );
-	meshFolder.add( meshParams, 'floorVisible' ).onChange( v => {
-
-		floorPlane.visible = v;
-		pathTracer.setScene( scene, activeCamera );
-		pathTracer.reset();
 
 	} );
 
@@ -684,9 +615,13 @@ async function updateModel() {
 	box.setFromObject( model );
 	floorPlane.position.y = box.min.y;
 
-	// scene.add( model );
+	scene.add( model );
 
-	pathTracer.setSceneAsync( scene, activeCamera );
+	await pathTracer.setSceneAsync( scene, activeCamera, {
+
+		onProgress: v => loader.setPercentage( 0.5 + 0.5 * v ),
+
+	} );
 
 	loader.setPercentage( 1 );
 	loader.setCredits( modelInfo.credit || '' );

--- a/src/core/utils/StaticGeometryGenerator.js
+++ b/src/core/utils/StaticGeometryGenerator.js
@@ -237,7 +237,6 @@ export class StaticGeometryGenerator {
 
 		}
 
-
 		for ( let i = 0, l = meshes.length; i < l; i ++ ) {
 
 			const mesh = meshes[ i ];

--- a/src/core/utils/StaticGeometryGenerator.js
+++ b/src/core/utils/StaticGeometryGenerator.js
@@ -231,6 +231,13 @@ export class StaticGeometryGenerator {
 
 		// get the list of geometries to merge
 		let forceUpdate = false;
+		// if ( meshes.length !== previousMergeInfo.length ) {
+
+		// 	forceUpdate = true;
+
+		// }
+
+		console.log('meshes', meshes.map(m => m.name))
 		for ( let i = 0, l = meshes.length; i < l; i ++ ) {
 
 			const mesh = meshes[ i ];
@@ -239,16 +246,19 @@ export class StaticGeometryGenerator {
 
 			const info = previousMergeInfo[ i ];
 			if ( ! info || info.uuid !== geom.uuid ) {
-
+				
+				console.log('forceUpdate true')
 				skipAssigningAttributes.push( false );
 				forceUpdate = true;
 
 			} else if ( info.version !== geom.version ) {
 
+				console.log('GEOMETRY_ADJUSTED')
 				skipAssigningAttributes.push( false );
 
 			} else {
-
+				
+				console.log('NO_CHANGE')
 				skipAssigningAttributes.push( true );
 
 			}

--- a/src/core/utils/StaticGeometryGenerator.js
+++ b/src/core/utils/StaticGeometryGenerator.js
@@ -237,7 +237,7 @@ export class StaticGeometryGenerator {
 
 		// }
 
-		console.log('meshes', meshes.map(m => m.name))
+		console.log( 'meshes', meshes.map( m => m.name ) );
 		for ( let i = 0, l = meshes.length; i < l; i ++ ) {
 
 			const mesh = meshes[ i ];
@@ -246,19 +246,19 @@ export class StaticGeometryGenerator {
 
 			const info = previousMergeInfo[ i ];
 			if ( ! info || info.uuid !== geom.uuid ) {
-				
-				console.log('forceUpdate true')
+
+				console.log( 'forceUpdate true' );
 				skipAssigningAttributes.push( false );
 				forceUpdate = true;
 
 			} else if ( info.version !== geom.version ) {
 
-				console.log('GEOMETRY_ADJUSTED')
+				console.log( 'GEOMETRY_ADJUSTED' );
 				skipAssigningAttributes.push( false );
 
 			} else {
-				
-				console.log('NO_CHANGE')
+
+				console.log( 'NO_CHANGE' );
 				skipAssigningAttributes.push( true );
 
 			}

--- a/src/core/utils/StaticGeometryGenerator.js
+++ b/src/core/utils/StaticGeometryGenerator.js
@@ -231,13 +231,13 @@ export class StaticGeometryGenerator {
 
 		// get the list of geometries to merge
 		let forceUpdate = false;
-		// if ( meshes.length !== previousMergeInfo.length ) {
+		if ( meshes.length !== previousMergeInfo.length ) {
 
-		// 	forceUpdate = true;
+			forceUpdate = true;
 
-		// }
+		}
 
-		console.log( 'meshes', meshes.map( m => m.name ) );
+
 		for ( let i = 0, l = meshes.length; i < l; i ++ ) {
 
 			const mesh = meshes[ i ];
@@ -247,18 +247,15 @@ export class StaticGeometryGenerator {
 			const info = previousMergeInfo[ i ];
 			if ( ! info || info.uuid !== geom.uuid ) {
 
-				console.log( 'forceUpdate true' );
 				skipAssigningAttributes.push( false );
 				forceUpdate = true;
 
 			} else if ( info.version !== geom.version ) {
 
-				console.log( 'GEOMETRY_ADJUSTED' );
 				skipAssigningAttributes.push( false );
 
 			} else {
 
-				console.log( 'NO_CHANGE' );
 				skipAssigningAttributes.push( true );
 
 			}


### PR DESCRIPTION
Hi I found a bug so i made a pr for reproducing bug sample
check the sample(index.js) in my pr

# how to reproduce a bug

a screenshot after initialization
<img width="1148" alt="image" src="https://github.com/gkjohnson/three-gpu-pathtracer/assets/108255990/5900752f-4feb-48f2-96c2-589c89876c02">

## 1. check the last mesh name in the console
<img width="401" alt="image" src="https://github.com/gkjohnson/three-gpu-pathtracer/assets/108255990/d1dd67d7-a527-455b-9c7a-546f37a01d02">
<br/>

## 2. make visible false mesh at the last of array(in this case mesh4)
<img width="1351" alt="image" src="https://github.com/gkjohnson/three-gpu-pathtracer/assets/108255990/59c26177-7555-44ca-a2ef-9939f6ca151f">
<br/>
then you can see artifact at mesh4's position



### Description
at this time console here
<img width="419" alt="image" src="https://github.com/gkjohnson/three-gpu-pathtracer/assets/108255990/182419ea-aab4-4394-b2bf-5dce638ac288">

At first initialization force update true in all meshes because there's no cached

after testMesh4 visible false,
meshes from this._getMeshes make an array that only visible in the scene
then for loop check difference but there's no difference even testMesh4 is disappear(because for loop just check current meshes) so staticGenerator return NO_CHANGE result and then it causes an artifact

## How to fix it

```
		let forceUpdate = false;
		if ( meshes.length !== previousMergeInfo.length ) {

			forceUpdate = true;

		}

		console.log('meshes', meshes.map(m => m.name))
		for ( let i = 0, l = meshes.length; i < l; i ++ ) {
```

if you guys agree my solution i'll clean up this pr that only remain solution