### PR TITLE
Physical Material Database example update

### DIFF
--- a/example/materialDatabase.js
+++ b/example/materialDatabase.js
@@ -126,7 +126,7 @@ function applyMaterialInfo( info, material ) {
 	// defaults
 	material.color.set( 0xffffff );
 	material.transmission = 0.0;
-	material.attenuationDistance = Infinity;
+	material.attenuationDistance = 1;
 	material.attenuationColor.set( 0xffffff );
 	material.specularColor.set( 0xffffff );
 	material.metalness = 0.0;
@@ -159,9 +159,15 @@ function applyMaterialInfo( info, material ) {
 
 		}
 
-		// Blender uses 1 / density when exporting volume transmission which doesn't look
-		// exactly right. But because the scene is 1000x in size we multiply by 1000 here.
-		material.attenuationDistance = 1000 / info.density;
+		if ( info.transmissionDepth ) {
+
+			material.attenuationDistance = info.transmissionDepth;
+
+		} else {
+
+			material.attenuationDistance = 1;
+
+		}
 
 	} else {
 


### PR DESCRIPTION
Updated **attenuationDistance** so it uses the new **transmissionDepth** attribute from the API instead of **density**.
Density is not really useful for shading and is only meant to be used for physics simulations.
I've recently added **transmissionDepth** to the database for a few materials and it gives much more accurate results.
The affected materials (only Blood and Coffee so far) now look quite dark but is expected as the shader ball is quite big (4 cm grid size) and these materials have very strong absorption.

Examples:

Blood (before)
<img width="1686" height="1634" alt="image" src="https://github.com/user-attachments/assets/039df0f9-b7ca-4c7b-906e-e2f16194e193" />
Blood (after)
<img width="1686" height="1634" alt="image" src="https://github.com/user-attachments/assets/587e13f0-7b48-46a6-b311-d212316c4ed2" />

Coffee (before)
<img width="1686" height="1634" alt="image" src="https://github.com/user-attachments/assets/bddc484d-4c17-4d56-aabe-e149899971a7" />
Coffee (after)
<img width="1686" height="1634" alt="image" src="https://github.com/user-attachments/assets/10f2eaa1-10f4-4536-860d-343cd589f516" />

Gasoline should in reality be unaffected as it doesn't have transmission depth, but a slight difference can be seen as it was previously using **1000 / density** which is now set to **1.0** for materials without the transmissionDepth attribute. This should however be more accurate.

Gasoline (before)
<img width="1686" height="1634" alt="image" src="https://github.com/user-attachments/assets/c09a90f2-42d9-4f3a-b8c7-704147ac06df" />
Gasoline (after)
<img width="1686" height="1634" alt="image" src="https://github.com/user-attachments/assets/3d6247f2-ea11-406b-862d-689416c52812" />


