### PR TITLE
WebGPUPathTracer: Improve build performance, fix failures when rendering an empty scene

### DIFF
--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -567,7 +567,7 @@ export class BVHComputeData {
 					const n16 = n32 * 2;
 
 					// write bounds
-					targetF32.set( new Float32Array( 6 ), n32 );
+					targetF32.set( new Float32Array( root, i * BYTES_PER_NODE, 6 ), n32 );
 
 					const isLeaf = IS_LEAFNODE_FLAG === rootBuffer16[ r16 + 15 ];
 					if ( isLeaf ) {
@@ -658,7 +658,7 @@ export class BVHComputeData {
 			const { geometry, mesh = null } = bvh;
 			const { vertexStart, vertexCount } = range;
 			const attributesBufferF32 = new Float32Array( target );
-			const stepSize = attributeStruct.getLength();
+			const attrStructLength = attributeStruct.getLength();
 			attributeStruct.membersLayout.forEach( ( { name }, interleavedOffset ) => {
 
 				// TODO: we should be able to have access to memory layout offsets here via the struct
@@ -701,7 +701,7 @@ export class BVHComputeData {
 
 					}
 
-					_vec.toArray( attributesBufferF32, ( writeOffset + i ) * stepSize + interleavedOffset * 4 );
+					_vec.toArray( attributesBufferF32, ( writeOffset + i ) * attrStructLength + interleavedOffset * 4 );
 
 				}
 

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -476,6 +476,13 @@ export class BVHComputeData {
 
 		//
 
+		// NOTE: These buffer lengths are increased to a minimum size of 2 to avoid the TSL of converting storage buffers
+		// with length 1 being converted to a scalar value.
+		// TODO: remove this when fixed in three
+		const transformBufferLength = Math.max( transformInfo.length, 2 );
+		indexBufferLength = Math.max( indexBufferLength, 2 );
+		attributesBufferLength = Math.max( indexBufferLength, 2 );
+
 		// construct the attribute struct
 		const attributeStruct = new StructTypeNode( attributes, `${ prefix }GeometryStruct` );
 
@@ -483,8 +490,8 @@ export class BVHComputeData {
 		let attributesOffset = 0;
 		let indexOffset = 0;
 		let nodeWriteOffset = 0;
-		const indexBuffer = new Uint32Array( Math.max( indexBufferLength, 2 ) );
-		const attributesBuffer = new ArrayBuffer( Math.max( attributesBufferLength, 2 ) * attributeStruct.getLength() * 4 );
+		const indexBuffer = new Uint32Array( indexBufferLength );
+		const attributesBuffer = new ArrayBuffer( attributesBufferLength * attributeStruct.getLength() * 4 );
 		const bvhNodesBuffer = new ArrayBuffer( bvhNodesBufferLength );
 
 		// append TLAS data
@@ -511,7 +518,7 @@ export class BVHComputeData {
 		//
 
 		// write the transforms
-		const transformArrayBuffer = new ArrayBuffer( structs.transform.getLength() * Math.max( transformInfo.length, 2 ) * 4 );
+		const transformArrayBuffer = new ArrayBuffer( structs.transform.getLength() * transformBufferLength * 4 );
 		transformInfo.forEach( ( info, i ) => {
 
 			_inverseMatrix.copy( bvh.matrixWorld ).invert();

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -567,7 +567,34 @@ export class BVHComputeData {
 					const n16 = n32 * 2;
 
 					// write bounds
-					targetF32.set( new Float32Array( root, i * BYTES_PER_NODE, 6 ), n32 );
+					const view = new Float32Array( root, i * BYTES_PER_NODE, 6 );
+					if ( i === 0 ) {
+
+						// if we're copying the root then check for cases where there are no primitives and therefore
+						// be a bounds of [ Infinity, - Infinity ]. Convert this to [ 1, - 1 ] for reliable GPU behavior.
+						for ( let i = 0; i < 3; i ++ ) {
+
+							const vMin = view[ i + 0 ];
+							const vMax = view[ i + 3 ];
+							if ( vMin > vMax ) {
+
+								targetF32[ n32 + i + 0 ] = 1;
+								targetF32[ n32 + i + 3 ] = - 1;
+
+							} else {
+
+								targetF32[ n32 + i + 0 ] = vMin;
+								targetF32[ n32 + i + 3 ] = vMax;
+
+							}
+
+						}
+
+					} else {
+
+						targetF32.set( view, n32 );
+
+					}
 
 					const isLeaf = IS_LEAFNODE_FLAG === rootBuffer16[ r16 + 15 ];
 					if ( isLeaf ) {

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -481,7 +481,7 @@ export class BVHComputeData {
 		// TODO: remove this when fixed in three
 		const transformBufferLength = Math.max( transformInfo.length, 2 );
 		indexBufferLength = Math.max( indexBufferLength, 2 );
-		attributesBufferLength = Math.max( indexBufferLength, 2 );
+		attributesBufferLength = Math.max( attributesBufferLength, 2 );
 
 		// construct the attribute struct
 		const attributeStruct = new StructTypeNode( attributes, `${ prefix }GeometryStruct` );

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -483,8 +483,8 @@ export class BVHComputeData {
 		let attributesOffset = 0;
 		let indexOffset = 0;
 		let nodeWriteOffset = 0;
-		const indexBuffer = new Uint32Array( indexBufferLength );
-		const attributesBuffer = new ArrayBuffer( attributesBufferLength * attributeStruct.getLength() * 4 );
+		const indexBuffer = new Uint32Array( Math.max( indexBufferLength, 2 ) );
+		const attributesBuffer = new ArrayBuffer( Math.max( attributesBufferLength, 2 ) * attributeStruct.getLength() * 4 );
 		const bvhNodesBuffer = new ArrayBuffer( bvhNodesBufferLength );
 
 		// append TLAS data
@@ -511,7 +511,7 @@ export class BVHComputeData {
 		//
 
 		// write the transforms
-		const transformArrayBuffer = new ArrayBuffer( structs.transform.getLength() * transformInfo.length * 4 );
+		const transformArrayBuffer = new ArrayBuffer( structs.transform.getLength() * Math.max( transformInfo.length, 2 ) * 4 );
 		transformInfo.forEach( ( info, i ) => {
 
 			_inverseMatrix.copy( bvh.matrixWorld ).invert();
@@ -560,7 +560,7 @@ export class BVHComputeData {
 					const n16 = n32 * 2;
 
 					// write bounds
-					targetF32.set( new Float32Array( root, i * BYTES_PER_NODE, 6 ), n32 );
+					targetF32.set( new Float32Array( 6 ), n32 );
 
 					const isLeaf = IS_LEAFNODE_FLAG === rootBuffer16[ r16 + 15 ];
 					if ( isLeaf ) {
@@ -651,6 +651,7 @@ export class BVHComputeData {
 			const { geometry, mesh = null } = bvh;
 			const { vertexStart, vertexCount } = range;
 			const attributesBufferF32 = new Float32Array( target );
+			const stepSize = attributeStruct.getLength();
 			attributeStruct.membersLayout.forEach( ( { name }, interleavedOffset ) => {
 
 				// TODO: we should be able to have access to memory layout offsets here via the struct
@@ -693,7 +694,7 @@ export class BVHComputeData {
 
 					}
 
-					_vec.toArray( attributesBufferF32, ( writeOffset + i ) * attributeStruct.getLength() + interleavedOffset * 4 );
+					_vec.toArray( attributesBufferF32, ( writeOffset + i ) * stepSize + interleavedOffset * 4 );
 
 				}
 

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -128,7 +128,10 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 		const textureLookUp = new Map();
 		const textures = [];
 
-		const floatArray = new Float32Array( Math.max( materials.length, 2 ) * this.structs.material.getLength() );
+		// NOTE: make the minimum material buffer length 2 in order to avoid TSL converting it to a scalar
+		// TODO: remove this when fixed in three
+		const materialBufferLength = Math.max( materials.length, 2 );
+		const floatArray = new Float32Array( materialBufferLength * this.structs.material.getLength() );
 		const intArray = new Int32Array( floatArray.buffer );
 
 		// TODO: make features work

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -128,7 +128,7 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 		const textureLookUp = new Map();
 		const textures = [];
 
-		const floatArray = new Float32Array( materials.length * this.structs.material.getLength() );
+		const floatArray = new Float32Array( Math.max( materials.length, 2 ) * this.structs.material.getLength() );
 		const intArray = new Int32Array( floatArray.buffer );
 
 		// TODO: make features work


### PR DESCRIPTION
1. Improve the performance to BVHComputeData.update by caching "attributeStruct.getLength()".
2. ensure buffers are declared to have at least 2 values in order to prevent TSL from converting them to a scalar value and breaking our shader code.
3. Ensure bvh bounds storage buffer is not contain "Infinity"

cc @theblek - is there already an issue submitted for point 2?