### PR TITLE
WebGPUPathTracer: Convert kernels to use wgsl tag fn

### DIFF
--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -36,8 +36,8 @@ export class PathTracerBackend {
 		this.sampleCountTarget.name = 'Sample Count';
 		this.sampleCountTarget.generateMipmaps = false;
 
-		this.sampleCountClearKernel = new ZeroOutKernel( { textureType: 'r32uint' } ).setWorkgroupSize( 8, 8, 1 );
-		this.outputTargetClearKernel = new ZeroOutKernel( { textureType: 'rgba32float' } ).setWorkgroupSize( 8, 8, 1 );
+		this.sampleCountClearKernel = new ZeroOutKernel().setWorkgroupSize( 8, 8, 1 );
+		this.outputTargetClearKernel = new ZeroOutKernel().setWorkgroupSize( 8, 8, 1 );
 
 	}
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -47,8 +47,6 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const materialStorage = proxy( 'bvhData.value.storage.materials', parameters );
-		const transformStorage = proxy( 'bvhData.value.storage.transforms', parameters );
 		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', parameters );
 		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', parameters );
 
@@ -85,6 +83,9 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				textureSampler: sampler
 
 			) -> void {
+
+				let transforms = &${ proxy( 'bvhData.value.storage.transforms', parameters ) };
+				let materials = &${ proxy( 'bvhData.value.storage.materials', parameters ) };
 
 				let envInfo = EnvironmentInfo(
 					envMapRotation,
@@ -132,8 +133,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 					let hitResult = ${ raycastFirstHitFn }( ray );
 					if ( hitResult.didHit ) {
 
-						let object = ${ transformStorage }[ hitResult.objectIndex ];
-						var material = ${ materialStorage }[ object.materialIndex ];
+						let object = transforms[ hitResult.objectIndex ];
+						var material = materials[ object.materialIndex ];
 
 						// apply per-object colors
 						material.color *= object.color.rgb;

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -12,7 +12,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 	constructor() {
 
-		const parameters = {
+		const params = {
 			bvhData: { value: null },
 
 			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
@@ -47,8 +47,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', parameters );
-		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', parameters );
+		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', params );
+		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', params );
 
 		const shader = wgslTagFn/* wgsl */`
 
@@ -84,8 +84,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 			) -> void {
 
-				let transforms = &${ proxy( 'bvhData.value.storage.transforms', parameters ) };
-				let materials = &${ proxy( 'bvhData.value.storage.materials', parameters ) };
+				let transforms = &${ proxy( 'bvhData.value.storage.transforms', params ) };
+				let materials = &${ proxy( 'bvhData.value.storage.materials', params ) };
 
 				let envInfo = EnvironmentInfo(
 					envMapRotation,
@@ -108,7 +108,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				// to screen coordinates
 				let indexUV = offset + globalId.xy;
-				let targetDimensions = textureDimensions( ${ parameters.outputTarget } );
+				let targetDimensions = textureDimensions( ${ params.outputTarget } );
 				if ( indexUV.x >= targetDimensions.x || indexUV.y >= targetDimensions.y ) {
 
 					return;
@@ -172,17 +172,17 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				}
 
-				let sampleCount = textureLoad( ${ parameters.sampleCountTarget }, indexUV ).r + 1;
-				let prevColor = textureLoad( ${ parameters.prevOutputTarget }, indexUV );
+				let sampleCount = textureLoad( ${ params.sampleCountTarget }, indexUV ).r + 1;
+				let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
 				let blendedColor = ${ weightedAlphaBlendFn }( prevColor, resultColor, 1.0 / f32( sampleCount ) );
-				textureStore( ${ parameters.sampleCountTarget }, indexUV, vec4( sampleCount ) );
-				textureStore( ${ parameters.outputTarget }, indexUV, blendedColor );
+				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
+				textureStore( ${ params.outputTarget }, indexUV, blendedColor );
 
 			}`;
 
-		super( shader( parameters ) );
+		super( shader( params ) );
 
-		this.defineUniformAccessors( parameters );
+		this.defineUniformAccessors( params );
 
 	}
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -2,10 +2,10 @@ import { DataTexture, Matrix3, Matrix4, Vector2, StorageTexture } from 'three/we
 import { ndcToCameraRay } from '../lib/wgsl/common.wgsl.js';
 import { ComputeKernel } from './ComputeKernel.js';
 import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
-import { pcgRand2, pcgRand3, pcgInit } from '../nodes/random.wgsl.js';
+import { pcgRand2, pcgInit } from '../nodes/random.wgsl.js';
 import { getSurfaceRecordFunc, lambertBsdfFunc } from '../nodes/material.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
-import { proxy } from '../lib/nodes/NodeProxy.js';
+import { proxy, proxyFn } from '../lib/nodes/NodeProxy.js';
 import { wgslTagFn } from '../lib/nodes/WGSLTagFnNode.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
@@ -46,6 +46,11 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			// compute variables
 			globalId: globalId,
 		};
+
+		const materialStorage = proxy( 'bvhData.value.storage.materials', parameters );
+		const transformStorage = proxy( 'bvhData.value.storage.transforms', parameters );
+		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', parameters );
+		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', parameters );
 
 		const shader = wgslTagFn/* wgsl */`
 
@@ -112,11 +117,11 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				let uv = vec2f( indexUV ) / vec2f( targetDimensions );
 				let ndc = uv * 2.0 - vec2f( 1.0 );
 
-				pcgInitialize( indexUV, seed );
+				${ pcgInit }( indexUV, seed );
 
 				// scene ray
-				var jitter = 2.0 * pcgRand2() / vec2f( targetDimensions.xy );
-				var ray = ndcToCameraRay( ndc + jitter, cameraToModelMatrix * inverseProjectionMatrix );
+				var jitter = 2.0 * ${ pcgRand2 }() / vec2f( targetDimensions.xy );
+				var ray = ${ ndcToCameraRay }( ndc + jitter, cameraToModelMatrix * inverseProjectionMatrix );
 				ray.direction = normalize( ray.direction );
 
 				var resultColor = vec4f( 0, 0, 0, 1 );
@@ -124,23 +129,23 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				for ( var bounce = 0u; bounce < bounces; bounce ++ ) {
 
-					let hitResult = bvh_RaycastFirstHit( ray );
+					let hitResult = ${ raycastFirstHitFn }( ray );
 					if ( hitResult.didHit ) {
 
-						let object = bvh_transforms.value[ hitResult.objectIndex ];
-						var material = bvh_materials.value[ object.materialIndex ];
+						let object = ${ transformStorage }[ hitResult.objectIndex ];
+						var material = ${ materialStorage }[ object.materialIndex ];
 
 						// apply per-object colors
 						material.color *= object.color.rgb;
 						material.opacity *= object.color.a;
 
-						var vertexData = bvh_sampleTrianglePoint( hitResult.barycoord, hitResult.indices.xyz );
+						var vertexData = ${ sampleTrianglePointFn }( hitResult.barycoord, hitResult.indices.xyz );
 						vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 						vertexData.position = object.matrixWorld * vertexData.position;
 
-						let surface = getSurfaceRecord( material, vertexData, hitResult.side, hitResult.normal, textures, textureSampler );
+						let surface = ${ getSurfaceRecordFunc }( material, vertexData, hitResult.side, hitResult.normal, textures, textureSampler );
 
-						let scatterRec = bsdfSample( - ray.direction, surface );
+						let scatterRec = ${ lambertBsdfFunc }( - ray.direction, surface );
 
 						// white diffuse surface
 						throughputColor *= scatterRec.color / scatterRec.pdf;
@@ -152,11 +157,11 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						if ( bounce > 0u ) {
 
-							resultColor = sampleEnvironment( envMap, envMapSampler, envInfo, ray.direction, pcgRand2() ) * vec4f( throughputColor, 1.0 );
+							resultColor = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, ray.direction, pcgRand2() ) * vec4f( throughputColor, 1.0 );
 
 						} else {
 
-							resultColor = sampleEnvironment( background, backgroundSampler, backgroundInfo, ray.direction, pcgRand2() );
+							resultColor = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, ray.direction, pcgRand2() );
 
 						}
 
@@ -168,21 +173,11 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				let sampleCount = textureLoad( ${ parameters.sampleCountTarget }, indexUV ).r + 1;
 				let prevColor = textureLoad( ${ parameters.prevOutputTarget }, indexUV );
-				let blendedColor = weightedAlphaBlend( prevColor, resultColor, 1.0 / f32( sampleCount ) );
+				let blendedColor = ${ weightedAlphaBlendFn }( prevColor, resultColor, 1.0 / f32( sampleCount ) );
 				textureStore( ${ parameters.sampleCountTarget }, indexUV, vec4( sampleCount ) );
 				textureStore( ${ parameters.outputTarget }, indexUV, blendedColor );
 
-			}
-
-	${ [
-		proxy( 'bvhData.value.storage.materials', parameters ),
-		proxy( 'bvhData.value.structs.material', parameters ),
-		proxy( 'bvhData.value.structs.transform', parameters ),
-		proxy( 'bvhData.value.fns.raycastFirstHit', parameters ),
-		proxy( 'bvhData.value.fns.sampleTrianglePoint', parameters ),
-		ndcToCameraRay, pcgRand2, pcgRand3, pcgInit, lambertBsdfFunc,
-		sampleEnvironmentFn, getSurfaceRecordFunc, weightedAlphaBlendFn,
-	] }`;
+			}`;
 
 		super( shader( parameters ) );
 

--- a/src/webgpu/compute/ZeroOutBufferKernel.js
+++ b/src/webgpu/compute/ZeroOutBufferKernel.js
@@ -1,6 +1,7 @@
 import { IndirectStorageBufferAttribute } from 'three/webgpu';
 import { ComputeKernel } from './ComputeKernel.js';
-import { storage, wgslFn, globalId } from 'three/tsl';
+import { storage, globalId } from 'three/tsl';
+import { wgslTagFn } from '../lib/nodes/WGSLTagFnNode.js';
 
 export class ZeroOutBufferKernel extends ComputeKernel {
 
@@ -15,19 +16,15 @@ export class ZeroOutBufferKernel extends ComputeKernel {
 			outputTarget: storage( new IndirectStorageBufferAttribute( 1, 1 ), type ),
 		};
 
-		const fn = wgslFn( /* wgsl */`
+		const fn = wgslTagFn/* wgsl */`
+			fn compute( globalId: vec3u ) -> void {
 
-			fn compute(
-				globalId: vec3u,
-				outputTarget: ptr<storage, array<u32>, read_write>,
-			) -> void {
-
-				outputTarget[ globalId.x ] = 0;
+				${ params.outputTarget }[ globalId.x ] = 0;
 
 			}
-		` )( params );
+		`;
 
-		super( fn );
+		super( fn( params ) );
 
 		this.defineUniformAccessors( {
 			target: params.outputTarget,

--- a/src/webgpu/compute/wavefront/PrimeRayGenerationDispatchKernel.js
+++ b/src/webgpu/compute/wavefront/PrimeRayGenerationDispatchKernel.js
@@ -1,8 +1,9 @@
 import { Vector2, Vector3 } from 'three';
 import { IndirectStorageBufferAttribute } from 'three/webgpu';
-import { wgslFn, uniform, storage } from 'three/tsl';
+import { uniform, storage } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { queuedRayStruct } from './structs.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class PrimeRayGenerationDispatchKernel extends ComputeKernel {
 
@@ -18,24 +19,24 @@ export class PrimeRayGenerationDispatchKernel extends ComputeKernel {
 			rayQueue: storage( new IndirectStorageBufferAttribute( 1, queuedRayStruct.getLength() ), queuedRayStruct ).toReadOnly(),
 			rayQueueSize: storage( new IndirectStorageBufferAttribute( 2, 1 ), 'u32' ),
 
-			outputTileIndex: storage( new IndirectStorageBufferAttribute( 2, 1 ), 'u32' ),
-			outputDispatch: storage( new IndirectStorageBufferAttribute( 3, 1 ), 'u32' ),
+			outputTileIndex: storage( new IndirectStorageBufferAttribute( 2, 1 ), 'u32' ).setName( 'outputTileIndex' ),
+			outputDispatch: storage( new IndirectStorageBufferAttribute( 3, 1 ), 'u32' ).setName( 'outputDispatch' ),
 		};
 
-		const kernel = wgslFn( /* wgsl */`
+		const fn = wgslTagFn/* wgsl */`
 			fn compute(
 				rayWorkGroupSize: vec3u,
 
 				tileSize: vec2u,
 				tileCount: vec2u,
 				tileOffset: u32,
-
-				rayQueue: ptr<storage, array<QueuedRay>, read>,
-				rayQueueSize: ptr<storage, array<u32>, read_write>,
-
-				outputTileIndex: ptr<storage, array<u32>, read_write>,
-				outputDispatch: ptr<storage, array<u32>, read_write>,
 			) -> void {
+
+				let rayQueue = &${ params.rayQueue };
+				let rayQueueSize = &${ params.rayQueueSize };
+
+				let outputTileIndex = &${ params.outputTileIndex };
+				let outputDispatch = &${ params.outputDispatch };
 
 				// keep the queue index small
 			    let queueCapacity = arrayLength( rayQueue );
@@ -79,9 +80,9 @@ export class PrimeRayGenerationDispatchKernel extends ComputeKernel {
 				}
 
 			}
-		`, [ queuedRayStruct ] )( params );
+		`;
 
-		super( kernel );
+		super( fn( params ) );
 
 		this.defineUniformAccessors( params );
 

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -1,17 +1,17 @@
 import { IndirectStorageBufferAttribute, StorageTexture, DataTexture } from 'three/webgpu';
 import { ComputeKernel } from '../ComputeKernel.js';
-import { uniform, storage, wgslFn, textureStore, globalId, texture, sampler } from 'three/tsl';
-import { pcgRand3, pcgInit } from '../../nodes/random.wgsl.js';
+import { uniform, storage, textureStore, globalId, texture, sampler } from 'three/tsl';
 import { getSurfaceRecordFunc, lambertBsdfFunc } from '../../nodes/material.wgsl.js';
 import { queuedRayStruct, queuedHitStruct } from './structs.js';
-import { proxy } from '../../lib/nodes/NodeProxy.js';
+import { proxy, proxyFn } from '../../lib/nodes/NodeProxy.js';
 import { weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class ProcessHitsKernel extends ComputeKernel {
 
 	constructor() {
 
-		const parameters = {
+		const params = {
 			bvhData: { value: null },
 
 			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
@@ -35,31 +35,29 @@ export class ProcessHitsKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const fn = wgslFn( /* wgsl */`
+		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', params );
+
+		const fn = wgslTagFn/* wgsl */`
 
 			fn compute(
-				// indices and target
-				prevOutputTarget: texture_storage_2d<rgba32float, read>,
-				outputTarget: texture_storage_2d<rgba32float, write>,
-				sampleCountTarget: texture_storage_2d<r32uint, read_write>,
-
 				// settings
 				smoothNormals: u32,
 				bounces: u32,
-
-				// rays
-				rayQueue: ptr<storage, array<QueuedRay>, read_write>,
-				rayQueueSize: ptr<storage, array<atomic<u32>>, read_write>,
-
-				// hits
-				hitQueue: ptr<storage, array<QueuedHit>, read_write>,
-				hitQueueSize: ptr<storage, array<u32>, read_write>,
 
 				textures: texture_2d_array<f32>,
 				textureSampler: sampler,
 
 				globalId: vec3u
 			) -> void {
+
+				let rayQueue = &${ params.rayQueue };
+				let rayQueueSize = &${ params.rayQueueSize };
+
+				let hitQueue = &${ params.hitQueue };
+				let hitQueueSize = &${ params.hitQueueSize };
+
+				let materials = &${ proxy( 'bvhData.value.storage.materials', params ) };
+				let transforms = &${ proxy( 'bvhData.value.storage.transforms', params ) };
 
 				// skip any rays invocations beyond the ray count
 				let hitQueueCapacity = arrayLength( hitQueue );
@@ -77,29 +75,29 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 				g_state.s0 = input.pcgStateS0;
 
-				let object = bvh_transforms.value[ input.objectIndex ];
-				var material = bvh_materials.value[ object.materialIndex ];
+				let object = transforms[ input.objectIndex ];
+				var material = materials[ object.materialIndex ];
 
 				// apply per-object colors
 				material.color *= object.color.rgb;
 				material.opacity *= object.color.a;
 
-				var vertexData = bvh_sampleTrianglePoint( input.barycoord, input.indices.xyz );
+				var vertexData = ${ sampleTrianglePointFn }( input.barycoord, input.indices.xyz );
 				vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 				vertexData.position = object.matrixWorld * vertexData.position;
 
-				let surface = getSurfaceRecord( material, vertexData, input.side, input.normal, textures, textureSampler );
+				let surface = ${ getSurfaceRecordFunc }( material, vertexData, input.side, input.normal, textures, textureSampler );
 
-				let scatterRec = bsdfSample( input.view, surface );
+				let scatterRec = ${ lambertBsdfFunc }( input.view, surface );
 
 				if ( input.currentBounce >= bounces ) {
 
 					// terminate ray, write color
-					let sampleCount = ( textureLoad( sampleCountTarget, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
-					let prevColor = textureLoad( prevOutputTarget, indexUV );
-					let blendedColor = weightedAlphaBlend( prevColor, vec4f( 0, 0, 0, 1 ), 1.0 / f32( sampleCount ) );
-					textureStore( sampleCountTarget, indexUV, vec4( sampleCount ) );
-					textureStore( outputTarget, indexUV, blendedColor );
+					let sampleCount = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
+					let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
+					let blendedColor = ${ weightedAlphaBlendFn }( prevColor, vec4f( 0, 0, 0, 1 ), 1.0 / f32( sampleCount ) );
+					textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
+					textureStore( ${ params.outputTarget }, indexUV, blendedColor );
 
 				} else {
 
@@ -114,21 +112,11 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 				}
 
-			}
-		`, [
-			proxy( 'bvhData.value.structs.material', parameters ),
-			proxy( 'bvhData.value.structs.transform', parameters ),
-			proxy( 'bvhData.value.storage.materials', parameters ),
-			proxy( 'bvhData.value.storage.transforms', parameters ),
-			proxy( 'bvhData.value.fns.sampleTrianglePoint', parameters ),
-			queuedRayStruct, lambertBsdfFunc, getSurfaceRecordFunc,
-			pcgRand3, pcgInit, queuedHitStruct,
-			weightedAlphaBlendFn,
-		] );
+			}`;
 
-		super( fn( parameters ) );
+		super( fn( params ) );
 
-		this.defineUniformAccessors( parameters );
+		this.defineUniformAccessors( params );
 
 	}
 

--- a/src/webgpu/compute/wavefront/RayGenerationKernel.js
+++ b/src/webgpu/compute/wavefront/RayGenerationKernel.js
@@ -1,10 +1,11 @@
 import { Vector2, Matrix4 } from 'three';
 import { IndirectStorageBufferAttribute, StorageTexture } from 'three/webgpu';
-import { wgslFn, uniform, storage, globalId, textureStore } from 'three/tsl';
+import { uniform, storage, globalId, textureStore } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { ndcToCameraRay } from '../../lib/wgsl/common.wgsl.js';
 import { pcgInit, pcgRand2 } from '../../nodes/random.wgsl.js';
 import { queuedRayStruct } from './structs.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class RayGenerationKernel extends ComputeKernel {
 
@@ -27,23 +28,20 @@ export class RayGenerationKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const kernel = wgslFn( /* wgsl */`
+		const fn = wgslTagFn /* wgsl */`
 			fn compute(
 				cameraToModelMatrix: mat4x4f,
 				inverseProjectionMatrix: mat4x4f,
 
 				seed: u32,
-
-				tileIndexBuffer: ptr<storage, array<u32>, read_write>,
 				tileSize: vec2u,
-
-				rayQueue: ptr<storage, array<QueuedRay>, read_write>,
-				rayQueueSize: ptr<storage, array<atomic<u32>>, read_write>,
-
-				sampleCountTarget: texture_storage_2d<r32uint, read_write>,
 
 				globalId: vec3u
 			) -> void {
+
+				let rayQueue = &${ params.rayQueue };
+				let rayQueueSize = &${ params.rayQueueSize };
+				let tileIndexBuffer = &${ params.tileIndexBuffer };
 
 				// don't overstep the edge of the tile
 				if ( globalId.x >= tileSize.x || globalId.y >= tileSize.y ) {
@@ -55,7 +53,7 @@ export class RayGenerationKernel extends ComputeKernel {
 				// calculate the pixel index and ensure we are not generating rays outside the texture bounds
 				let offset = vec2( tileIndexBuffer[ 0 ] * tileSize.x, tileIndexBuffer[ 1 ] * tileSize.y );
 				let indexUV = offset + globalId.xy;
-				let targetDimensions = textureDimensions( sampleCountTarget );
+				let targetDimensions = textureDimensions( ${ params.sampleCountTarget } );
 				if ( indexUV.x >= targetDimensions.x || indexUV.y >= targetDimensions.y ) {
 
 					return;
@@ -68,7 +66,7 @@ export class RayGenerationKernel extends ComputeKernel {
 
 				// check whether ray is already active (added on the queue) and skip it if it is
 				let ACTIVE_FLAG = 0xF0000000u;
-				let combinedField = textureLoad( sampleCountTarget, indexUV ).r;
+				let combinedField = textureLoad( ${ params.sampleCountTarget }, indexUV ).r;
 				let isActive = ( ACTIVE_FLAG & combinedField ) != 0;
 				let samples = ( ( ~ ACTIVE_FLAG ) & combinedField );
 
@@ -82,11 +80,11 @@ export class RayGenerationKernel extends ComputeKernel {
 				let queueCapacity = arrayLength( rayQueue );
 				let index = atomicAdd( &rayQueueSize[ 1 ], 1 ) % queueCapacity;
 
-				pcgInitialize( indexUV, seed );
+				${ pcgInit }( indexUV, seed );
 
 				// write the ray data
-				var jitter = 2.0 * pcgRand2() / vec2f( targetDimensions.xy );
-				var ray = ndcToCameraRay( ndc + jitter, cameraToModelMatrix * inverseProjectionMatrix );
+				var jitter = 2.0 * ${ pcgRand2 }() / vec2f( targetDimensions.xy );
+				var ray = ${ ndcToCameraRay }( ndc + jitter, cameraToModelMatrix * inverseProjectionMatrix );
 				ray.direction = normalize( ray.direction );
 
 				rayQueue[ index ].origin = ray.origin;
@@ -97,12 +95,12 @@ export class RayGenerationKernel extends ComputeKernel {
 				rayQueue[ index ].pcgStateS0 = g_state.s0;
 
 				// write the active params
-				textureStore( sampleCountTarget, indexUV, vec4( ACTIVE_FLAG | samples ) );
+				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( ACTIVE_FLAG | samples ) );
 
 			}
-		`, [ queuedRayStruct, ndcToCameraRay, pcgInit, pcgRand2 ] )( params );
+		`;
 
-		super( kernel );
+		super( fn( params ) );
 
 		this.defineUniformAccessors( params );
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -1,17 +1,17 @@
 import { DataTexture, Matrix3, IndirectStorageBufferAttribute, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from '../ComputeKernel.js';
-import { uniform, texture, sampler, storage, wgslFn, textureStore, globalId } from 'three/tsl';
-import { pcgRand2, pcgRand3, pcgInit } from '../../nodes/random.wgsl.js';
+import { uniform, texture, sampler, storage, textureStore, globalId } from 'three/tsl';
+import { pcgRand2, pcgInit } from '../../nodes/random.wgsl.js';
 import { queuedRayStruct, queuedHitStruct } from './structs.js';
 import { proxy } from '../../lib/nodes/NodeProxy.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
-import { rayStruct } from '../../lib/wgsl/structs.wgsl.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class RayIntersectionKernel extends ComputeKernel {
 
 	constructor() {
 
-		const parameters = {
+		const params = {
 			bvhData: { value: null },
 
 			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
@@ -40,22 +40,12 @@ export class RayIntersectionKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const fn = wgslFn( /* wgsl */`
+
+		const raycastFirstHitFn = proxy( 'bvhData.value.fns.raycastFirstHit', params );
+
+		const fn = wgslTagFn /* wgsl */`
 
 			fn compute(
-				// indices and target
-				prevOutputTarget: texture_storage_2d<rgba32float, read>,
-				outputTarget: texture_storage_2d<rgba32float, write>,
-				sampleCountTarget: texture_storage_2d<r32uint, read_write>,
-
-				// rays
-				rayQueue: ptr<storage, array<QueuedRay>, read>,
-				rayQueueSize: ptr<storage, array<u32>, read>,
-
-				// hits
-				hitQueue: ptr<storage, array<QueuedHit>, read_write>,
-				hitQueueSize: ptr<storage, array<atomic<u32>>, read_write>,
-
 				// environment
 				envMap: texture_2d<f32>,
 				envMapSampler: sampler,
@@ -70,6 +60,12 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 				globalId: vec3u
 			) -> void {
+
+				let rayQueue = &${ params.rayQueue };
+				let rayQueueSize = &${ params.rayQueueSize };
+
+				let hitQueue = &${ params.hitQueue };
+				let hitQueueSize = &${ params.hitQueueSize };
 
 				let envInfo = EnvironmentInfo(
 					envMapRotation,
@@ -96,13 +92,13 @@ export class RayIntersectionKernel extends ComputeKernel {
 				let ACTIVE_FLAG = 0xF0000000u;
 				let input = rayQueue[ rayIndex % queueCapacity ];
 				let indexUV = input.pixel;
-				let seed = ( textureLoad( sampleCountTarget, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + input.currentBounce;
+				let seed = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + input.currentBounce;
 
-				pcgInitialize( indexUV, seed );
+				${ pcgInit }( indexUV, seed );
 
 				// run intersection
 				let ray = Ray( input.origin, input.direction );
-				let hitResult = bvh_RaycastFirstHit( ray );
+				let hitResult = ${ raycastFirstHitFn }( ray );
 				if ( hitResult.didHit ) {
 
 					// TODO: we process all of these materials immediately to push to the ray queue
@@ -124,33 +120,28 @@ export class RayIntersectionKernel extends ComputeKernel {
 					var resultColor: vec4f;
 					if ( input.currentBounce > 0u ) {
 
-						resultColor = sampleEnvironment( envMap, envMapSampler, envInfo, input.direction, pcgRand2() ) * vec4f( input.throughputColor, 1.0 );
+						resultColor = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, input.direction, ${ pcgRand2 }() ) * vec4f( input.throughputColor, 1.0 );
 
 					} else {
 
-						resultColor = sampleEnvironment( background, backgroundSampler, backgroundInfo, input.direction, pcgRand2() );
+						resultColor = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, input.direction, ${ pcgRand2 }() );
 
 					}
 
-					let sampleCount = ( textureLoad( sampleCountTarget, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
-					let prevColor = textureLoad( prevOutputTarget, indexUV );
-					let blendedColor = weightedAlphaBlend( prevColor, resultColor, 1.0 / f32( sampleCount ) );
-					textureStore( sampleCountTarget, indexUV, vec4( sampleCount ) );
-					textureStore( outputTarget, indexUV, blendedColor );
+					let sampleCount = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
+					let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
+					let blendedColor = ${ weightedAlphaBlendFn }( prevColor, resultColor, 1.0 / f32( sampleCount ) );
+					textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
+					textureStore( ${ params.outputTarget }, indexUV, blendedColor );
 
 				}
 
 			}
-		`, [
-			proxy( 'bvhData.value.fns.raycastFirstHit', parameters ),
-			proxy( 'bvhData.value.structs.material', parameters ),
-			rayStruct, queuedRayStruct, pcgRand2, pcgRand3, pcgInit, queuedHitStruct,
-			sampleEnvironmentFn, weightedAlphaBlendFn,
-		] );
+		`;
 
-		super( fn( parameters ) );
+		super( fn( params ) );
 
-		this.defineUniformAccessors( parameters );
+		this.defineUniformAccessors( params );
 
 	}
 

--- a/src/webgpu/compute/wavefront/UpdateRayQueueParamsKernel.js
+++ b/src/webgpu/compute/wavefront/UpdateRayQueueParamsKernel.js
@@ -1,7 +1,7 @@
 import { IndirectStorageBufferAttribute } from 'three/webgpu';
-import { wgslFn, uniform, storage } from 'three/tsl';
+import { uniform, storage } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
-import { queuedRayStruct } from './structs.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class UpdateRayQueueParamsKernel extends ComputeKernel {
 
@@ -12,12 +12,10 @@ export class UpdateRayQueueParamsKernel extends ComputeKernel {
 			rayQueueSize: storage( new IndirectStorageBufferAttribute( 2, 1 ), 'u32' ),
 		};
 
-		const kernel = wgslFn( /* wgsl */`
-			fn compute(
-				processed: u32,
-				rayQueueSize: ptr<storage, array<u32>, read_write>,
-			) -> void {
+		const fn = wgslTagFn/* wgsl */`
+			fn compute( processed: u32 ) -> void {
 
+				let rayQueueSize = &${ params.rayQueueSize };
 			    var queueSize = rayQueueSize[ 1 ] - rayQueueSize[ 0 ];
 				if ( processed > queueSize ) {
 
@@ -30,9 +28,9 @@ export class UpdateRayQueueParamsKernel extends ComputeKernel {
 				}
 
 			}
-		`, [ queuedRayStruct ] )( params );
+		`;
 
-		super( kernel );
+		super( fn( params ) );
 
 		this.defineUniformAccessors( params );
 

--- a/src/webgpu/lib/nodes/WGSLTagFnNode.js
+++ b/src/webgpu/lib/nodes/WGSLTagFnNode.js
@@ -167,14 +167,16 @@ export class WGSLTagFnNode extends FunctionNode {
 		super( '', extractIncludes( args ), lang );
 
 		this.tokens = tokens;
-		this.args = normalizeArgs( args );
+		this.args = args;
 
 	}
 
 	// assemble the signature from tokens and arg names then parse
 	getNodeFunction( builder ) {
 
-		const { tokens, args } = this;
+		const { tokens } = this;
+		const args = normalizeArgs( this.args );
+
 		const nodeData = builder.getDataFromNode( this );
 		let nodeFunction = nodeData.nodeFunction;
 		if ( nodeFunction === undefined ) {
@@ -235,7 +237,7 @@ export class WGSLTagFnNode extends FunctionNode {
 	generate( builder, output ) {
 
 		const result = super.generate( builder, output );
-		const fullCode = assembleTemplate( this.tokens, this.args, builder );
+		const fullCode = assembleTemplate( this.tokens, normalizeArgs( this.args ), builder );
 
 		const { type } = this.getNodeFunction( builder );
 		const nodeCode = builder.getCodeFromNode( this, type );


### PR DESCRIPTION
Related to #745

- Convert all wavefront kernels to use wgslTagFn, get it working in Firefox, Safari
- Normalize some parameter names between kernel definitions

Somewhat related: I've noticed that there are issues with mobile rendering, as well, since some devices don't support linear interpolation of float textures. We may need to fall back to non-interpolated sampling or investigate use of Half Float textures (though I had noticed some precision artifacts when using these in webgl).

cc @theblek