### PR TITLE
WebGPUPathTracer: Use half float storage target w/ Kahan summation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/node": "^24.3.1",
         "@types/three": "^0.183.0",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
+        "@vitejs/plugin-basic-ssl": "^2.1.4",
         "canvas-capture": "^2.0.5",
         "eslint": "^8.56.0",
         "eslint-config-mdcs": "^5.0.0",
@@ -1354,6 +1355,19 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.4.tgz",
+      "integrity": "sha512-HXciTXN/sDBYWgeAD4V4s0DN0g72x5mlxQhHxtYu3Tt8BLa6MzcJZUyDVFCdtjNs3bfENVHVzOsmooTVuNgAAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0"
+      }
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.66",
@@ -4854,6 +4868,13 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
+    },
+    "@vitejs/plugin-basic-ssl": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.4.tgz",
+      "integrity": "sha512-HXciTXN/sDBYWgeAD4V4s0DN0g72x5mlxQhHxtYu3Tt8BLa6MzcJZUyDVFCdtjNs3bfENVHVzOsmooTVuNgAAw==",
+      "dev": true,
+      "requires": {}
     },
     "@webgpu/types": {
       "version": "0.1.66",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^24.3.1",
     "@types/three": "^0.183.0",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
+    "@vitejs/plugin-basic-ssl": "^2.1.4",
     "canvas-capture": "^2.0.5",
     "eslint": "^8.56.0",
     "eslint-config-mdcs": "^5.0.0",

--- a/src/textures/ProceduralEquirectTexture.js
+++ b/src/textures/ProceduralEquirectTexture.js
@@ -2,13 +2,14 @@ import {
 	ClampToEdgeWrapping,
 	Color,
 	DataTexture,
+	DataUtils,
 	EquirectangularReflectionMapping,
+	HalfFloatType,
 	LinearFilter,
 	RepeatWrapping,
 	RGBAFormat,
 	Spherical,
 	Vector2,
-	FloatType
 } from 'three';
 
 const _uv = new Vector2();
@@ -20,8 +21,8 @@ export class ProceduralEquirectTexture extends DataTexture {
 	constructor( width = 512, height = 512 ) {
 
 		super(
-			new Float32Array( width * height * 4 ),
-			width, height, RGBAFormat, FloatType, EquirectangularReflectionMapping,
+			new Uint16Array( width * height * 4 ),
+			width, height, RGBAFormat, HalfFloatType, EquirectangularReflectionMapping,
 			RepeatWrapping, ClampToEdgeWrapping, LinearFilter, LinearFilter,
 		);
 
@@ -53,10 +54,10 @@ export class ProceduralEquirectTexture extends DataTexture {
 
 				const i = y * width + x;
 				const i4 = 4 * i;
-				data[ i4 + 0 ] = ( _color.r );
-				data[ i4 + 1 ] = ( _color.g );
-				data[ i4 + 2 ] = ( _color.b );
-				data[ i4 + 3 ] = ( 1.0 );
+				data[ i4 + 0 ] = DataUtils.toHalfFloat( _color.r );
+				data[ i4 + 1 ] = DataUtils.toHalfFloat( _color.g );
+				data[ i4 + 2 ] = DataUtils.toHalfFloat( _color.b );
+				data[ i4 + 3 ] = DataUtils.toHalfFloat( 1.0 );
 
 			}
 

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -90,6 +90,7 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 			tiles,
 			outputTarget,
 			sampleCountTarget,
+			compensationTarget,
 			lowResMode,
 		} = this;
 
@@ -98,6 +99,7 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 		// init parameters
 		kernel.outputTarget = outputTarget;
 		kernel.sampleCountTarget = sampleCountTarget;
+		kernel.compensationTarget = compensationTarget;
 
 		kernel.bounces = bounces;
 		kernel.inverseProjectionMatrix.copy( camera.projectionMatrixInverse );

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -39,8 +39,8 @@ export class PathTracerBackend {
 		this.sampleCountClearKernel = new ZeroOutKernel( { textureType: 'r32uint' } ).setWorkgroupSize( 8, 8, 1 );
 		this.outputTargetClearKernel = new ZeroOutKernel( { textureType: 'rgba32float' } ).setWorkgroupSize( 8, 8, 1 );
 		this.compensationTarget = new StorageTexture( 1, 1 );
-		this.compensationTarget.format = RGBAFormat;
-		this.compensationTarget.type = HalfFloatType;
+		this.compensationTarget.format = RedIntegerFormat;
+		this.compensationTarget.type = UnsignedIntType;
 		this.compensationTarget.name = 'Accumulation Compensation';
 		this.compensationTarget.generateMipmaps = false;
 
@@ -170,8 +170,8 @@ export class PathTracerBackend {
 		sampleCountClearKernel.target = sampleCountTarget;
 		renderer.compute( sampleCountClearKernel.kernel, dispatchSize );
 
-		outputTargetClearKernel.target = compensationTarget;
-		renderer.compute( outputTargetClearKernel.kernel, dispatchSize );
+		sampleCountClearKernel.target = compensationTarget;
+		renderer.compute( sampleCountClearKernel.kernel, dispatchSize );
 
 		this.samples = 0;
 		this._renderTask = null;

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -36,8 +36,8 @@ export class PathTracerBackend {
 		this.sampleCountTarget.name = 'Sample Count';
 		this.sampleCountTarget.generateMipmaps = false;
 
-		this.sampleCountClearKernel = new ZeroOutKernel( { textureType: 'r32uint' } ).setWorkgroupSize( 8, 8, 1 );
-		this.outputTargetClearKernel = new ZeroOutKernel( { textureType: 'rgba32float' } ).setWorkgroupSize( 8, 8, 1 );
+		this.sampleCountClearKernel = new ZeroOutKernel().setWorkgroupSize( 8, 8, 1 );
+		this.outputTargetClearKernel = new ZeroOutKernel().setWorkgroupSize( 8, 8, 1 );
 
 	}
 

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -1,4 +1,4 @@
-import { ColorManagement, FloatType, LinearFilter, RGBAFormat } from 'three';
+import { ColorManagement, HalfFloatType, LinearFilter, RGBAFormat } from 'three';
 import { RedIntegerFormat, StorageTexture, UnsignedIntType } from 'three/webgpu';
 import { ZeroOutKernel } from './compute/ZeroOutKernel.js';
 
@@ -16,7 +16,7 @@ export class PathTracerBackend {
 
 		this.outputTarget = new StorageTexture( 1, 1, );
 		this.outputTarget.format = RGBAFormat;
-		this.outputTarget.type = FloatType;
+		this.outputTarget.type = HalfFloatType;
 		this.outputTarget.magFilter = LinearFilter;
 		this.outputTarget.colorSpace = ColorManagement.workingColorSpace;
 		this.outputTarget.name = 'Output #0';
@@ -24,7 +24,7 @@ export class PathTracerBackend {
 
 		this.prevOutputTarget = new StorageTexture( 1, 1, );
 		this.prevOutputTarget.format = RGBAFormat;
-		this.prevOutputTarget.type = FloatType;
+		this.prevOutputTarget.type = HalfFloatType;
 		this.prevOutputTarget.magFilter = LinearFilter;
 		this.prevOutputTarget.colorSpace = ColorManagement.workingColorSpace;
 		this.prevOutputTarget.name = 'Output #1';
@@ -36,8 +36,13 @@ export class PathTracerBackend {
 		this.sampleCountTarget.name = 'Sample Count';
 		this.sampleCountTarget.generateMipmaps = false;
 
-		this.sampleCountClearKernel = new ZeroOutKernel().setWorkgroupSize( 8, 8, 1 );
-		this.outputTargetClearKernel = new ZeroOutKernel().setWorkgroupSize( 8, 8, 1 );
+		this.sampleCountClearKernel = new ZeroOutKernel( { textureType: 'r32uint' } ).setWorkgroupSize( 8, 8, 1 );
+		this.outputTargetClearKernel = new ZeroOutKernel( { textureType: 'rgba32float' } ).setWorkgroupSize( 8, 8, 1 );
+		this.compensationTarget = new StorageTexture( 1, 1 );
+		this.compensationTarget.format = RGBAFormat;
+		this.compensationTarget.type = HalfFloatType;
+		this.compensationTarget.name = 'Accumulation Compensation';
+		this.compensationTarget.generateMipmaps = false;
 
 	}
 
@@ -84,14 +89,17 @@ export class PathTracerBackend {
 		this.outputTarget.dispose();
 		this.prevOutputTarget.dispose();
 		this.sampleCountTarget.dispose();
+		this.compensationTarget.dispose();
 
 		this.outputTarget = this.outputTarget.clone();
 		this.prevOutputTarget = this.outputTarget.clone();
 		this.sampleCountTarget = this.sampleCountTarget.clone();
+		this.compensationTarget = this.compensationTarget.clone();
 
 		this.outputTarget.setSize( w, h );
 		this.prevOutputTarget.setSize( w, h );
 		this.sampleCountTarget.setSize( w, h );
+		this.compensationTarget.setSize( w, h );
 
 		this.reset();
 		return true;
@@ -141,6 +149,7 @@ export class PathTracerBackend {
 			outputTarget,
 			prevOutputTarget,
 			sampleCountTarget,
+			compensationTarget,
 		} = this;
 
 		if ( ! renderer.initialized ) {
@@ -161,6 +170,9 @@ export class PathTracerBackend {
 		sampleCountClearKernel.target = sampleCountTarget;
 		renderer.compute( sampleCountClearKernel.kernel, dispatchSize );
 
+		outputTargetClearKernel.target = compensationTarget;
+		renderer.compute( outputTargetClearKernel.kernel, dispatchSize );
+
 		this.samples = 0;
 		this._renderTask = null;
 
@@ -171,6 +183,7 @@ export class PathTracerBackend {
 		this.outputTarget.dispose();
 		this.prevOutputTarget.dispose();
 		this.sampleCountTarget.dispose();
+		this.compensationTarget.dispose();
 
 		this._renderTask = null;
 

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -242,8 +242,10 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 				[ this.outputTarget, this.prevOutputTarget ] = [ this.prevOutputTarget, this.outputTarget ];
 				rayIntersectionKernel.prevOutputTarget = this.prevOutputTarget;
 				rayIntersectionKernel.outputTarget = this.outputTarget;
+				rayIntersectionKernel.compensationTarget = this.compensationTarget;
 				hitProcessKernel.prevOutputTarget = this.prevOutputTarget;
 				hitProcessKernel.outputTarget = this.outputTarget;
+				hitProcessKernel.compensationTarget = this.compensationTarget;
 
 				// Step 1: Top up the ray queue
 				// set up the ray prime kernel

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -1,4 +1,4 @@
-import { DataTexture, LinearFilter, Vector2, Scene, PerspectiveCamera, Color, NoToneMapping, FloatType, Timer, StorageTexture, HalfFloatType } from 'three/webgpu';
+import { DataTexture, LinearFilter, Vector2, Scene, PerspectiveCamera, Color, NoToneMapping, Timer, StorageTexture, HalfFloatType } from 'three/webgpu';
 import { SkinnedMeshBVH, MeshBVH, SAH } from 'three-mesh-bvh';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { RenderToScreenNodeMaterial } from './materials/RenderToScreenMaterial.js';

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -1,4 +1,4 @@
-import { DataTexture, LinearFilter, Vector2, Scene, PerspectiveCamera, Color, NoToneMapping, FloatType, Timer, StorageTexture } from 'three/webgpu';
+import { DataTexture, LinearFilter, Vector2, Scene, PerspectiveCamera, Color, NoToneMapping, FloatType, Timer, StorageTexture, HalfFloatType } from 'three/webgpu';
 import { SkinnedMeshBVH, MeshBVH, SAH } from 'three-mesh-bvh';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { RenderToScreenNodeMaterial } from './materials/RenderToScreenMaterial.js';
@@ -70,7 +70,7 @@ export class WebGPUPathTracer {
 		this._fadeState = 0;
 		this._size = new Vector2();
 		this._lowResTarget = new StorageTexture( 1, 1 );
-		this._lowResTarget.type = FloatType;
+		this._lowResTarget.type = HalfFloatType;
 		this._blitQuad = new FullScreenQuad( new RenderToScreenNodeMaterial() );
 
 		// options

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -47,8 +47,6 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const materialStorage = proxy( 'bvhData.value.storage.materials', parameters );
-		const transformStorage = proxy( 'bvhData.value.storage.transforms', parameters );
 		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', parameters );
 		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', parameters );
 
@@ -85,6 +83,9 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				textureSampler: sampler
 
 			) -> void {
+
+				let transforms = &${ proxy( 'bvhData.value.storage.transforms', parameters ) };
+				let materials = &${ proxy( 'bvhData.value.storage.materials', parameters ) };
 
 				let envInfo = EnvironmentInfo(
 					envMapRotation,
@@ -132,8 +133,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 					let hitResult = ${ raycastFirstHitFn }( ray );
 					if ( hitResult.didHit ) {
 
-						let object = ${ transformStorage }[ hitResult.objectIndex ];
-						var material = ${ materialStorage }[ object.materialIndex ];
+						let object = transforms[ hitResult.objectIndex ];
+						var material = materials[ object.materialIndex ];
 
 						// apply per-object colors
 						material.color *= object.color.rgb;

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -12,7 +12,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 	constructor() {
 
-		const parameters = {
+		const params = {
 			bvhData: { value: null },
 
 			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
@@ -47,8 +47,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', parameters );
-		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', parameters );
+		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', params );
+		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', params );
 
 		const shader = wgslTagFn/* wgsl */`
 
@@ -84,8 +84,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 			) -> void {
 
-				let transforms = &${ proxy( 'bvhData.value.storage.transforms', parameters ) };
-				let materials = &${ proxy( 'bvhData.value.storage.materials', parameters ) };
+				let transforms = &${ proxy( 'bvhData.value.storage.transforms', params ) };
+				let materials = &${ proxy( 'bvhData.value.storage.materials', params ) };
 
 				let envInfo = EnvironmentInfo(
 					envMapRotation,
@@ -108,7 +108,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				// to screen coordinates
 				let indexUV = offset + globalId.xy;
-				let targetDimensions = textureDimensions( ${ parameters.outputTarget } );
+				let targetDimensions = textureDimensions( ${ params.outputTarget } );
 				if ( indexUV.x >= targetDimensions.x || indexUV.y >= targetDimensions.y ) {
 
 					return;
@@ -172,17 +172,17 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				}
 
-				let sampleCount = textureLoad( ${ parameters.sampleCountTarget }, indexUV ).r + 1;
-				let prevColor = textureLoad( ${ parameters.prevOutputTarget }, indexUV );
+				let sampleCount = textureLoad( ${ params.sampleCountTarget }, indexUV ).r + 1;
+				let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
 				let blendedColor = ${ weightedAlphaBlendFn }( prevColor, resultColor, 1.0 / f32( sampleCount ) );
-				textureStore( ${ parameters.sampleCountTarget }, indexUV, vec4( sampleCount ) );
-				textureStore( ${ parameters.outputTarget }, indexUV, blendedColor );
+				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
+				textureStore( ${ params.outputTarget }, indexUV, blendedColor );
 
 			}`;
 
-		super( shader( parameters ) );
+		super( shader( params ) );
 
-		this.defineUniformAccessors( parameters );
+		this.defineUniformAccessors( params );
 
 	}
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -2,10 +2,10 @@ import { DataTexture, Matrix3, Matrix4, Vector2, StorageTexture } from 'three/we
 import { ndcToCameraRay } from '../lib/wgsl/common.wgsl.js';
 import { ComputeKernel } from './ComputeKernel.js';
 import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
-import { pcgRand2, pcgRand3, pcgInit } from '../nodes/random.wgsl.js';
+import { pcgRand2, pcgInit } from '../nodes/random.wgsl.js';
 import { getSurfaceRecordFunc, lambertBsdfFunc } from '../nodes/material.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
-import { proxy } from '../lib/nodes/NodeProxy.js';
+import { proxy, proxyFn } from '../lib/nodes/NodeProxy.js';
 import { wgslTagFn } from '../lib/nodes/WGSLTagFnNode.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
@@ -46,6 +46,11 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			// compute variables
 			globalId: globalId,
 		};
+
+		const materialStorage = proxy( 'bvhData.value.storage.materials', parameters );
+		const transformStorage = proxy( 'bvhData.value.storage.transforms', parameters );
+		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', parameters );
+		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', parameters );
 
 		const shader = wgslTagFn/* wgsl */`
 
@@ -112,11 +117,11 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				let uv = vec2f( indexUV ) / vec2f( targetDimensions );
 				let ndc = uv * 2.0 - vec2f( 1.0 );
 
-				pcgInitialize( indexUV, seed );
+				${ pcgInit }( indexUV, seed );
 
 				// scene ray
-				var jitter = 2.0 * pcgRand2() / vec2f( targetDimensions.xy );
-				var ray = ndcToCameraRay( ndc + jitter, cameraToModelMatrix * inverseProjectionMatrix );
+				var jitter = 2.0 * ${ pcgRand2 }() / vec2f( targetDimensions.xy );
+				var ray = ${ ndcToCameraRay }( ndc + jitter, cameraToModelMatrix * inverseProjectionMatrix );
 				ray.direction = normalize( ray.direction );
 
 				var resultColor = vec4f( 0, 0, 0, 1 );
@@ -124,23 +129,23 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				for ( var bounce = 0u; bounce < bounces; bounce ++ ) {
 
-					let hitResult = bvh_RaycastFirstHit( ray );
+					let hitResult = ${ raycastFirstHitFn }( ray );
 					if ( hitResult.didHit ) {
 
-						let object = bvh_transforms.value[ hitResult.objectIndex ];
-						var material = bvh_materials.value[ object.materialIndex ];
+						let object = ${ transformStorage }[ hitResult.objectIndex ];
+						var material = ${ materialStorage }[ object.materialIndex ];
 
 						// apply per-object colors
 						material.color *= object.color.rgb;
 						material.opacity *= object.color.a;
 
-						var vertexData = bvh_sampleTrianglePoint( hitResult.barycoord, hitResult.indices.xyz );
+						var vertexData = ${ sampleTrianglePointFn }( hitResult.barycoord, hitResult.indices.xyz );
 						vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 						vertexData.position = object.matrixWorld * vertexData.position;
 
-						let surface = getSurfaceRecord( material, vertexData, hitResult.side, hitResult.normal, textures, textureSampler );
+						let surface = ${ getSurfaceRecordFunc }( material, vertexData, hitResult.side, hitResult.normal, textures, textureSampler );
 
-						let scatterRec = bsdfSample( - ray.direction, surface );
+						let scatterRec = ${ lambertBsdfFunc }( - ray.direction, surface );
 
 						// white diffuse surface
 						throughputColor *= scatterRec.color / scatterRec.pdf;
@@ -152,11 +157,11 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						if ( bounce > 0u ) {
 
-							resultColor = sampleEnvironment( envMap, envMapSampler, envInfo, ray.direction, pcgRand2() ) * vec4f( throughputColor, 1.0 );
+							resultColor = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, ray.direction, pcgRand2() ) * vec4f( throughputColor, 1.0 );
 
 						} else {
 
-							resultColor = sampleEnvironment( background, backgroundSampler, backgroundInfo, ray.direction, pcgRand2() );
+							resultColor = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, ray.direction, pcgRand2() );
 
 						}
 
@@ -168,21 +173,11 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				let sampleCount = textureLoad( ${ parameters.sampleCountTarget }, indexUV ).r + 1;
 				let prevColor = textureLoad( ${ parameters.prevOutputTarget }, indexUV );
-				let blendedColor = weightedAlphaBlend( prevColor, resultColor, 1.0 / f32( sampleCount ) );
+				let blendedColor = ${ weightedAlphaBlendFn }( prevColor, resultColor, 1.0 / f32( sampleCount ) );
 				textureStore( ${ parameters.sampleCountTarget }, indexUV, vec4( sampleCount ) );
 				textureStore( ${ parameters.outputTarget }, indexUV, blendedColor );
 
-			}
-
-	${ [
-		proxy( 'bvhData.value.storage.materials', parameters ),
-		proxy( 'bvhData.value.structs.material', parameters ),
-		proxy( 'bvhData.value.structs.transform', parameters ),
-		proxy( 'bvhData.value.fns.raycastFirstHit', parameters ),
-		proxy( 'bvhData.value.fns.sampleTrianglePoint', parameters ),
-		ndcToCameraRay, pcgRand2, pcgRand3, pcgInit, lambertBsdfFunc,
-		sampleEnvironmentFn, getSurfaceRecordFunc, weightedAlphaBlendFn,
-	] }`;
+			}`;
 
 		super( shader( parameters ) );
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -1,7 +1,7 @@
 import { DataTexture, Matrix3, Matrix4, Vector2, StorageTexture } from 'three/webgpu';
 import { ndcToCameraRay } from '../lib/wgsl/common.wgsl.js';
 import { ComputeKernel } from './ComputeKernel.js';
-import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
+import { texture, sampler, uniform, globalId, textureStore, wgsl, wgslFn } from 'three/tsl';
 import { pcgRand2, pcgInit } from '../nodes/random.wgsl.js';
 import { getSurfaceRecordFunc, lambertBsdfFunc } from '../nodes/material.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
@@ -51,7 +51,51 @@ export class PathTracerMegaKernel extends ComputeKernel {
 		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', params );
 		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', params );
 
+		const unpackCompensationFn = wgslFn( /* wgsl */`
+			fn unpackCompensation( packed: u32, scale: vec4f ) -> vec4f {
+
+				// FP16 has 10 mantissa bits so 2^-10 * 0.5 = 2^-11 = 1 / 2048 relative rounding error
+				// 127 maps the value to a signed 8 bit range
+				const COMP_SCALE = 127.0 * 2048.0;
+				let raw = vec4f(
+					f32( ( packed >> 0u ) & 0xFFu ),
+					f32( ( packed >> 8u ) & 0xFFu ),
+					f32( ( packed >> 16u ) & 0xFFu ),
+					f32( ( packed >> 24u ) & 0xFFu )
+				) - 128.0;
+
+				// scale the value by the input color to accommodate relative error differences
+				return ( raw / COMP_SCALE ) * scale;
+
+			}
+		` );
+
+		const packCompensationFn = wgslFn( /* wgsl */`
+			fn packCompensation( compensation: vec4f, scale: vec4f ) -> u32 {
+
+				const COMP_SCALE = 127.0 * 2048.0;
+
+				// avoid divide by zero
+				let safeScale = select( scale, vec4f( 1.0 ), scale == vec4f( 0.0 ) );
+
+				// undo the above packing calculation, clamping to be safe
+				var quantized = ( compensation / safeScale ) * COMP_SCALE + 128.0;
+				quantized = clamp( quantized, vec4f( 0.0 ), vec4f( 255.0 ) );
+
+				// pack all the channels
+				return u32(
+					( u32( quantized.r ) << 0u ) |
+					( u32( quantized.g ) << 8u ) |
+					( u32( quantized.b ) << 16u ) |
+					( u32( quantized.a ) << 24u )
+				);
+
+			}
+		` );
+
 		const shader = wgslTagFn/* wgsl */`
+
+			${ [ unpackCompensationFn, packCompensationFn ] }
 
 			fn compute(
 
@@ -173,31 +217,16 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				}
 
-				// decode relative compensation from packed r32uint
-				const COMP_SCALE: f32 = 127.0 * 2048.0;
-				let packedComp = textureLoad( ${ params.compensationTarget }, indexUV ).r;
-				let rawComp = vec4f(
-					f32( packedComp & 0xFFu ),
-					f32( ( packedComp >> 8u ) & 0xFFu ),
-					f32( ( packedComp >> 16u ) & 0xFFu ),
-					f32( ( packedComp >> 24u ) & 0xFFu )
-				) - 128.0;
-				let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
-				let compensation = ( rawComp / COMP_SCALE ) * prevColor;
-
 				// Kahan-compensated running mean: recover true mean before computing delta
+				let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
+				let packedComp = textureLoad( ${ params.compensationTarget }, indexUV ).r;
+				let compensation = ${ unpackCompensationFn }( packedComp, prevColor );
 				let sampleCount = textureLoad( ${ params.sampleCountTarget }, indexUV ).r + 1;
 				let blendedColor = ${ weightedAlphaBlendFn }( prevColor + compensation, resultColor, 1.0 / f32( sampleCount ) );
 
 				// simulate FP16 rounding via pack/unpack to compute the residual that will be lost at store
 				let storedColor = quantizeToF16( blendedColor );
-				let newCompensation = blendedColor - storedColor;
-
-				// encode relative compensation into packed r32uint
-				let safeStored = select( storedColor, vec4f( 1.0 ), abs( storedColor ) < vec4f( 1e-10 ) );
-				let relComp = newCompensation / safeStored;
-				let quantized = clamp( relComp * COMP_SCALE + 128.0, vec4f( 0.0 ), vec4f( 255.0 ) );
-				let newPackedComp = u32( quantized.r ) | ( u32( quantized.g ) << 8u ) | ( u32( quantized.b ) << 16u ) | ( u32( quantized.a ) << 24u );
+				let newPackedComp = ${ packCompensationFn }( blendedColor - storedColor, storedColor );
 
 				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
 				textureStore( ${ params.outputTarget }, indexUV, storedColor );

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -18,6 +18,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
 			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toWriteOnly(),
 			sampleCountTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
+			compensationTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
 
 			offset: uniform( new Vector2() ),
 			tileSize: uniform( new Vector2() ),
@@ -172,11 +173,20 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				}
 
+				// Kahan-compensated running mean: recover true mean before computing delta
+				let compensation = textureLoad( ${ params.compensationTarget }, indexUV );
 				let sampleCount = textureLoad( ${ params.sampleCountTarget }, indexUV ).r + 1;
-				let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
+				let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV ) + compensation;
+
 				let blendedColor = ${ weightedAlphaBlendFn }( prevColor, resultColor, 1.0 / f32( sampleCount ) );
+
+				// simulate FP16 rounding via pack/unpack to compute the residual that will be lost at store
+				let storedColor = quantizeToF16( blendedColor );
+				let newCompensation = blendedColor - storedColor;
+
 				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
-				textureStore( ${ params.outputTarget }, indexUV, blendedColor );
+				textureStore( ${ params.outputTarget }, indexUV, storedColor );
+				textureStore( ${ params.compensationTarget }, indexUV, newCompensation );
 
 			}`;
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -7,6 +7,7 @@ import { getSurfaceRecordFunc, lambertBsdfFunc } from '../nodes/material.wgsl.js
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
 import { proxy, proxyFn } from '../lib/nodes/NodeProxy.js';
 import { wgslTagFn } from '../lib/nodes/WGSLTagFnNode.js';
+import { packCompensationFn, unpackCompensationFn } from '../nodes/f16packing.wgsl.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
 
@@ -51,51 +52,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', params );
 		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', params );
 
-		const unpackCompensationFn = wgslFn( /* wgsl */`
-			fn unpackCompensation( packed: u32, scale: vec4f ) -> vec4f {
-
-				// FP16 has 10 mantissa bits so 2^-10 * 0.5 = 2^-11 = 1 / 2048 relative rounding error
-				// 127 maps the value to a signed 8 bit range
-				const COMP_SCALE = 127.0 * 2048.0;
-				let raw = vec4f(
-					f32( ( packed >> 0u ) & 0xFFu ),
-					f32( ( packed >> 8u ) & 0xFFu ),
-					f32( ( packed >> 16u ) & 0xFFu ),
-					f32( ( packed >> 24u ) & 0xFFu )
-				) - 128.0;
-
-				// scale the value by the input color to accommodate relative error differences
-				return ( raw / COMP_SCALE ) * scale;
-
-			}
-		` );
-
-		const packCompensationFn = wgslFn( /* wgsl */`
-			fn packCompensation( compensation: vec4f, scale: vec4f ) -> u32 {
-
-				const COMP_SCALE = 127.0 * 2048.0;
-
-				// avoid divide by zero
-				let safeScale = select( scale, vec4f( 1.0 ), scale == vec4f( 0.0 ) );
-
-				// undo the above packing calculation, clamping to be safe
-				var quantized = ( compensation / safeScale ) * COMP_SCALE + 128.0;
-				quantized = clamp( quantized, vec4f( 0.0 ), vec4f( 255.0 ) );
-
-				// pack all the channels
-				return u32(
-					( u32( quantized.r ) << 0u ) |
-					( u32( quantized.g ) << 8u ) |
-					( u32( quantized.b ) << 16u ) |
-					( u32( quantized.a ) << 24u )
-				);
-
-			}
-		` );
 
 		const shader = wgslTagFn/* wgsl */`
-
-			${ [ unpackCompensationFn, packCompensationFn ] }
 
 			fn compute(
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -173,20 +173,35 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				}
 
-				// Kahan-compensated running mean: recover true mean before computing delta
-				let compensation = textureLoad( ${ params.compensationTarget }, indexUV );
-				let sampleCount = textureLoad( ${ params.sampleCountTarget }, indexUV ).r + 1;
-				let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV ) + compensation;
+				// decode relative compensation from packed r32uint
+				const COMP_SCALE: f32 = 127.0 * 2048.0;
+				let packedComp = textureLoad( ${ params.compensationTarget }, indexUV ).r;
+				let rawComp = vec4f(
+					f32( packedComp & 0xFFu ),
+					f32( ( packedComp >> 8u ) & 0xFFu ),
+					f32( ( packedComp >> 16u ) & 0xFFu ),
+					f32( ( packedComp >> 24u ) & 0xFFu )
+				) - 128.0;
+				let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
+				let compensation = ( rawComp / COMP_SCALE ) * prevColor;
 
-				let blendedColor = ${ weightedAlphaBlendFn }( prevColor, resultColor, 1.0 / f32( sampleCount ) );
+				// Kahan-compensated running mean: recover true mean before computing delta
+				let sampleCount = textureLoad( ${ params.sampleCountTarget }, indexUV ).r + 1;
+				let blendedColor = ${ weightedAlphaBlendFn }( prevColor + compensation, resultColor, 1.0 / f32( sampleCount ) );
 
 				// simulate FP16 rounding via pack/unpack to compute the residual that will be lost at store
 				let storedColor = quantizeToF16( blendedColor );
 				let newCompensation = blendedColor - storedColor;
 
+				// encode relative compensation into packed r32uint
+				let safeStored = select( storedColor, vec4f( 1.0 ), abs( storedColor ) < vec4f( 1e-10 ) );
+				let relComp = newCompensation / safeStored;
+				let quantized = clamp( relComp * COMP_SCALE + 128.0, vec4f( 0.0 ), vec4f( 255.0 ) );
+				let newPackedComp = u32( quantized.r ) | ( u32( quantized.g ) << 8u ) | ( u32( quantized.b ) << 16u ) | ( u32( quantized.a ) << 24u );
+
 				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
 				textureStore( ${ params.outputTarget }, indexUV, storedColor );
-				textureStore( ${ params.compensationTarget }, indexUV, newCompensation );
+				textureStore( ${ params.compensationTarget }, indexUV, vec4u( newPackedComp ) );
 
 			}`;
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -1,7 +1,7 @@
 import { DataTexture, Matrix3, Matrix4, Vector2, StorageTexture } from 'three/webgpu';
 import { ndcToCameraRay } from '../lib/wgsl/common.wgsl.js';
 import { ComputeKernel } from './ComputeKernel.js';
-import { texture, sampler, uniform, globalId, textureStore, wgsl, wgslFn } from 'three/tsl';
+import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
 import { pcgRand2, pcgInit } from '../nodes/random.wgsl.js';
 import { getSurfaceRecordFunc, lambertBsdfFunc } from '../nodes/material.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -188,7 +188,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
 				textureStore( ${ params.outputTarget }, indexUV, storedColor );
-				textureStore( ${ params.compensationTarget }, indexUV, vec4u( newPackedComp ) );
+				textureStore( ${ params.compensationTarget }, indexUV, vec4( newPackedComp ) );
 
 			}`;
 

--- a/src/webgpu/compute/ZeroOutBufferKernel.js
+++ b/src/webgpu/compute/ZeroOutBufferKernel.js
@@ -1,6 +1,7 @@
 import { IndirectStorageBufferAttribute } from 'three/webgpu';
 import { ComputeKernel } from './ComputeKernel.js';
-import { storage, wgslFn, globalId } from 'three/tsl';
+import { storage, globalId } from 'three/tsl';
+import { wgslTagFn } from '../lib/nodes/WGSLTagFnNode.js';
 
 export class ZeroOutBufferKernel extends ComputeKernel {
 
@@ -15,19 +16,15 @@ export class ZeroOutBufferKernel extends ComputeKernel {
 			outputTarget: storage( new IndirectStorageBufferAttribute( 1, 1 ), type ),
 		};
 
-		const fn = wgslFn( /* wgsl */`
+		const fn = wgslTagFn/* wgsl */`
+			fn compute( globalId: vec3u ) -> void {
 
-			fn compute(
-				globalId: vec3u,
-				outputTarget: ptr<storage, array<u32>, read_write>,
-			) -> void {
-
-				outputTarget[ globalId.x ] = 0;
+				${ params.outputTarget }[ globalId.x ] = 0;
 
 			}
-		` )( params );
+		`;
 
-		super( fn );
+		super( fn( params ) );
 
 		this.defineUniformAccessors( {
 			target: params.outputTarget,

--- a/src/webgpu/compute/wavefront/PrimeRayGenerationDispatchKernel.js
+++ b/src/webgpu/compute/wavefront/PrimeRayGenerationDispatchKernel.js
@@ -1,8 +1,9 @@
 import { Vector2, Vector3 } from 'three';
 import { IndirectStorageBufferAttribute } from 'three/webgpu';
-import { wgslFn, uniform, storage } from 'three/tsl';
+import { uniform, storage } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { queuedRayStruct } from './structs.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class PrimeRayGenerationDispatchKernel extends ComputeKernel {
 
@@ -18,24 +19,24 @@ export class PrimeRayGenerationDispatchKernel extends ComputeKernel {
 			rayQueue: storage( new IndirectStorageBufferAttribute( 1, queuedRayStruct.getLength() ), queuedRayStruct ).toReadOnly(),
 			rayQueueSize: storage( new IndirectStorageBufferAttribute( 2, 1 ), 'u32' ),
 
-			outputTileIndex: storage( new IndirectStorageBufferAttribute( 2, 1 ), 'u32' ),
-			outputDispatch: storage( new IndirectStorageBufferAttribute( 3, 1 ), 'u32' ),
+			outputTileIndex: storage( new IndirectStorageBufferAttribute( 2, 1 ), 'u32' ).setName( 'outputTileIndex' ),
+			outputDispatch: storage( new IndirectStorageBufferAttribute( 3, 1 ), 'u32' ).setName( 'outputDispatch' ),
 		};
 
-		const kernel = wgslFn( /* wgsl */`
+		const fn = wgslTagFn/* wgsl */`
 			fn compute(
 				rayWorkGroupSize: vec3u,
 
 				tileSize: vec2u,
 				tileCount: vec2u,
 				tileOffset: u32,
-
-				rayQueue: ptr<storage, array<QueuedRay>, read>,
-				rayQueueSize: ptr<storage, array<u32>, read_write>,
-
-				outputTileIndex: ptr<storage, array<u32>, read_write>,
-				outputDispatch: ptr<storage, array<u32>, read_write>,
 			) -> void {
+
+				let rayQueue = &${ params.rayQueue };
+				let rayQueueSize = &${ params.rayQueueSize };
+
+				let outputTileIndex = &${ params.outputTileIndex };
+				let outputDispatch = &${ params.outputDispatch };
 
 				// keep the queue index small
 			    let queueCapacity = arrayLength( rayQueue );
@@ -79,9 +80,9 @@ export class PrimeRayGenerationDispatchKernel extends ComputeKernel {
 				}
 
 			}
-		`, [ queuedRayStruct ] )( params );
+		`;
 
-		super( kernel );
+		super( fn( params ) );
 
 		this.defineUniformAccessors( params );
 

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -1,17 +1,17 @@
 import { IndirectStorageBufferAttribute, StorageTexture, DataTexture } from 'three/webgpu';
 import { ComputeKernel } from '../ComputeKernel.js';
-import { uniform, storage, wgslFn, textureStore, globalId, texture, sampler } from 'three/tsl';
-import { pcgRand3, pcgInit } from '../../nodes/random.wgsl.js';
+import { uniform, storage, textureStore, globalId, texture, sampler } from 'three/tsl';
 import { getSurfaceRecordFunc, lambertBsdfFunc } from '../../nodes/material.wgsl.js';
 import { queuedRayStruct, queuedHitStruct } from './structs.js';
-import { proxy } from '../../lib/nodes/NodeProxy.js';
+import { proxy, proxyFn } from '../../lib/nodes/NodeProxy.js';
 import { weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class ProcessHitsKernel extends ComputeKernel {
 
 	constructor() {
 
-		const parameters = {
+		const params = {
 			bvhData: { value: null },
 
 			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
@@ -35,31 +35,29 @@ export class ProcessHitsKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const fn = wgslFn( /* wgsl */`
+		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', params );
+
+		const fn = wgslTagFn/* wgsl */`
 
 			fn compute(
-				// indices and target
-				prevOutputTarget: texture_storage_2d<rgba32float, read>,
-				outputTarget: texture_storage_2d<rgba32float, write>,
-				sampleCountTarget: texture_storage_2d<r32uint, read_write>,
-
 				// settings
 				smoothNormals: u32,
 				bounces: u32,
-
-				// rays
-				rayQueue: ptr<storage, array<QueuedRay>, read_write>,
-				rayQueueSize: ptr<storage, array<atomic<u32>>, read_write>,
-
-				// hits
-				hitQueue: ptr<storage, array<QueuedHit>, read_write>,
-				hitQueueSize: ptr<storage, array<u32>, read_write>,
 
 				textures: texture_2d_array<f32>,
 				textureSampler: sampler,
 
 				globalId: vec3u
 			) -> void {
+
+				let rayQueue = &${ params.rayQueue };
+				let rayQueueSize = &${ params.rayQueueSize };
+
+				let hitQueue = &${ params.hitQueue };
+				let hitQueueSize = &${ params.hitQueueSize };
+
+				let materials = &${ proxy( 'bvhData.value.storage.materials', params ) };
+				let transforms = &${ proxy( 'bvhData.value.storage.transforms', params ) };
 
 				// skip any rays invocations beyond the ray count
 				let hitQueueCapacity = arrayLength( hitQueue );
@@ -77,29 +75,29 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 				g_state.s0 = input.pcgStateS0;
 
-				let object = bvh_transforms.value[ input.objectIndex ];
-				var material = bvh_materials.value[ object.materialIndex ];
+				let object = transforms[ input.objectIndex ];
+				var material = materials[ object.materialIndex ];
 
 				// apply per-object colors
 				material.color *= object.color.rgb;
 				material.opacity *= object.color.a;
 
-				var vertexData = bvh_sampleTrianglePoint( input.barycoord, input.indices.xyz );
+				var vertexData = ${ sampleTrianglePointFn }( input.barycoord, input.indices.xyz );
 				vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 				vertexData.position = object.matrixWorld * vertexData.position;
 
-				let surface = getSurfaceRecord( material, vertexData, input.side, input.normal, textures, textureSampler );
+				let surface = ${ getSurfaceRecordFunc }( material, vertexData, input.side, input.normal, textures, textureSampler );
 
-				let scatterRec = bsdfSample( input.view, surface );
+				let scatterRec = ${ lambertBsdfFunc }( input.view, surface );
 
 				if ( input.currentBounce >= bounces ) {
 
 					// terminate ray, write color
-					let sampleCount = ( textureLoad( sampleCountTarget, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
-					let prevColor = textureLoad( prevOutputTarget, indexUV );
-					let blendedColor = weightedAlphaBlend( prevColor, vec4f( 0, 0, 0, 1 ), 1.0 / f32( sampleCount ) );
-					textureStore( sampleCountTarget, indexUV, vec4( sampleCount ) );
-					textureStore( outputTarget, indexUV, blendedColor );
+					let sampleCount = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
+					let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
+					let blendedColor = ${ weightedAlphaBlendFn }( prevColor, vec4f( 0, 0, 0, 1 ), 1.0 / f32( sampleCount ) );
+					textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
+					textureStore( ${ params.outputTarget }, indexUV, blendedColor );
 
 				} else {
 
@@ -114,21 +112,11 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 				}
 
-			}
-		`, [
-			proxy( 'bvhData.value.structs.material', parameters ),
-			proxy( 'bvhData.value.structs.transform', parameters ),
-			proxy( 'bvhData.value.storage.materials', parameters ),
-			proxy( 'bvhData.value.storage.transforms', parameters ),
-			proxy( 'bvhData.value.fns.sampleTrianglePoint', parameters ),
-			queuedRayStruct, lambertBsdfFunc, getSurfaceRecordFunc,
-			pcgRand3, pcgInit, queuedHitStruct,
-			weightedAlphaBlendFn,
-		] );
+			}`;
 
-		super( fn( parameters ) );
+		super( fn( params ) );
 
-		this.defineUniformAccessors( parameters );
+		this.defineUniformAccessors( params );
 
 	}
 

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -6,6 +6,7 @@ import { queuedRayStruct, queuedHitStruct } from './structs.js';
 import { proxy, proxyFn } from '../../lib/nodes/NodeProxy.js';
 import { weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
 import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
+import { packCompensationFn, unpackCompensationFn } from '../../nodes/f16packing.wgsl.js';
 
 export class ProcessHitsKernel extends ComputeKernel {
 
@@ -17,6 +18,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
 			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toWriteOnly(),
 			sampleCountTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
+			compensationTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
 
 			// settings
 			smoothNormals: uniform( 1 ),
@@ -95,9 +97,12 @@ export class ProcessHitsKernel extends ComputeKernel {
 					// terminate ray, write color
 					let sampleCount = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
 					let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
-					let blendedColor = ${ weightedAlphaBlendFn }( prevColor, vec4f( 0, 0, 0, 1 ), 1.0 / f32( sampleCount ) );
+					let compensation = ${ unpackCompensationFn }( textureLoad( ${ params.compensationTarget }, indexUV ).r, prevColor );
+					let blendedColor = ${ weightedAlphaBlendFn }( prevColor + compensation, vec4f( 0, 0, 0, 1 ), 1.0 / f32( sampleCount ) );
+					let storedColor = quantizeToF16( blendedColor );
 					textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
-					textureStore( ${ params.outputTarget }, indexUV, blendedColor );
+					textureStore( ${ params.outputTarget }, indexUV, storedColor );
+					textureStore( ${ params.compensationTarget }, indexUV, vec4u( ${ packCompensationFn }( blendedColor - storedColor, storedColor ) ) );
 
 				} else {
 

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -95,14 +95,19 @@ export class ProcessHitsKernel extends ComputeKernel {
 				if ( input.currentBounce >= bounces ) {
 
 					// terminate ray, write color
+					// Kahan-compensated running mean: recover true mean before computing delta
 					let sampleCount = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
 					let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
 					let compensation = ${ unpackCompensationFn }( textureLoad( ${ params.compensationTarget }, indexUV ).r, prevColor );
 					let blendedColor = ${ weightedAlphaBlendFn }( prevColor + compensation, vec4f( 0, 0, 0, 1 ), 1.0 / f32( sampleCount ) );
+
+					// simulate FP16 rounding via pack/unpack to compute the residual that will be lost at store
 					let storedColor = quantizeToF16( blendedColor );
+					let newPackedComp = ${ packCompensationFn }( blendedColor - storedColor, storedColor );
+
 					textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
 					textureStore( ${ params.outputTarget }, indexUV, storedColor );
-					textureStore( ${ params.compensationTarget }, indexUV, vec4u( ${ packCompensationFn }( blendedColor - storedColor, storedColor ) ) );
+					textureStore( ${ params.compensationTarget }, indexUV, vec4( newPackedComp ) );
 
 				} else {
 

--- a/src/webgpu/compute/wavefront/RayGenerationKernel.js
+++ b/src/webgpu/compute/wavefront/RayGenerationKernel.js
@@ -1,10 +1,11 @@
 import { Vector2, Matrix4 } from 'three';
 import { IndirectStorageBufferAttribute, StorageTexture } from 'three/webgpu';
-import { wgslFn, uniform, storage, globalId, textureStore } from 'three/tsl';
+import { uniform, storage, globalId, textureStore } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { ndcToCameraRay } from '../../lib/wgsl/common.wgsl.js';
 import { pcgInit, pcgRand2 } from '../../nodes/random.wgsl.js';
 import { queuedRayStruct } from './structs.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class RayGenerationKernel extends ComputeKernel {
 
@@ -27,23 +28,20 @@ export class RayGenerationKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const kernel = wgslFn( /* wgsl */`
+		const fn = wgslTagFn /* wgsl */`
 			fn compute(
 				cameraToModelMatrix: mat4x4f,
 				inverseProjectionMatrix: mat4x4f,
 
 				seed: u32,
-
-				tileIndexBuffer: ptr<storage, array<u32>, read_write>,
 				tileSize: vec2u,
-
-				rayQueue: ptr<storage, array<QueuedRay>, read_write>,
-				rayQueueSize: ptr<storage, array<atomic<u32>>, read_write>,
-
-				sampleCountTarget: texture_storage_2d<r32uint, read_write>,
 
 				globalId: vec3u
 			) -> void {
+
+				let rayQueue = &${ params.rayQueue };
+				let rayQueueSize = &${ params.rayQueueSize };
+				let tileIndexBuffer = &${ params.tileIndexBuffer };
 
 				// don't overstep the edge of the tile
 				if ( globalId.x >= tileSize.x || globalId.y >= tileSize.y ) {
@@ -55,7 +53,7 @@ export class RayGenerationKernel extends ComputeKernel {
 				// calculate the pixel index and ensure we are not generating rays outside the texture bounds
 				let offset = vec2( tileIndexBuffer[ 0 ] * tileSize.x, tileIndexBuffer[ 1 ] * tileSize.y );
 				let indexUV = offset + globalId.xy;
-				let targetDimensions = textureDimensions( sampleCountTarget );
+				let targetDimensions = textureDimensions( ${ params.sampleCountTarget } );
 				if ( indexUV.x >= targetDimensions.x || indexUV.y >= targetDimensions.y ) {
 
 					return;
@@ -68,7 +66,7 @@ export class RayGenerationKernel extends ComputeKernel {
 
 				// check whether ray is already active (added on the queue) and skip it if it is
 				let ACTIVE_FLAG = 0xF0000000u;
-				let combinedField = textureLoad( sampleCountTarget, indexUV ).r;
+				let combinedField = textureLoad( ${ params.sampleCountTarget }, indexUV ).r;
 				let isActive = ( ACTIVE_FLAG & combinedField ) != 0;
 				let samples = ( ( ~ ACTIVE_FLAG ) & combinedField );
 
@@ -82,11 +80,11 @@ export class RayGenerationKernel extends ComputeKernel {
 				let queueCapacity = arrayLength( rayQueue );
 				let index = atomicAdd( &rayQueueSize[ 1 ], 1 ) % queueCapacity;
 
-				pcgInitialize( indexUV, seed );
+				${ pcgInit }( indexUV, seed );
 
 				// write the ray data
-				var jitter = 2.0 * pcgRand2() / vec2f( targetDimensions.xy );
-				var ray = ndcToCameraRay( ndc + jitter, cameraToModelMatrix * inverseProjectionMatrix );
+				var jitter = 2.0 * ${ pcgRand2 }() / vec2f( targetDimensions.xy );
+				var ray = ${ ndcToCameraRay }( ndc + jitter, cameraToModelMatrix * inverseProjectionMatrix );
 				ray.direction = normalize( ray.direction );
 
 				rayQueue[ index ].origin = ray.origin;
@@ -97,12 +95,12 @@ export class RayGenerationKernel extends ComputeKernel {
 				rayQueue[ index ].pcgStateS0 = g_state.s0;
 
 				// write the active params
-				textureStore( sampleCountTarget, indexUV, vec4( ACTIVE_FLAG | samples ) );
+				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( ACTIVE_FLAG | samples ) );
 
 			}
-		`, [ queuedRayStruct, ndcToCameraRay, pcgInit, pcgRand2 ] )( params );
+		`;
 
-		super( kernel );
+		super( fn( params ) );
 
 		this.defineUniformAccessors( params );
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -6,6 +6,7 @@ import { queuedRayStruct, queuedHitStruct } from './structs.js';
 import { proxy } from '../../lib/nodes/NodeProxy.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
 import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
+import { packCompensationFn, unpackCompensationFn } from '../../nodes/f16packing.wgsl.js';
 
 export class RayIntersectionKernel extends ComputeKernel {
 
@@ -17,6 +18,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
 			outputTarget: textureStore( new StorageTexture( 1, 1 ) ).toWriteOnly(),
 			sampleCountTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
+			compensationTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadWrite(),
 
 			// rays
 			rayQueue: storage( new IndirectStorageBufferAttribute( 1, queuedRayStruct.getLength() ), queuedRayStruct ).toReadOnly(),
@@ -130,9 +132,12 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 					let sampleCount = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
 					let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
-					let blendedColor = ${ weightedAlphaBlendFn }( prevColor, resultColor, 1.0 / f32( sampleCount ) );
+					let compensation = ${ unpackCompensationFn }( textureLoad( ${ params.compensationTarget }, indexUV ).r, prevColor );
+					let blendedColor = ${ weightedAlphaBlendFn }( prevColor + compensation, resultColor, 1.0 / f32( sampleCount ) );
+					let storedColor = quantizeToF16( blendedColor );
 					textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
-					textureStore( ${ params.outputTarget }, indexUV, blendedColor );
+					textureStore( ${ params.outputTarget }, indexUV, storedColor );
+					textureStore( ${ params.compensationTarget }, indexUV, vec4u( ${ packCompensationFn }( blendedColor - storedColor, storedColor ) ) );
 
 				}
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -130,14 +130,19 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 					}
 
+					// Kahan-compensated running mean: recover true mean before computing delta
 					let sampleCount = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
 					let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
 					let compensation = ${ unpackCompensationFn }( textureLoad( ${ params.compensationTarget }, indexUV ).r, prevColor );
 					let blendedColor = ${ weightedAlphaBlendFn }( prevColor + compensation, resultColor, 1.0 / f32( sampleCount ) );
+
+					// simulate FP16 rounding via pack/unpack to compute the residual that will be lost at store
 					let storedColor = quantizeToF16( blendedColor );
+					let newPackedComp = ${ packCompensationFn }( blendedColor - storedColor, storedColor );
+
 					textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
 					textureStore( ${ params.outputTarget }, indexUV, storedColor );
-					textureStore( ${ params.compensationTarget }, indexUV, vec4u( ${ packCompensationFn }( blendedColor - storedColor, storedColor ) ) );
+					textureStore( ${ params.compensationTarget }, indexUV, vec4( newPackedComp ) );
 
 				}
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -1,17 +1,17 @@
 import { DataTexture, Matrix3, IndirectStorageBufferAttribute, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from '../ComputeKernel.js';
-import { uniform, texture, sampler, storage, wgslFn, textureStore, globalId } from 'three/tsl';
-import { pcgRand2, pcgRand3, pcgInit } from '../../nodes/random.wgsl.js';
+import { uniform, texture, sampler, storage, textureStore, globalId } from 'three/tsl';
+import { pcgRand2, pcgInit } from '../../nodes/random.wgsl.js';
 import { queuedRayStruct, queuedHitStruct } from './structs.js';
 import { proxy } from '../../lib/nodes/NodeProxy.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
-import { rayStruct } from '../../lib/wgsl/structs.wgsl.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class RayIntersectionKernel extends ComputeKernel {
 
 	constructor() {
 
-		const parameters = {
+		const params = {
 			bvhData: { value: null },
 
 			prevOutputTarget: textureStore( new StorageTexture( 1, 1 ) ).toReadOnly(),
@@ -40,22 +40,12 @@ export class RayIntersectionKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-		const fn = wgslFn( /* wgsl */`
+
+		const raycastFirstHitFn = proxy( 'bvhData.value.fns.raycastFirstHit', params );
+
+		const fn = wgslTagFn /* wgsl */`
 
 			fn compute(
-				// indices and target
-				prevOutputTarget: texture_storage_2d<rgba32float, read>,
-				outputTarget: texture_storage_2d<rgba32float, write>,
-				sampleCountTarget: texture_storage_2d<r32uint, read_write>,
-
-				// rays
-				rayQueue: ptr<storage, array<QueuedRay>, read>,
-				rayQueueSize: ptr<storage, array<u32>, read>,
-
-				// hits
-				hitQueue: ptr<storage, array<QueuedHit>, read_write>,
-				hitQueueSize: ptr<storage, array<atomic<u32>>, read_write>,
-
 				// environment
 				envMap: texture_2d<f32>,
 				envMapSampler: sampler,
@@ -70,6 +60,12 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 				globalId: vec3u
 			) -> void {
+
+				let rayQueue = &${ params.rayQueue };
+				let rayQueueSize = &${ params.rayQueueSize };
+
+				let hitQueue = &${ params.hitQueue };
+				let hitQueueSize = &${ params.hitQueueSize };
 
 				let envInfo = EnvironmentInfo(
 					envMapRotation,
@@ -96,13 +92,13 @@ export class RayIntersectionKernel extends ComputeKernel {
 				let ACTIVE_FLAG = 0xF0000000u;
 				let input = rayQueue[ rayIndex % queueCapacity ];
 				let indexUV = input.pixel;
-				let seed = ( textureLoad( sampleCountTarget, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + input.currentBounce;
+				let seed = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + input.currentBounce;
 
-				pcgInitialize( indexUV, seed );
+				${ pcgInit }( indexUV, seed );
 
 				// run intersection
 				let ray = Ray( input.origin, input.direction );
-				let hitResult = bvh_RaycastFirstHit( ray );
+				let hitResult = ${ raycastFirstHitFn }( ray );
 				if ( hitResult.didHit ) {
 
 					// TODO: we process all of these materials immediately to push to the ray queue
@@ -124,33 +120,28 @@ export class RayIntersectionKernel extends ComputeKernel {
 					var resultColor: vec4f;
 					if ( input.currentBounce > 0u ) {
 
-						resultColor = sampleEnvironment( envMap, envMapSampler, envInfo, input.direction, pcgRand2() ) * vec4f( input.throughputColor, 1.0 );
+						resultColor = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, input.direction, ${ pcgRand2 }() ) * vec4f( input.throughputColor, 1.0 );
 
 					} else {
 
-						resultColor = sampleEnvironment( background, backgroundSampler, backgroundInfo, input.direction, pcgRand2() );
+						resultColor = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, input.direction, ${ pcgRand2 }() );
 
 					}
 
-					let sampleCount = ( textureLoad( sampleCountTarget, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
-					let prevColor = textureLoad( prevOutputTarget, indexUV );
-					let blendedColor = weightedAlphaBlend( prevColor, resultColor, 1.0 / f32( sampleCount ) );
-					textureStore( sampleCountTarget, indexUV, vec4( sampleCount ) );
-					textureStore( outputTarget, indexUV, blendedColor );
+					let sampleCount = ( textureLoad( ${ params.sampleCountTarget }, indexUV ).r & ( ~ ACTIVE_FLAG ) ) + 1;
+					let prevColor = textureLoad( ${ params.prevOutputTarget }, indexUV );
+					let blendedColor = ${ weightedAlphaBlendFn }( prevColor, resultColor, 1.0 / f32( sampleCount ) );
+					textureStore( ${ params.sampleCountTarget }, indexUV, vec4( sampleCount ) );
+					textureStore( ${ params.outputTarget }, indexUV, blendedColor );
 
 				}
 
 			}
-		`, [
-			proxy( 'bvhData.value.fns.raycastFirstHit', parameters ),
-			proxy( 'bvhData.value.structs.material', parameters ),
-			rayStruct, queuedRayStruct, pcgRand2, pcgRand3, pcgInit, queuedHitStruct,
-			sampleEnvironmentFn, weightedAlphaBlendFn,
-		] );
+		`;
 
-		super( fn( parameters ) );
+		super( fn( params ) );
 
-		this.defineUniformAccessors( parameters );
+		this.defineUniformAccessors( params );
 
 	}
 

--- a/src/webgpu/compute/wavefront/UpdateRayQueueParamsKernel.js
+++ b/src/webgpu/compute/wavefront/UpdateRayQueueParamsKernel.js
@@ -1,7 +1,7 @@
 import { IndirectStorageBufferAttribute } from 'three/webgpu';
-import { wgslFn, uniform, storage } from 'three/tsl';
+import { uniform, storage } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
-import { queuedRayStruct } from './structs.js';
+import { wgslTagFn } from '../../lib/nodes/WGSLTagFnNode.js';
 
 export class UpdateRayQueueParamsKernel extends ComputeKernel {
 
@@ -12,12 +12,10 @@ export class UpdateRayQueueParamsKernel extends ComputeKernel {
 			rayQueueSize: storage( new IndirectStorageBufferAttribute( 2, 1 ), 'u32' ),
 		};
 
-		const kernel = wgslFn( /* wgsl */`
-			fn compute(
-				processed: u32,
-				rayQueueSize: ptr<storage, array<u32>, read_write>,
-			) -> void {
+		const fn = wgslTagFn/* wgsl */`
+			fn compute( processed: u32 ) -> void {
 
+				let rayQueueSize = &${ params.rayQueueSize };
 			    var queueSize = rayQueueSize[ 1 ] - rayQueueSize[ 0 ];
 				if ( processed > queueSize ) {
 
@@ -30,9 +28,9 @@ export class UpdateRayQueueParamsKernel extends ComputeKernel {
 				}
 
 			}
-		`, [ queuedRayStruct ] )( params );
+		`;
 
-		super( kernel );
+		super( fn( params ) );
 
 		this.defineUniformAccessors( params );
 

--- a/src/webgpu/lib/nodes/NodeProxy.js
+++ b/src/webgpu/lib/nodes/NodeProxy.js
@@ -1,28 +1,4 @@
-import { Node } from 'three/webgpu';
-
-class ProxyCallNode extends Node {
-
-	static get type() {
-
-		return 'ProxyCallNode';
-
-	}
-
-	constructor( proxyNode, params ) {
-
-		super();
-		this.proxyNode = proxyNode;
-		this.params = params;
-
-	}
-
-	setup() {
-
-		return this.proxyNode.proxyNode.call( ...this.params );
-
-	}
-
-}
+import { FunctionCallNode } from 'three/webgpu';
 
 export class NodeProxy {
 
@@ -118,7 +94,16 @@ export const proxy = ( ...args ) => {
 export const proxyFn = ( ...args ) => {
 
 	const nodeProxy = new NodeProxy( ...args );
-	const fn = ( ...params ) => new ProxyCallNode( nodeProxy, params );
+	const fn = ( ...params ) => {
+
+		// match FunctionCallNode.call() convention
+		const parameters = params.length === 1 && params[ 0 ] && typeof params[ 0 ] === 'object' && ! params[ 0 ].isNode
+			? params[ 0 ]
+			: params;
+		return new FunctionCallNode( nodeProxy, parameters );
+
+	};
+
 	fn.functionNode = nodeProxy;
 	return fn;
 

--- a/src/webgpu/lib/nodes/WGSLTagFnNode.js
+++ b/src/webgpu/lib/nodes/WGSLTagFnNode.js
@@ -1,4 +1,4 @@
-import { CodeNode, FunctionNode, Node } from 'three/webgpu';
+import { CodeNode, FunctionCallNode, FunctionNode, Node } from 'three/webgpu';
 
 // minimal node that outputs a raw WGSL expression verbatim when built
 class LiteralExpression extends Node {
@@ -64,6 +64,10 @@ function getIncludeNode( arg ) {
 		if ( arg.isStruct ) return arg.layout;
 		else return null;
 
+	} else if ( arg.functionNode ) {
+
+		return arg.functionNode;
+
 	} else if ( arg.isNode ) {
 
 		return new PropertyRefNode( arg );
@@ -104,6 +108,44 @@ function extractIncludes( args ) {
 
 }
 
+// replace any string values in a keyed params object with LiteralExpression
+function wrapStringValues( obj ) {
+
+	const wrapped = {};
+	for ( const key in obj ) {
+
+		wrapped[ key ] = typeof obj[ key ] === 'string' ? new LiteralExpression( obj[ key ] ) : obj[ key ];
+
+	}
+
+	return wrapped;
+
+}
+
+// return a new FunctionCallNode with string parameter values replaced by LiteralExpression
+function wrapStringParams( callNode ) {
+
+	const params = callNode.parameters;
+	let wrapped;
+	if ( Array.isArray( params ) ) {
+
+		wrapped = params.map( p => typeof p === 'string' ? new LiteralExpression( p ) : p );
+
+	} else if ( params && typeof params === 'object' ) {
+
+		wrapped = wrapStringValues( params );
+
+	} else {
+
+		debugger
+		return callNode;
+
+	}
+
+	return new FunctionCallNode( callNode.functionNode, wrapped );
+
+}
+
 // normalize args so generate can resolve them uniformly with build():
 // - callable wrappers > PropertyRefNode (emits just the function name)
 // - struct callables > StructTypeNode (emits the type name via build)
@@ -114,7 +156,7 @@ function normalizeArgs( args ) {
 
 		if ( typeof arg === 'function' && arg.functionNode ) return new PropertyRefNode( arg.functionNode );
 		if ( typeof arg === 'function' && arg.isStruct ) return arg.layout;
-		if ( arg && arg.isNode && arg.functionNode ) return new InlineCallNode( arg );
+		if ( arg && arg.isNode && arg.functionNode ) return new InlineCallNode( wrapStringParams( arg ) );
 		if ( arg && arg.isNode ) return new PropertyRefNode( arg );
 		return arg;
 
@@ -164,18 +206,24 @@ export class WGSLTagFnNode extends FunctionNode {
 
 	constructor( tokens, args, lang = 'wgsl' ) {
 
-		super( '', extractIncludes( args ), lang );
+		super( '', [], lang );
 
 		this.tokens = tokens;
-		this.args = args;
+		this.rawArgs = args;
+
+	}
+
+	getIncludes( /*builder*/ ) {
+
+		return extractIncludes( normalizeArgs( this.rawArgs ) );
 
 	}
 
 	// assemble the signature from tokens and arg names then parse
 	getNodeFunction( builder ) {
 
-		const { tokens } = this;
-		const args = normalizeArgs( this.args );
+		const { tokens, rawArgs } = this;
+		const args = normalizeArgs( rawArgs );
 
 		const nodeData = builder.getDataFromNode( this );
 		let nodeFunction = nodeData.nodeFunction;
@@ -237,7 +285,9 @@ export class WGSLTagFnNode extends FunctionNode {
 	generate( builder, output ) {
 
 		const result = super.generate( builder, output );
-		const fullCode = assembleTemplate( this.tokens, normalizeArgs( this.args ), builder );
+		const { rawArgs, tokens } = this;
+		const args = normalizeArgs( rawArgs );
+		const fullCode = assembleTemplate( tokens, args, builder );
 
 		const { type } = this.getNodeFunction( builder );
 		const nodeCode = builder.getCodeFromNode( this, type );
@@ -260,24 +310,26 @@ export class WGSLTagCodeNode extends CodeNode {
 
 	constructor( tokens, args, lang = 'wgsl' ) {
 
-		super( '', extractIncludes( args ), lang );
+		super( '', [], lang );
 
 		this.tokens = tokens;
-		this.args = normalizeArgs( args );
+		this.rawArgs = args;
 
 	}
 
 	generate( builder ) {
 
+		const { tokens, rawArgs } = this;
+		const args = normalizeArgs( rawArgs );
+
 		// build includes so dependencies are registered before the parent code block
-		const includes = this.getIncludes( builder );
-		for ( const include of includes ) {
+		for ( const include of extractIncludes( rawArgs ) ) {
 
 			include.build( builder );
 
 		}
 
-		return assembleTemplate( this.tokens, this.args, builder );
+		return assembleTemplate( tokens, args, builder );
 
 	}
 
@@ -285,29 +337,7 @@ export class WGSLTagCodeNode extends CodeNode {
 
 const getFn = functionNode => {
 
-	const fn = ( ...params ) => {
-
-		// wrap string parameter values as raw WGSL expressions so they
-		// output verbatim as identifiers like local variable names
-		if ( params.length === 1 && params[ 0 ] && typeof params[ 0 ] === 'object' && ! params[ 0 ].isNode ) {
-
-			const obj = params[ 0 ];
-			for ( const key in obj ) {
-
-				if ( typeof obj[ key ] === 'string' ) {
-
-					obj[ key ] = new LiteralExpression( obj[ key ] );
-
-				}
-
-			}
-
-		}
-
-		return functionNode.call( ...params );
-
-	};
-
+	const fn = ( ...params ) => functionNode.call( ...params );
 	fn.functionNode = functionNode;
 	return fn;
 

--- a/src/webgpu/lib/nodes/WGSLTagFnNode.js
+++ b/src/webgpu/lib/nodes/WGSLTagFnNode.js
@@ -167,14 +167,16 @@ export class WGSLTagFnNode extends FunctionNode {
 		super( '', extractIncludes( args ), lang );
 
 		this.tokens = tokens;
-		this.args = normalizeArgs( args );
+		this.args = args;
 
 	}
 
 	// assemble the signature from tokens and arg names then parse
 	getNodeFunction( builder ) {
 
-		const { tokens, args } = this;
+		const { tokens } = this;
+		const args = normalizeArgs( this.args );
+
 		const nodeData = builder.getDataFromNode( this );
 		let nodeFunction = nodeData.nodeFunction;
 		if ( nodeFunction === undefined ) {
@@ -235,7 +237,7 @@ export class WGSLTagFnNode extends FunctionNode {
 	generate( builder, output ) {
 
 		const result = super.generate( builder, output );
-		const fullCode = assembleTemplate( this.tokens, this.args, builder );
+		const fullCode = assembleTemplate( this.tokens, normalizeArgs( this.args ), builder );
 
 		const { type } = this.getNodeFunction( builder );
 		const nodeCode = builder.getCodeFromNode( this, type );

--- a/src/webgpu/nodes/f16packing.wgsl.js
+++ b/src/webgpu/nodes/f16packing.wgsl.js
@@ -5,8 +5,8 @@ export const unpackCompensationFn = wgslFn( /* wgsl */`
 
 		// FP16 has 10 mantissa bits so 2^-10 * 0.5 = 2^-11 = 1 / 2048 relative rounding error
 		// 127 maps the value to a signed 8 bit range
-		const COMP_SCALE = 127.0 * 2048.0;
-		let raw = vec4f(
+		const UNPACK_FACTOR = 1.0 / ( 127.0 * 2048.0 );
+		let quantized = vec4f(
 			f32( ( packed >> 0u ) & 0xFFu ),
 			f32( ( packed >> 8u ) & 0xFFu ),
 			f32( ( packed >> 16u ) & 0xFFu ),
@@ -14,7 +14,7 @@ export const unpackCompensationFn = wgslFn( /* wgsl */`
 		) - 128.0;
 
 		// scale the value by the input color to accommodate relative error differences
-		return ( raw / COMP_SCALE ) * color;
+		return UNPACK_FACTOR * quantized * color;
 
 	}
 ` );
@@ -22,21 +22,23 @@ export const unpackCompensationFn = wgslFn( /* wgsl */`
 export const packCompensationFn = wgslFn( /* wgsl */`
 	fn packCompensation( compensation: vec4f, color: vec4f ) -> u32 {
 
-		const COMP_SCALE = 127.0 * 2048.0;
+		// see above UNPACK_FACTOR comment
+		const PACK_FACTOR = 127.0 * 2048.0;
 
 		// avoid divide by zero
-		let safeScale = select( color, vec4f( 1.0 ), color == vec4f( 0.0 ) );
+		// note that select operates component-wise
+		let safeColor = select( color, vec4f( 1.0 ), color == vec4f( 0.0 ) );
 
 		// undo the above packing calculation, clamping to be safe
-		var quantized = ( compensation / safeScale ) * COMP_SCALE + 128.0;
-		quantized = clamp( quantized, vec4f( 0.0 ), vec4f( 255.0 ) );
+		var quantized = vec4u( PACK_FACTOR * compensation / safeColor ) + 128u;
+		quantized = clamp( quantized, vec4u( 0 ), vec4u( 255 ) );
 
 		// pack all the channels
-		return u32(
-			( u32( quantized.r ) << 0u ) |
-			( u32( quantized.g ) << 8u ) |
-			( u32( quantized.b ) << 16u ) |
-			( u32( quantized.a ) << 24u )
+		return (
+			( quantized.r << 0u ) |
+			( quantized.g << 8u ) |
+			( quantized.b << 16u ) |
+			( quantized.a << 24u )
 		);
 
 	}

--- a/src/webgpu/nodes/f16packing.wgsl.js
+++ b/src/webgpu/nodes/f16packing.wgsl.js
@@ -1,0 +1,43 @@
+import { wgslFn } from 'three/tsl';
+
+export const unpackCompensationFn = wgslFn( /* wgsl */`
+	fn unpackCompensation( packed: u32, color: vec4f ) -> vec4f {
+
+		// FP16 has 10 mantissa bits so 2^-10 * 0.5 = 2^-11 = 1 / 2048 relative rounding error
+		// 127 maps the value to a signed 8 bit range
+		const COMP_SCALE = 127.0 * 2048.0;
+		let raw = vec4f(
+			f32( ( packed >> 0u ) & 0xFFu ),
+			f32( ( packed >> 8u ) & 0xFFu ),
+			f32( ( packed >> 16u ) & 0xFFu ),
+			f32( ( packed >> 24u ) & 0xFFu )
+		) - 128.0;
+
+		// scale the value by the input color to accommodate relative error differences
+		return ( raw / COMP_SCALE ) * color;
+
+	}
+` );
+
+export const packCompensationFn = wgslFn( /* wgsl */`
+	fn packCompensation( compensation: vec4f, color: vec4f ) -> u32 {
+
+		const COMP_SCALE = 127.0 * 2048.0;
+
+		// avoid divide by zero
+		let safeScale = select( color, vec4f( 1.0 ), color == vec4f( 0.0 ) );
+
+		// undo the above packing calculation, clamping to be safe
+		var quantized = ( compensation / safeScale ) * COMP_SCALE + 128.0;
+		quantized = clamp( quantized, vec4f( 0.0 ), vec4f( 255.0 ) );
+
+		// pack all the channels
+		return u32(
+			( u32( quantized.r ) << 0u ) |
+			( u32( quantized.g ) << 8u ) |
+			( u32( quantized.b ) << 16u ) |
+			( u32( quantized.a ) << 24u )
+		);
+
+	}
+` );

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
 import { searchForWorkspaceRoot } from 'vite';
+import basicSsl from '@vitejs/plugin-basic-ssl';
 import fs from 'fs';
 
-export default {
+export default ( { mode } ) => ( {
+
+	plugins: mode === 'ssl' ? [ basicSsl() ] : [],
 
 	root: './example/',
 	base: '',
@@ -26,4 +29,4 @@ export default {
 	optimizeDeps: {
     	exclude: [ 'three-mesh-bvh' ],
   	},
-};
+} );


### PR DESCRIPTION
Relies on #748 
Related to #133 

- Changes the output buffers to use HalfFloatType to ensure support on mobile and WebGPU in general (float type targets are not guaranteed).
- Half float targets are also always filterable.
- Use Kahan summation to avoid accumulation of error:
  - Quantize the blended color to F16
  - Calculate the delta between the F16 and F32 value
  - Pack the delta into an 8 bit value for each channel
  - Write those 8 bit values into a read/write r32 texture via bitwise ops
  - Read and unpack the delta on subsequent blend to prevent error accumulation
- Add an ssl option to the start command to allow for testing on mobile (WebGPU requires https) - run `npm start -- --mode=ssl --host`
- Adjust the ProceduralEquirectTexture to use HalfFloatType to guarantee its filterable.

With these changes both the wavefront and megakernel path tracers work on my phone 🎉

<img height="400" alt="image" src="https://github.com/user-attachments/assets/6b5ddc4a-2df0-4e78-9194-b471ac4687e5" />

cc @theblek
 