### PR TITLE
feat: add shaped area light helper

### DIFF
--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -32,6 +32,7 @@ const params = {
 	// area light settings
 	enabled: true,
 	isCircular: false,
+	visibleSurface: false,
 	intensity: 2,
 	color: '#ffffff',
 	width: 1,
@@ -128,7 +129,7 @@ async function init() {
 	redLight.position.z = - 1.5;
 	redLight.rotateX( Math.PI );
 	redLight.isCircular = false;
-	scene.add( redLight );
+	// scene.add( redLight );
 
 	// initialize scene
 	await pathTracer.setSceneAsync( scene, camera, {
@@ -157,6 +158,7 @@ async function init() {
 
 	const areaLightFolder = gui.addFolder( 'Area Light' );
 	areaLightFolder.add( params, 'enabled' ).name( 'enable' ).onChange( onParamsChange );
+	areaLightFolder.add( params, 'visibleSurface' ).name( 'visibleSurface' ).onChange( onParamsChange );
 	areaLightFolder.add( params, 'isCircular' ).name( 'isCircular' ).onChange( onParamsChange );
 	areaLightFolder.add( params, 'intensity', 0, 200 ).name( 'intensity' ).onChange( onParamsChange );
 	areaLightFolder.addColor( params, 'color' ).name( 'color' ).onChange( onParamsChange );
@@ -179,6 +181,7 @@ function onParamsChange() {
 	areaLight.height = params.height;
 	areaLight.color.set( params.color ).convertSRGBToLinear();
 	areaLight.visible = params.enabled;
+	areaLight.visible = params.visibleSurface;
 
 	pathTracer.filterGlossyFactor = params.filterGlossyFactor;
 	pathTracer.bounces = params.bounces;

--- a/src/materials/pathtracing/PhysicalPathTracingMaterial.js
+++ b/src/materials/pathtracing/PhysicalPathTracingMaterial.js
@@ -361,6 +361,7 @@ export class PhysicalPathTracingMaterial extends MaterialBase {
 									// NOTE: Only area lights are supported for forward sampling and can be hit
 									float misWeight = misHeuristic( scatterRec.pdf, lightRec.pdf / lightsDenom );
 									gl_FragColor.rgb += lightRec.emission * state.throughputColor * misWeight;
+									gl_FragColor.a = lightRec.visibleSurface; // This is not working as expected
 
 									#else
 

--- a/src/objects/ShapedAreaLight.js
+++ b/src/objects/ShapedAreaLight.js
@@ -6,6 +6,7 @@ export class ShapedAreaLight extends RectAreaLight {
 
 		super( ...args );
 		this.isCircular = false;
+		this.visibleSurface = false;
 
 	}
 
@@ -14,6 +15,7 @@ export class ShapedAreaLight extends RectAreaLight {
 		super.copy( source, recursive );
 
 		this.isCircular = source.isCircular;
+		this.visibleSurface = source.visibleSurface;
 
 		return this;
 

--- a/src/shader/sampling/light_sampling_functions.glsl.js
+++ b/src/shader/sampling/light_sampling_functions.glsl.js
@@ -35,6 +35,7 @@ export const light_sampling_functions = /* glsl */`
 	struct LightRecord {
 
 		float dist;
+		float visibleSurface;
 		vec3 direction;
 		float pdf;
 		vec3 emission;
@@ -72,7 +73,7 @@ export const light_sampling_functions = /* glsl */`
 				lightRec.emission = light.color * light.intensity;
 				lightRec.direction = rayDirection;
 				lightRec.type = light.type;
-
+				lightRec.visibleSurface = light.visibleSurface;
 			}
 
 		}

--- a/src/shader/structs/lights_struct.glsl.js
+++ b/src/shader/structs/lights_struct.glsl.js
@@ -17,6 +17,7 @@ export const lights_struct = /* glsl */`
 
 		vec3 position;
 		int type;
+		float visibleSurface;
 
 		vec3 color;
 		float intensity;
@@ -44,12 +45,14 @@ export const lights_struct = /* glsl */`
 		vec4 s1 = texelFetch1D( tex, i + 1u );
 		vec4 s2 = texelFetch1D( tex, i + 2u );
 		vec4 s3 = texelFetch1D( tex, i + 3u );
+		vec4 s4 = texelFetch1D( tex, i + 4u );
 
 		Light l;
 		l.position = s0.rgb;
 		l.type = int( round( s0.a ) );
 
 		l.color = s1.rgb;
+		l.visibleSurface = s4.r;
 		l.intensity = s1.a;
 
 		l.u = s2.rgb;
@@ -58,7 +61,6 @@ export const lights_struct = /* glsl */`
 
 		if ( l.type == SPOT_LIGHT_TYPE || l.type == POINT_LIGHT_TYPE ) {
 
-			vec4 s4 = texelFetch1D( tex, i + 4u );
 			vec4 s5 = texelFetch1D( tex, i + 5u );
 			l.radius = s4.r;
 			l.decay = s4.g;

--- a/src/uniforms/LightsInfoUniformStruct.js
+++ b/src/uniforms/LightsInfoUniformStruct.js
@@ -126,6 +126,10 @@ export class LightsInfoUniformStruct {
 
 				// area
 				floatArray[ baseIndex + ( index ++ ) ] = u.cross( v ).length() * ( l.isCircular ? ( Math.PI / 4.0 ) : 1.0 );
+				index ++;
+
+				// sample 5
+				floatArray[ baseIndex + ( index ++ ) ] = l.visibleSurface ? 0.0 : 1.0;
 
 			} else if ( l.isSpotLight ) {
 


### PR DESCRIPTION
I manage to add the new visibleSurface value, but I couldn't find a way to render the texture as helper. So I believe I need some help here. I should have to modify the src/shader/sampling/light_sampling_functions.glsl.js in order to access to the src/materials/pathtracing/PhysicalPathTracingMaterial.js

(now is just adding it to the alpha channel hideous just to prove that it reach the value, of course also tried to move in other locations like using the `state.firstRay`, but didn't find the right one to render a texture as helper)

![Area Light Path Tracing](https://github.com/gkjohnson/three-gpu-pathtracer/assets/63722373/4ca74e4f-e004-4acb-aff2-b7b4c5252491)

btw, I'll be off a couple of days, so if this is not priority, with your help we can solve it :)
