### PR TITLE
StaticGeometryGenerator: Ensure geometries are updated

### DIFF
--- a/src/core/utils/BakedGeometry.js
+++ b/src/core/utils/BakedGeometry.js
@@ -24,7 +24,7 @@ export class BakedGeometry extends BufferGeometry {
 
 			const attr1 = attributes[ key ];
 			const attr2 = this.attributes[ key ];
-			if ( attr2 && ! validateAttributes( attr1, attr2 ) ) {
+			if ( ! validateAttributes( attr1, attr2 ) ) {
 
 				return false;
 

--- a/src/core/utils/BakedGeometry.js
+++ b/src/core/utils/BakedGeometry.js
@@ -1,6 +1,7 @@
 import { BufferGeometry } from 'three';
 import { MeshDiff } from './MeshDiff.js';
 import { convertToStaticGeometry } from './convertToStaticGeometry.js';
+import { validateAttributes } from './BufferAttributeUtils.js';
 
 export class BakedGeometry extends BufferGeometry {
 
@@ -10,6 +11,28 @@ export class BakedGeometry extends BufferGeometry {
 		this.version = 0;
 		this.hash = null;
 		this._diff = new MeshDiff();
+
+	}
+
+	// returns whether the passed mesh is compatible with this baked geometry
+	// such that it can be updated without resizing attributes
+	isCompatible( mesh ) {
+
+		const geometry = mesh.geometry;
+		const attributes = geometry.attributes;
+		for ( const key in attributes ) {
+
+			const attr1 = attributes[ key ];
+			const attr2 = this.attributes[ key ];
+			if ( attr2 && ! validateAttributes( attr1, attr2 ) ) {
+
+				return false;
+
+			}
+
+		}
+
+		return true;
 
 	}
 

--- a/src/core/utils/BufferAttributeUtils.js
+++ b/src/core/utils/BufferAttributeUtils.js
@@ -41,12 +41,18 @@ export function createAttributeClone( attr, countOverride = null ) {
 
 }
 
-// Confirms that the two provided attributes are compatible
+// Confirms that the two provided attributes are compatible. Returns false if they are not.
 export function validateAttributes( attr1, attr2 ) {
 
 	if ( ! attr1 && ! attr2 ) {
 
-		return;
+		return true;
+
+	}
+
+	if ( Boolean( attr1 ) !== Boolean( attr2 ) ) {
+
+		return false;
 
 	}
 
@@ -57,8 +63,10 @@ export function validateAttributes( attr1, attr2 ) {
 
 	if ( ! sameCount || ! sameNormalized || ! sameType || ! sameItemSize ) {
 
-		throw new Error();
+		return false;
 
 	}
+
+	return true;
 
 }

--- a/src/core/utils/MeshDiff.js
+++ b/src/core/utils/MeshDiff.js
@@ -13,9 +13,8 @@ function getGeometryHash( geometry ) {
 	}
 
 	const keys = Object.keys( attributes ).sort();
-	for ( const i in keys ) {
+	for ( const key of keys ) {
 
-		const key = keys[ i ];
 		const attr = attributes[ key ];
 		hash += `${ key }_${ attr.version }|`;
 

--- a/src/core/utils/MeshDiff.js
+++ b/src/core/utils/MeshDiff.js
@@ -1,29 +1,23 @@
 import { Matrix4 } from 'three';
 import { bufferToHash } from '../../utils/bufferToHash.js';
 
-function attributeSort( a, b ) {
-
-	if ( a.uuid > b.uuid ) return 1;
-	if ( a.uuid < b.uuid ) return - 1;
-	return 0;
-
-}
-
 function getGeometryHash( geometry ) {
 
-	let hash = '';
+	let hash = geometry.uuid;
 	const attributes = Object.values( geometry.attributes );
 	if ( geometry.index ) {
 
 		attributes.push( geometry.index );
+		hash += `index|${ geometry.index.version }`;
 
 	}
 
-	attributes.sort( attributeSort );
+	const keys = Object.keys( attributes ).sort();
+	for ( const i in keys ) {
 
-	for ( const attr of attributes ) {
-
-		hash += `${ attr.uuid }_${ attr.version }|`;
+		const key = keys[ i ];
+		const attr = attributes[ key ];
+		hash += `${ key }_${ attr.version }|`;
 
 	}
 

--- a/src/core/utils/StaticGeometryGenerator.js
+++ b/src/core/utils/StaticGeometryGenerator.js
@@ -171,15 +171,24 @@ export class StaticGeometryGenerator {
 			unusedMeshKeys.delete( meshKey );
 
 			// initialize the intermediate geometry
-			if ( ! _intermediateGeometry.has( meshKey ) ) {
+			// if the mesh and source geometry have changed in such a way that they are no longer
+			// compatible then regenerate the baked geometry from scratch
+			let geom = _intermediateGeometry.get( meshKey );
+			if ( ! geom || ! geom.isCompatible( mesh ) ) {
 
-				_intermediateGeometry.set( meshKey, new BakedGeometry() );
+				if ( geom ) {
+
+					geom.dispose();
+
+				}
+
+				geom = new BakedGeometry();
+				_intermediateGeometry.set( meshKey, geom );
 
 			}
 
 			// transform the geometry into the intermediate buffer geometry, saving whether
 			// or not it changed.
-			const geom = _intermediateGeometry.get( meshKey );
 			if ( geom.updateFrom( mesh, convertOptions ) ) {
 
 				// TODO: provide option for only generating the set of attributes that are present


### PR DESCRIPTION
Fix #646 

Fixes cases where replacing the geometry causes errors on scene update or no change:
- Include the geometry uuid instead of the (non existent) BufferAttribute UUIDs for representing a BufferGeometry hash.
- Discard BakedBufferGeometry instance if it needs to be resized, forcing a full scene geometry update.

cc @ycw @dongho-shin would it be possible to test this to make sure it addresses the problems from #646?