### PR TITLE
Remove usages of storage textures <rgba32float, read_write>

### DIFF
--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -39,6 +39,13 @@ function* renderTask() {
 		const dispatchSize = kernel.getDispatchSize( tileSize.x, tileSize.y );
 		kernel.seed += 1;
 
+		// Swap targets to support devices without <rgba32float, read_write> textures
+		// Copy latest data to a new outputTarget to keep the appearance
+		renderer.copyTextureToTexture( this.outputTarget, this.prevOutputTarget );
+		[ this.outputTarget, this.prevOutputTarget ] = [ this.prevOutputTarget, this.outputTarget ];
+		kernel.prevOutputTarget = this.prevOutputTarget;
+		kernel.outputTarget = this.outputTarget;
+
 		for ( let x = 0; x < tiles.x; x ++ ) {
 
 			for ( let y = 0; y < tiles.y; y ++ ) {
@@ -87,8 +94,16 @@ export class MegaKernelPathTracer {
 		this.outputTarget.type = FloatType;
 		this.outputTarget.magFilter = LinearFilter;
 		this.outputTarget.colorSpace = ColorManagement.workingColorSpace;
-		this.outputTarget.name = 'Output';
+		this.outputTarget.name = 'Output #0';
 		this.outputTarget.generateMipmaps = false;
+
+		this.prevOutputTarget = new StorageTexture( 1, 1, );
+		this.prevOutputTarget.format = RGBAFormat;
+		this.prevOutputTarget.type = FloatType;
+		this.prevOutputTarget.magFilter = LinearFilter;
+		this.prevOutputTarget.colorSpace = ColorManagement.workingColorSpace;
+		this.prevOutputTarget.name = 'Output #1';
+		this.prevOutputTarget.generateMipmaps = false;
 
 		this.sampleCountTarget = new StorageTexture( 1, 1, );
 		this.sampleCountTarget.format = RedIntegerFormat;
@@ -143,12 +158,15 @@ export class MegaKernelPathTracer {
 		}
 
 		this.outputTarget.dispose();
+		this.prevOutputTarget.dispose();
 		this.sampleCountTarget.dispose();
 
 		this.outputTarget = this.outputTarget.clone();
+		this.prevOutputTarget = this.outputTarget.clone();
 		this.sampleCountTarget = this.sampleCountTarget.clone();
 
 		this.outputTarget.setSize( w, h );
+		this.prevOutputTarget.setSize( w, h );
 		this.sampleCountTarget.setSize( w, h );
 
 		this.reset();
@@ -193,6 +211,7 @@ export class MegaKernelPathTracer {
 			outputTargetClearKernel,
 			sampleCountTarget,
 			outputTarget,
+			prevOutputTarget,
 		} = this;
 
 		if ( ! renderer.initialized ) {
@@ -212,6 +231,9 @@ export class MegaKernelPathTracer {
 		renderer.compute( sampleCountClearKernel.kernel, dispatchSize );
 
 		outputTargetClearKernel.target = outputTarget;
+		renderer.compute( outputTargetClearKernel.kernel, dispatchSize );
+
+		outputTargetClearKernel.target = prevOutputTarget;
 		renderer.compute( outputTargetClearKernel.kernel, dispatchSize );
 
 	}

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -23,7 +23,6 @@ function* renderTask() {
 		bounces,
 
 		tiles,
-		outputTarget,
 		sampleCountTarget,
 
 		rayQueue,
@@ -52,6 +51,15 @@ function* renderTask() {
 
 		this.getTileSize( tileSize );
 
+		// Swap targets to support devices without <rgba32float, read_write> textures
+		// Copy latest data to a new outputTarget to keep the appearance
+		renderer.copyTextureToTexture( this.outputTarget, this.prevOutputTarget );
+		[ this.outputTarget, this.prevOutputTarget ] = [ this.prevOutputTarget, this.outputTarget ];
+		rayIntersectionKernel.prevOutputTarget = this.prevOutputTarget;
+		rayIntersectionKernel.outputTarget = this.outputTarget;
+		hitProcessKernel.prevOutputTarget = this.prevOutputTarget;
+		hitProcessKernel.outputTarget = this.outputTarget;
+
 		// Step 1: Top up the ray queue
 		// set up the ray prime kernel
 		primeRayGenerationDispatchKernel.setWorkgroupSize( 1, 1, 1 );
@@ -73,7 +81,6 @@ function* renderTask() {
 		enqueueRaysKernel.rayQueue = rayQueue;
 		enqueueRaysKernel.rayQueueSize = rayQueueSize;
 		enqueueRaysKernel.sampleCountTarget = sampleCountTarget;
-		enqueueRaysKernel.outputTarget = outputTarget;
 
 		for ( let i = 0; i < tiles.x * tiles.y; i ++ ) {
 
@@ -88,7 +95,6 @@ function* renderTask() {
 		// TODO: setting dispatch size to 10000 is causing failures / missed rays
 		rayIntersectionKernel.setWorkgroupSize( 64, 1, 1 );
 		const intersectDispatch = rayIntersectionKernel.getDispatchSize( RAYS_TO_PROCESS, 1, 1 );
-		rayIntersectionKernel.outputTarget = outputTarget;
 		rayIntersectionKernel.sampleCountTarget = sampleCountTarget;
 		rayIntersectionKernel.rayQueue = rayQueue;
 		rayIntersectionKernel.rayQueueSize = rayQueueSize;
@@ -111,7 +117,6 @@ function* renderTask() {
 		// as needed to iterate over all the fields
 		// Step 3: attenuate ray color, scatter, run russian roulette
 		hitProcessKernel.setWorkgroupSize( 64, 1, 1 );
-		hitProcessKernel.outputTarget = outputTarget;
 		hitProcessKernel.sampleCountTarget = sampleCountTarget;
 		hitProcessKernel.bounces = bounces;
 		hitProcessKernel.rayQueue = rayQueue;
@@ -175,8 +180,16 @@ export class WaveFrontPathTracer {
 		this.outputTarget.type = FloatType;
 		this.outputTarget.magFilter = LinearFilter;
 		this.outputTarget.colorSpace = ColorManagement.workingColorSpace;
-		this.outputTarget.name = 'Output';
+		this.outputTarget.name = 'Output #0';
 		this.outputTarget.generateMipmaps = false;
+
+		this.prevOutputTarget = new StorageTexture( 1, 1, );
+		this.prevOutputTarget.format = RGBAFormat;
+		this.prevOutputTarget.type = FloatType;
+		this.prevOutputTarget.magFilter = LinearFilter;
+		this.prevOutputTarget.colorSpace = ColorManagement.workingColorSpace;
+		this.prevOutputTarget.name = 'Output #1';
+		this.prevOutputTarget.generateMipmaps = false;
 
 		this.sampleCountTarget = new StorageTexture( 1, 1, );
 		this.sampleCountTarget.format = RedIntegerFormat;
@@ -258,12 +271,15 @@ export class WaveFrontPathTracer {
 		}
 
 		this.outputTarget.dispose();
+		this.prevOutputTarget.dispose();
 		this.sampleCountTarget.dispose();
 
 		this.outputTarget = this.outputTarget.clone();
+		this.prevOutputTarget = this.outputTarget.clone();
 		this.sampleCountTarget = this.sampleCountTarget.clone();
 
 		this.outputTarget.setSize( w, h );
+		this.prevOutputTarget.setSize( w, h );
 		this.sampleCountTarget.setSize( w, h );
 
 		this.reset();
@@ -311,6 +327,7 @@ export class WaveFrontPathTracer {
 
 			sampleCountTarget,
 			outputTarget,
+			prevOutputTarget,
 
 			hitProcessDispatch,
 			rayGenerationDispatch,
@@ -337,6 +354,10 @@ export class WaveFrontPathTracer {
 
 		outputTargetClearKernel.setWorkgroupSize( 8, 8, 1 );
 		outputTargetClearKernel.target = outputTarget;
+		renderer.compute( outputTargetClearKernel.kernel, dispatchSize );
+
+		outputTargetClearKernel.setWorkgroupSize( 8, 8, 1 );
+		outputTargetClearKernel.target = prevOutputTarget;
 		renderer.compute( outputTargetClearKernel.kernel, dispatchSize );
 
 		// clear queues

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -8,7 +8,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 	constructor() {
 
 		const megakernelShaderParams = {
-			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
+			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
+			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toWriteOnly(),
 			sampleCountTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
 
 			offset: uniform( new Vector2() ),

--- a/src/webgpu/compute/ZeroOutKernel.js
+++ b/src/webgpu/compute/ZeroOutKernel.js
@@ -8,14 +8,14 @@ export class ZeroOutKernel extends ComputeKernel {
 
 		const params = {
 			globalId: globalId,
-			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
+			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toWriteOnly(),
 		};
 
 		const fn = wgslFn( /* wgsl */`
 
 			fn compute(
 				globalId: vec3u,
-				outputTarget: texture_storage_2d<${ textureType }, read_write>,
+				outputTarget: texture_storage_2d<${ textureType }, write>,
 			) -> void {
 
 				textureStore( outputTarget, globalId.xy, vec4( 0, 0, 0, 1 ) );

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -12,7 +12,8 @@ export class ProcessHitsKernel extends ComputeKernel {
 	constructor() {
 
 		const parameters = {
-			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
+			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
+			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toWriteOnly(),
 			sampleCountTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
 
 			// settings
@@ -38,7 +39,8 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 			fn compute(
 				// indices and target
-				outputTarget: texture_storage_2d<rgba32float, read_write>,
+				prevOutputTarget: texture_storage_2d<rgba32float, read>,
+				outputTarget: texture_storage_2d<rgba32float, write>,
 				sampleCountTarget: texture_storage_2d<r32uint, read_write>,
 
 				// settings
@@ -87,7 +89,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 					// terminate ray, write color
 					let sampleCount = ( textureLoad( sampleCountTarget, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
-					var color = textureLoad( outputTarget, indexUV ).xyz;
+					var color = textureLoad( prevOutputTarget, indexUV ).xyz;
 					color += ( vec3( 0 ) - color.xyz ) / f32( sampleCount );
 
 					textureStore( sampleCountTarget, indexUV, vec4( sampleCount ) );

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -10,7 +10,8 @@ export class RayIntersectionKernel extends ComputeKernel {
 	constructor() {
 
 		const parameters = {
-			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
+			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
+			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toWriteOnly(),
 			sampleCountTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
 
 			// rays
@@ -33,7 +34,8 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 			fn compute(
 				// indices and target
-				outputTarget: texture_storage_2d<rgba32float, read_write>,
+				prevOutputTarget: texture_storage_2d<rgba32float, read>,
+				outputTarget: texture_storage_2d<rgba32float, write>,
 				sampleCountTarget: texture_storage_2d<r32uint, read_write>,
 
 				// rays
@@ -92,7 +94,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 					let newColor = background * input.throughputColor;
 
 					let sampleCount = ( textureLoad( sampleCountTarget, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
-					var color = textureLoad( outputTarget, indexUV ).xyz;
+					var color = textureLoad( prevOutputTarget, indexUV ).xyz;
 					color += ( newColor - color.xyz ) / f32( sampleCount );
 
 					textureStore( sampleCountTarget, indexUV, vec4( sampleCount ) );

--- a/src/webgpu/nodes/megakernel.wgsl.js
+++ b/src/webgpu/nodes/megakernel.wgsl.js
@@ -10,7 +10,8 @@ export const megakernelShader = wgslFn( /* wgsl */`
 
 		// indices and target
 		globalId: vec3u,
-		outputTarget: texture_storage_2d<rgba32float, read_write>,
+		prevOutputTarget: texture_storage_2d<rgba32float, read>,
+		outputTarget: texture_storage_2d<rgba32float, write>,
 		sampleCountTarget: texture_storage_2d<r32uint, read_write>,
 
 		// tiles
@@ -107,7 +108,7 @@ export const megakernelShader = wgslFn( /* wgsl */`
 		}
 
 		let sampleCount = textureLoad( sampleCountTarget, indexUV ).r + 1;
-		var color = textureLoad( outputTarget, indexUV ).xyz;
+		var color = textureLoad( prevOutputTarget, indexUV ).xyz;
 		color += ( resultColor - color.xyz ) / f32( sampleCount );
 
 		textureStore( sampleCountTarget, indexUV, vec4( sampleCount ) );


### PR DESCRIPTION
WebGPU does not support rgba32float storage textures with read_write access without requesting `texture-formats-tier2`:  https://www.w3.org/TR/webgpu/#texture-formats-tier2

Adds unified code path with ping-pong as per https://github.com/gkjohnson/three-gpu-pathtracer/pull/705#issuecomment-3901218461