### PR TITLE
WebGPUPathTracer: Get megakernel working in Firefox, Safari

### DIFF
--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -1,11 +1,12 @@
 import { DataTexture, Matrix3, Matrix4, Vector2, StorageTexture } from 'three/webgpu';
 import { ndcToCameraRay } from '../lib/wgsl/common.wgsl.js';
 import { ComputeKernel } from './ComputeKernel.js';
-import { texture, sampler, uniform, globalId, textureStore, wgslFn } from 'three/tsl';
+import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
 import { pcgRand2, pcgRand3, pcgInit } from '../nodes/random.wgsl.js';
 import { getSurfaceRecordFunc, lambertBsdfFunc } from '../nodes/material.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
 import { proxy } from '../lib/nodes/NodeProxy.js';
+import { wgslTagFn } from '../lib/nodes/WGSLTagFnNode.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
 
@@ -46,15 +47,12 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const shader = wgslFn( /* wgsl */`
+		const shader = wgslTagFn/* wgsl */`
 
 			fn compute(
 
 				// indices and target
 				globalId: vec3u,
-				prevOutputTarget: texture_storage_2d<rgba32float, read>,
-				outputTarget: texture_storage_2d<rgba32float, write>,
-				sampleCountTarget: texture_storage_2d<r32uint, read_write>,
 
 				// tiles
 				offset: vec2u,
@@ -104,7 +102,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				// to screen coordinates
 				let indexUV = offset + globalId.xy;
-				let targetDimensions = textureDimensions( outputTarget );
+				let targetDimensions = textureDimensions( ${ parameters.outputTarget } );
 				if ( indexUV.x >= targetDimensions.x || indexUV.y >= targetDimensions.y ) {
 
 					return;
@@ -128,7 +126,6 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 					let hitResult = bvh_RaycastFirstHit( ray );
 					if ( hitResult.didHit ) {
-
 
 						let object = bvh_transforms.value[ hitResult.objectIndex ];
 						var material = bvh_materials.value[ object.materialIndex ];
@@ -169,23 +166,23 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				}
 
-				let sampleCount = textureLoad( sampleCountTarget, indexUV ).r + 1;
-				let prevColor = textureLoad( prevOutputTarget, indexUV );
+				let sampleCount = textureLoad( ${ parameters.sampleCountTarget }, indexUV ).r + 1;
+				let prevColor = textureLoad( ${ parameters.prevOutputTarget }, indexUV );
 				let blendedColor = weightedAlphaBlend( prevColor, resultColor, 1.0 / f32( sampleCount ) );
-				textureStore( sampleCountTarget, indexUV, vec4( sampleCount ) );
-				textureStore( outputTarget, indexUV, blendedColor );
+				textureStore( ${ parameters.sampleCountTarget }, indexUV, vec4( sampleCount ) );
+				textureStore( ${ parameters.outputTarget }, indexUV, blendedColor );
 
 			}
 
-		`, [
-			proxy( 'bvhData.value.storage.materials', parameters ),
-			proxy( 'bvhData.value.structs.material', parameters ),
-			proxy( 'bvhData.value.structs.transform', parameters ),
-			proxy( 'bvhData.value.fns.raycastFirstHit', parameters ),
-			proxy( 'bvhData.value.fns.sampleTrianglePoint', parameters ),
-			ndcToCameraRay, pcgRand2, pcgRand3, pcgInit, lambertBsdfFunc,
-			sampleEnvironmentFn, getSurfaceRecordFunc, weightedAlphaBlendFn,
-		] );
+	${ [
+		proxy( 'bvhData.value.storage.materials', parameters ),
+		proxy( 'bvhData.value.structs.material', parameters ),
+		proxy( 'bvhData.value.structs.transform', parameters ),
+		proxy( 'bvhData.value.fns.raycastFirstHit', parameters ),
+		proxy( 'bvhData.value.fns.sampleTrianglePoint', parameters ),
+		ndcToCameraRay, pcgRand2, pcgRand3, pcgInit, lambertBsdfFunc,
+		sampleEnvironmentFn, getSurfaceRecordFunc, weightedAlphaBlendFn,
+	] }`;
 
 		super( shader( parameters ) );
 

--- a/src/webgpu/compute/ZeroOutKernel.js
+++ b/src/webgpu/compute/ZeroOutKernel.js
@@ -1,29 +1,26 @@
 import { StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from './ComputeKernel.js';
-import { textureStore, wgslFn, globalId } from 'three/tsl';
+import { textureStore, globalId } from 'three/tsl';
+import { wgslTagFn } from '../lib/nodes/WGSLTagFnNode.js';
 
 export class ZeroOutKernel extends ComputeKernel {
 
-	constructor( { textureType = 'rgba32float' } ) {
+	constructor() {
 
 		const params = {
 			globalId: globalId,
 			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toWriteOnly(),
 		};
 
-		const fn = wgslFn( /* wgsl */`
+		const fn = wgslTagFn/* wgsl */`
+			fn compute( globalId: vec3u ) -> void {
 
-			fn compute(
-				globalId: vec3u,
-				outputTarget: texture_storage_2d<${ textureType }, write>,
-			) -> void {
-
-				textureStore( outputTarget, globalId.xy, vec4( 0, 0, 0, 1 ) );
+				textureStore( ${ params.outputTarget }, globalId.xy, vec4( 0, 0, 0, 1 ) );
 
 			}
-		` )( params );
+		`;
 
-		super( fn );
+		super( fn( params ) );
 
 		this.defineUniformAccessors( {
 			target: params.outputTarget,

--- a/src/webgpu/lib/nodes/NodeProxy.js
+++ b/src/webgpu/lib/nodes/NodeProxy.js
@@ -26,6 +26,12 @@ class ProxyCallNode extends Node {
 
 export class NodeProxy {
 
+	get isNode() {
+
+		return true;
+
+	}
+
 	// getter for the node being proxied to
 	get proxyNode() {
 

--- a/src/webgpu/lib/nodes/WGSLTagFnNode.js
+++ b/src/webgpu/lib/nodes/WGSLTagFnNode.js
@@ -62,18 +62,17 @@ function getIncludeNode( arg ) {
 
 		if ( arg.functionNode ) return arg.functionNode;
 		if ( arg.isStruct ) return arg.layout;
+		else return null;
+
+	} else if ( arg.isNode ) {
+
+		return new PropertyRefNode( arg );
+
+	} else {
+
 		return null;
 
 	}
-
-	if ( arg && arg.isNode ) {
-
-		if ( arg.functionNode ) return arg.functionNode;
-		if ( arg.isStructLayoutNode || arg.isCodeNode ) return arg;
-
-	}
-
-	return null;
 
 }
 
@@ -116,6 +115,7 @@ function normalizeArgs( args ) {
 		if ( typeof arg === 'function' && arg.functionNode ) return new PropertyRefNode( arg.functionNode );
 		if ( typeof arg === 'function' && arg.isStruct ) return arg.layout;
 		if ( arg && arg.isNode && arg.functionNode ) return new InlineCallNode( arg );
+		if ( arg && arg.isNode ) return new PropertyRefNode( arg );
 		return arg;
 
 	} );
@@ -240,7 +240,7 @@ export class WGSLTagFnNode extends FunctionNode {
 		const { type } = this.getNodeFunction( builder );
 		const nodeCode = builder.getCodeFromNode( this, type );
 
-		nodeCode.code = fullCode.replace( /\/\/.+[\n\r]/g, '' ).replace( /->\s*void/, '' ).replace( /\s+/g, ' ' ).trim();
+		nodeCode.code = fullCode.replace( /\/\/.+[\n\r]/g, '' ).replace( /->\s*void/, '' ).trim();
 
 		return result;
 


### PR DESCRIPTION
"texture_storage_2d" nodes are not supported as function arguments so they've been replaced here with the wgslTagFn injection approach. If this looks okay I can adjust the remainder of the includes to use the template tag variable injection.

- Adjust WgslTagFn to support injecting storage texture nodes
- Adjust nodeProxy to be resilient to the type of checking that wgslTagFn does
- Remove whitespace stripping to make shader warnings, output readable

cc @theblek