### PR TITLE
materialDatabase updates

### DIFF
--- a/example/materialDatabase.js
+++ b/example/materialDatabase.js
@@ -183,7 +183,7 @@ function applyMaterialInfo( info, material ) {
 	material.thickness = 1.0;
 	material.iridescence = 0.0;
 	material.iridescenceIOR = 1.0;
-	material.iridescenceThicknessRange = [ 0, 0 ]
+	material.iridescenceThicknessRange = [ 0, 0 ];
 
 	if ( info.specularColor ) material.specularColor.setRGB( ...info.specularColor );
 	if ( 'metalness' in info ) material.metalness = info.metalness;
@@ -197,6 +197,7 @@ function applyMaterialInfo( info, material ) {
 		material.iridescenceThicknessRange = [ info.thinFilmThickness, info.thinFilmThickness ];
 
 	}
+
 	if ( material.transmission ) {
 
 		if ( info.color ) material.attenuationColor.setRGB( ...info.color );
@@ -208,7 +209,7 @@ function applyMaterialInfo( info, material ) {
 
 	}
 
-	imgEl.src = info.reference[0];
+	imgEl.src = info.reference[ 0 ];
 
 }
 

--- a/example/materialDatabase.js
+++ b/example/materialDatabase.js
@@ -1,5 +1,5 @@
 import {
-	ACESFilmicToneMapping,
+	AgXToneMapping,
 	PerspectiveCamera,
 	Scene,
 	Box3,
@@ -48,7 +48,7 @@ async function init() {
 
 	// renderer
 	renderer = new WebGLRenderer( { antialias: true } );
-	renderer.toneMapping = ACESFilmicToneMapping;
+	renderer.toneMapping = AgXToneMapping;
 	document.body.appendChild( renderer.domElement );
 
 	// path tracer
@@ -181,13 +181,22 @@ function applyMaterialInfo( info, material ) {
 	material.roughness = 1.0;
 	material.ior = 1.5;
 	material.thickness = 1.0;
+	material.iridescence = 0.0;
+	material.iridescenceIOR = 1.0;
+	material.iridescenceThicknessRange = [ 0, 0 ]
 
 	if ( info.specularColor ) material.specularColor.setRGB( ...info.specularColor );
 	if ( 'metalness' in info ) material.metalness = info.metalness;
 	if ( 'roughness' in info ) material.roughness = info.roughness;
 	if ( 'ior' in info ) material.ior = info.ior;
 	if ( 'transmission' in info ) material.transmission = info.transmission;
+	if ( 'thinFilmThickness' in info ) {
 
+		material.iridescence = 1.0;
+		material.iridescenceIOR = info.thinFilmIor;
+		material.iridescenceThicknessRange = [ info.thinFilmThickness, info.thinFilmThickness ];
+
+	}
 	if ( material.transmission ) {
 
 		if ( info.color ) material.attenuationColor.setRGB( ...info.color );
@@ -199,8 +208,7 @@ function applyMaterialInfo( info, material ) {
 
 	}
 
-	const cleanName = info.name.replace( /\s+/g, '-' ).replace( /[()]+/g, '' );
-	imgEl.src = `https://physicallybased.info/reference/render/${ cleanName }-cycles.png`;
+	imgEl.src = info.reference[0];
 
 }
 


### PR DESCRIPTION
### Switched tonemapper from ACES to AgX
Since the reference images use the AgX tonemapper (with the Base Contrast look), this update makes the render match the reference images better.

Before (ACES)
<img width="553" alt="Screenshot 2024-07-15 at 20 30 11" src="https://github.com/user-attachments/assets/9533cb2e-c7b2-442e-8a6d-6ef1ece400b4">
After (AgX)
<img width="553" alt="Screenshot 2024-07-15 at 20 28 46" src="https://github.com/user-attachments/assets/636e7186-3658-4d8d-95fb-d57e0a719abc">

### Added iridescence for materials that support it
Materials such as Pearl and Soap Bubble now have values for iridescence on the API side and this change enables it whenever a **thinFilmThickness** value is found on a material.
<img width="776" alt="Screenshot 2024-07-14 at 20 03 00" src="https://github.com/user-attachments/assets/62dea776-25a9-489e-8c62-3cacfb923c06">


### Changed reference image source
The API provides a **reference** field with a URL to a reference image (same images as before) and is made for just this kind of application. In v2 of the API there will also be different sizes and file types available.
