### PR TITLE
Fix to always set environment intensity

### DIFF
--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -306,7 +306,7 @@ export class WebGLPathTracer {
 		}
 
 		// update scene environment
-		material.environmentIntensity = scene.environment !== null ? (scene.environmentIntensity ?? 1) : 0;
+		material.environmentIntensity = scene.environment !== null ? ( scene.environmentIntensity ?? 1 ) : 0;
 		material.environmentRotation.makeRotationFromEuler( scene.environmentRotation ).invert();
 		if ( this._previousEnvironment !== scene.environment ) {
 
@@ -326,7 +326,7 @@ export class WebGLPathTracer {
 
 				}
 
-			} 
+			}
 
 		}
 

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -306,7 +306,7 @@ export class WebGLPathTracer {
 		}
 
 		// update scene environment
-		material.environmentIntensity = scene.environmentIntensity ?? 1;
+		material.environmentIntensity = scene.environment !== null ? (scene.environmentIntensity ?? 1) : 0;
 		material.environmentRotation.makeRotationFromEuler( scene.environmentRotation ).invert();
 		if ( this._previousEnvironment !== scene.environment ) {
 
@@ -326,11 +326,7 @@ export class WebGLPathTracer {
 
 				}
 
-			} else {
-
-				material.environmentIntensity = 0;
-
-			}
+			} 
 
 		}
 


### PR DESCRIPTION
Reproduction Paths
1. after the environment of Pathtracer is set once, change the environment of scene to null.
2. when pathtracer is executed again with the environment null, it does not set the environment intensity because it is the same as the previous environment, and the old environment of the scene is rendered.

Solution
Always reset environment intensity