### PR TITLE
WebGPUPathTracer: improvements to compute bvh shapecast fn

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
 			}
 		],
 		"quotes": [ "error", "single" ],
-		"indent": [ "error", "tab" ],
+		"indent": [ "error", "tab", { "SwitchCase": 1 } ],
 		"no-var": [ "error" ]
 	},
     	"overrides": [

--- a/src/detectors/PrecisionMaterial.js
+++ b/src/detectors/PrecisionMaterial.js
@@ -104,15 +104,15 @@ export class PrecisionMaterial extends MaterialBase {
 
 		switch ( v.toLowerCase() ) {
 
-		case 'float':
-			this.setDefine( 'MODE', 0 );
-			break;
-		case 'int':
-			this.setDefine( 'MODE', 1 );
-			break;
-		case 'uint':
-			this.setDefine( 'MODE', 2 );
-			break;
+			case 'float':
+				this.setDefine( 'MODE', 0 );
+				break;
+			case 'int':
+				this.setDefine( 'MODE', 1 );
+				break;
+			case 'uint':
+				this.setDefine( 'MODE', 2 );
+				break;
 
 		}
 

--- a/src/textures/BlueNoiseTexture.js
+++ b/src/textures/BlueNoiseTexture.js
@@ -19,12 +19,12 @@ function getFormat( channels ) {
 
 	switch ( channels ) {
 
-	case 1:
-		return RedFormat;
-	case 2:
-		return RGFormat;
-	default:
-		return RGBAFormat;
+		case 1:
+			return RedFormat;
+		case 2:
+			return RGFormat;
+		default:
+			return RGBAFormat;
 
 	}
 

--- a/src/uniforms/FloatAttributeTextureArray.js
+++ b/src/uniforms/FloatAttributeTextureArray.js
@@ -15,17 +15,17 @@ function copyArrayToArray( fromArray, fromStride, toArray, toStride, offset ) {
 	let maxValue = 1.0;
 	switch ( fromArray.constructor ) {
 
-	case Uint8Array:
-	case Uint16Array:
-	case Uint32Array:
-		maxValue = 2 ** bpe - 1;
-		break;
+		case Uint8Array:
+		case Uint16Array:
+		case Uint32Array:
+			maxValue = 2 ** bpe - 1;
+			break;
 
-	case Int8Array:
-	case Int16Array:
-	case Int32Array:
-		maxValue = 2 ** ( bpe - 1 ) - 1;
-		break;
+		case Int8Array:
+		case Int16Array:
+		case Int32Array:
+			maxValue = 2 ** ( bpe - 1 ) - 1;
+			break;
 
 	}
 

--- a/src/uniforms/MaterialsTexture.js
+++ b/src/uniforms/MaterialsTexture.js
@@ -362,15 +362,15 @@ export class MaterialsTexture extends DataTexture {
 
 				switch ( m.side ) {
 
-				case FrontSide:
-					floatArray[ index ++ ] = 1;
-					break;
-				case BackSide:
-					floatArray[ index ++ ] = - 1;
-					break;
-				case DoubleSide:
-					floatArray[ index ++ ] = 0;
-					break;
+					case FrontSide:
+						floatArray[ index ++ ] = 1;
+						break;
+					case BackSide:
+						floatArray[ index ++ ] = - 1;
+						break;
+					case DoubleSide:
+						floatArray[ index ++ ] = 0;
+						break;
 
 				}
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -47,6 +47,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
+		const raycastOutput = proxy( 'bvhData.value.fns.raycastFirstHit.outputType', params );
 		const raycastFirstHitFn = proxyFn( 'bvhData.value.fns.raycastFirstHit', params );
 		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', params );
 
@@ -130,8 +131,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				for ( var bounce = 0u; bounce < bounces; bounce ++ ) {
 
-					let hitResult = ${ raycastFirstHitFn }( ray );
-					if ( hitResult.didHit ) {
+					var hitResult: ${ raycastOutput };
+					if ( ${ raycastFirstHitFn }( ray, &hitResult ) ) {
 
 						let object = transforms[ hitResult.objectIndex ];
 						var material = materials[ object.materialIndex ];

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -40,7 +40,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 			globalId: globalId,
 		};
 
-
+		const raycastOutput = proxy( 'bvhData.value.fns.raycastFirstHit.outputType', params );
 		const raycastFirstHitFn = proxy( 'bvhData.value.fns.raycastFirstHit', params );
 
 		const fn = wgslTagFn /* wgsl */`
@@ -98,8 +98,8 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 				// run intersection
 				let ray = Ray( input.origin, input.direction );
-				let hitResult = ${ raycastFirstHitFn }( ray );
-				if ( hitResult.didHit ) {
+				var hitResult: ${ raycastOutput };
+				if ( ${ raycastFirstHitFn }( ray, &hitResult ) ) {
 
 					// TODO: we process all of these materials immediately to push to the ray queue
 					let index = atomicAdd( &hitQueueSize[ 1 ], 1 );

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -1,4 +1,4 @@
-import { Matrix4, SkinnedMesh, Vector4 } from 'three';
+import { Matrix4, Vector4 } from 'three';
 import { Mesh, StorageBufferAttribute, StructTypeNode } from 'three/webgpu';
 import { storage, wgsl } from 'three/tsl';
 import { constants } from './wgsl/common.wgsl.js';

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -340,7 +340,6 @@ export class BVHComputeData {
 			// returns a function with a snippet inserted for the leaf intersection test
 			return wgslTagCode/* wgsl */`
 				var bestHit: ${ resultStruct };
-				bestHit.didHit = false;
 				bestHit.dist = bestDist;
 
 				var pointer: i32 = 0;
@@ -359,8 +358,7 @@ export class BVHComputeData {
 					let node = ${ storage.nodes }[ nodeIndex ];
 					pointer = pointer - 1;
 
-					var boundsHitDist: f32 = ${ intersectsBoundsFn }( shape, node.bounds );
-					if ( boundsHitDist < 0.0 || boundsHitDist > bestHit.dist ) {
+					if ( ${ intersectsBoundsFn }( shape, node.bounds, &bestHit ) == 0u ) {
 
 						continue;
 
@@ -407,12 +405,7 @@ export class BVHComputeData {
 
 				${ getFnBody( wgslTagCode/* wgsl */`
 
-					let result = ${ intersectRangeFn }( shape, offset, count, bestDist );
-					if ( result.didHit && result.dist < bestHit.dist ) {
-
-						bestHit = result;
-
-					}
+					${ intersectRangeFn }( shape, offset, count, &bestHit );
 
 				` ) }
 
@@ -809,7 +802,7 @@ export class BVHComputeData {
 			intersectsBoundsFn: wgslTagFn/* wgsl */`
 				${ [ scratchRayScalar ] }
 
-				fn rayIntersectsBounds( ray: ${ rayStruct }, bounds: ${ bvhNodeBoundsStruct } ) -> f32 {
+				fn rayIntersectsBounds( ray: ${ rayStruct }, bounds: ${ bvhNodeBoundsStruct }, result: ptr<function, ${ intersectionResultStruct }> ) -> u32 {
 
 					let boundsMin = vec3( bounds.min[0], bounds.min[1], bounds.min[2] );
 					let boundsMax = vec3( bounds.max[0], bounds.max[1], bounds.max[2] );
@@ -834,13 +827,17 @@ export class BVHComputeData {
 					let t1 = min( min( tMaxHit.x, tMaxHit.y ), tMaxHit.z );
 
 					let dist = max( t0, 0.0 );
-					if ( t1 >= dist ) {
+					if ( t1 < dist ) {
 
-						return dist * bvh_rayScalar;
+						return 0u;
+
+					} else if ( result.didHit && dist * bvh_rayScalar >= result.dist ) {
+
+						return 0u;
 
 					} else {
 
-						return - 1.0;
+						return 1u;
 
 					}
 
@@ -850,11 +847,7 @@ export class BVHComputeData {
 			intersectRangeFn: wgslTagFn/* wgsl */`
 				${ [ scratchRayScalar ] }
 
-				fn intersectRange( ray: ${ rayStruct }, offset: u32, count: u32, bestDist: f32 ) -> ${ intersectionResultStruct } {
-
-					var bestHit: ${ intersectionResultStruct };
-					bestHit.didHit = false;
-					bestHit.dist = bestDist;
+				fn intersectRange( ray: ${ rayStruct }, offset: u32, count: u32, result: ptr<function, ${ intersectionResultStruct }> ) -> void {
 
 					for ( var ti = offset; ti < offset + count; ti = ti + 1u ) {
 
@@ -868,16 +861,18 @@ export class BVHComputeData {
 
 						var triResult = ${ intersectsTriangle }( ray, a, b, c );
 						triResult.dist *= bvh_rayScalar;
-						if ( triResult.didHit && triResult.dist < bestHit.dist ) {
+						if ( triResult.didHit && triResult.dist < result.dist ) {
 
-							bestHit = triResult;
-							bestHit.indices = vec4u( i0, i1, i2, ti );
+							result.didHit = true;
+							result.dist = triResult.dist;
+							result.normal = triResult.normal;
+							result.side = triResult.side;
+							result.barycoord = triResult.barycoord;
+							result.indices = vec4u( i0, i1, i2, ti );
 
 						}
 
 					}
-
-					return bestHit;
 
 				}
 			`,

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -295,9 +295,9 @@ export class BVHComputeData {
 	getShapecastFn( options ) {
 
 		const {
-			name,
+			name = `bvh_${ Math.random().toString( 36 ).substring( 2, 7 ) }`,
 			shapeStruct,
-			resultStruct,
+			resultStruct = null,
 
 			boundsOrderFn = null,
 			intersectsBoundsFn,
@@ -456,6 +456,9 @@ export class BVHComputeData {
 
 			}
 		`;
+
+		tlasFn.outputStruct = resultStruct;
+		tlasFn.name = name;
 
 		return tlasFn;
 

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -307,13 +307,13 @@ export class BVHComputeData {
 		} = options;
 
 		const { storage } = this;
-		const { BVH_STACK_DEPTH, INFINITY } = constants;
+		const { BVH_STACK_DEPTH } = constants;
 
 		// handle optional functions
 		let transformResultSnippet = '';
 		if ( transformResultFn ) {
 
-			transformResultSnippet = wgslTagCode/* wgsl */`${ transformResultFn }( &bestHit, i );`;
+			transformResultSnippet = wgslTagCode/* wgsl */`${ transformResultFn }( bestHit, i );`;
 
 		}
 
@@ -356,7 +356,7 @@ export class BVHComputeData {
 					let node = ${ storage.nodes }[ nodeIndex ];
 					pointer = pointer - 1;
 
-					if ( ${ intersectsBoundsFn }( shape, node.bounds, &bestHit ) == 0u ) {
+					if ( ${ intersectsBoundsFn }( shape, node.bounds, bestHit ) == 0u ) {
 
 						continue;
 
@@ -398,17 +398,14 @@ export class BVHComputeData {
 
 		const blasFn = wgslTagFn/* wgsl */`
 			// fn
-			fn ${ name }_blas( shape: ${ shapeStruct }, rootNodeIndex: u32, _bestHit: ptr<function, ${ resultStruct }> ) -> bool {
+			fn ${ name }_blas( shape: ${ shapeStruct }, rootNodeIndex: u32, bestHit: ptr<function, ${ resultStruct }> ) -> bool {
 
 				var didHit = false;
-				var bestHit = *_bestHit;
 				${ getFnBody( wgslTagCode/* wgsl */`
 
-					didHit = ${ intersectRangeFn }( shape, offset, count, &bestHit ) || didHit;
+					didHit = ${ intersectRangeFn }( shape, offset, count, bestHit ) || didHit;
 
 				` ) }
-
-				*_bestHit = bestHit;
 
 				return didHit;
 
@@ -417,14 +414,10 @@ export class BVHComputeData {
 
 		const tlasFn = wgslTagFn/* wgsl */`
 			// fn
-			fn ${ name }( shape: ${ shapeStruct } ) -> ${ resultStruct } {
+			fn ${ name }( shape: ${ shapeStruct }, bestHit: ptr<function, ${ resultStruct }> ) -> bool {
 
-				let bestDist = ${ INFINITY };
-				let rootNodeIndex = 0u;
-
-				var bestHit: ${ resultStruct };
-				bestHit.dist = bestDist;
-
+				const rootNodeIndex = 0u;
+				var didHit = false;
 				${ getFnBody( wgslTagCode/* wgsl */`
 
 					for ( var i = offset; i < offset + count; i ++ ) {
@@ -440,10 +433,12 @@ export class BVHComputeData {
 						var localShape = shape;
 						${ transformShapeSnippet }
 
-						if ( ${ blasFn }( localShape, transform.nodeOffset, &bestHit ) ) {
+						if ( ${ blasFn }( localShape, transform.nodeOffset, bestHit ) ) {
 
 							bestHit.objectIndex = i;
 							${ transformResultSnippet }
+
+							didHit = true;
 
 						}
 
@@ -451,12 +446,12 @@ export class BVHComputeData {
 
 				` ) }
 
-				return bestHit;
+				return didHit;
 
 			}
 		`;
 
-		tlasFn.outputStruct = resultStruct;
+		tlasFn.outputType = resultStruct;
 		tlasFn.functionName = name;
 
 		return tlasFn;

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -298,6 +298,8 @@ export class BVHComputeData {
 
 	getShapecastFn( options ) {
 
+		// TODO: test with and verify use with TSL Fn - both passing them as arguments,
+		// calling the function from a TSL Fn.
 		const {
 			name = `bvh_${ Math.random().toString( 36 ).substring( 2, 7 ) }`,
 			shapeStruct,

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -300,8 +300,11 @@ export class BVHComputeData {
 
 		// TODO: test with and verify use with TSL Fn - both passing them as arguments,
 		// calling the function from a TSL Fn.
+		// TODO: revisit the semantics and mental model of "transformShapeFn" and "transformResultFn".
+		// Are they "before" and "after" hooks? Should they include words implying a direction of transform?
+		// eg "toLocal" / "toWorld"?
 		const {
-			name = `bvh_${ Math.random().toString( 36 ).substring( 2, 7 ) }`,
+			name = `bvh_shapecast_fn_${ Math.random().toString( 36 ).substring( 2, 7 ) }`,
 			shapeStruct,
 			resultStruct = null,
 

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -26,6 +26,25 @@ StructTypeNode.prototype.isStruct = true;
 
 //
 
+const isVisible = object => {
+
+	let curr = object;
+	while ( curr ) {
+
+		if ( curr.visible === false ) {
+
+			return false;
+
+		}
+
+		curr = curr.parent;
+
+	}
+
+	return true;
+
+};
+
 const applyBoneTransform = ( () => {
 
 	// a vec4-compatible version of SkinnedMesh.applyBoneTransform to support directions, positions
@@ -913,7 +932,7 @@ export class BVHComputeData {
 		// write node offset
 		transformBufferU32[ writeOffset * structs.transform.getLength() + 32 ] = bvhNodeOffsets[ root ];
 
-		let visible = object.visible;
+		let visible = isVisible( object );
 		if ( object.isBatchedMesh ) {
 
 			visible = visible && object.getVisibleAt( instanceId );

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -268,11 +268,9 @@ export class BVHComputeData {
 		}
 
 		const {
-			prefix = 'bvh_',
 			attributes = { position: 'vec4f' },
 		} = options;
 
-		this.prefix = prefix;
 		this.attributes = attributes;
 		this.bvh = bvh;
 
@@ -466,7 +464,7 @@ export class BVHComputeData {
 	update() {
 
 		const self = this;
-		const { attributes, structs, prefix, bvh } = this;
+		const { attributes, structs, bvh } = this;
 
 		// collect the BVHs
 		const bvhInfo = [];
@@ -531,7 +529,7 @@ export class BVHComputeData {
 		attributesBufferLength = Math.max( attributesBufferLength, 2 );
 
 		// construct the attribute struct
-		const attributeStruct = new StructTypeNode( attributes, `${ prefix }GeometryStruct` );
+		const attributeStruct = new StructTypeNode( attributes, 'bvh_GeometryStruct' );
 
 		// write the geometry buffer attributes & bvh data
 		let attributesOffset = 0;
@@ -579,11 +577,11 @@ export class BVHComputeData {
 		// if itemSize for StorageBufferAttribute == arraySize,
 		// then buffer is treated not as array of structs, but as a single struct
 		// And that breaks code. For now itemSize = 1 does not seem to break anything
-		const bvhNodesStorage = storage( new StorageBufferAttribute( new Uint32Array( bvhNodesBuffer ), 1 ), bvhNodeStruct ).toReadOnly().setName( `${ prefix }nodes` );
+		const bvhNodesStorage = storage( new StorageBufferAttribute( new Uint32Array( bvhNodesBuffer ), 1 ), bvhNodeStruct ).toReadOnly().setName( 'bvh_nodes' );
 		const transformsBuffer = new StorageBufferAttribute( new Uint32Array( transformArrayBuffer ), 1 );
-		const transformsStorage = storage( transformsBuffer, structs.transform ).toReadOnly().setName( `${ prefix }transforms` );
-		const indexStorage = storage( new StorageBufferAttribute( indexBuffer, 1 ), 'uint' ).toReadOnly().setName( `${ prefix }index` );
-		const attributesStorage = storage( new StorageBufferAttribute( new Uint32Array( attributesBuffer ), attributeStruct.getLength() ), attributeStruct ).toReadOnly().setName( `${ prefix }attributes` );
+		const transformsStorage = storage( transformsBuffer, structs.transform ).toReadOnly().setName( 'bvh_transforms' );
+		const indexStorage = storage( new StorageBufferAttribute( indexBuffer, 1 ), 'uint' ).toReadOnly().setName( 'bvh_index' );
+		const attributesStorage = storage( new StorageBufferAttribute( new Uint32Array( attributesBuffer ), attributeStruct.getLength() ), attributeStruct ).toReadOnly().setName( 'bvh_attributes' );
 
 		this.storage.transforms = transformsStorage;
 		this.storage.nodes = bvhNodesStorage;
@@ -787,14 +785,14 @@ export class BVHComputeData {
 
 	_initFns() {
 
-		const { storage, structs, fns, prefix } = this;
+		const { storage, structs, fns } = this;
 
 		// raycast first hit
 		const scratchRayScalar = wgsl( /* wgsl */`
-			var<private> ${ prefix }rayScalar = 1.0;
+			var<private> bvh_rayScalar = 1.0;
 		` );
 		fns.raycastFirstHit = this.getShapecastFn( {
-			name: prefix + 'RaycastFirstHit',
+			name: 'bvh_RaycastFirstHit',
 			shapeStruct: rayStruct,
 			resultStruct: intersectionResultStruct,
 
@@ -835,7 +833,7 @@ export class BVHComputeData {
 					let dist = max( t0, 0.0 );
 					if ( t1 >= dist ) {
 
-						return dist * ${ prefix }rayScalar;
+						return dist * bvh_rayScalar;
 
 					} else {
 
@@ -866,7 +864,7 @@ export class BVHComputeData {
 						let c = ${ storage.attributes }[ i2 ].position.xyz;
 
 						var triResult = ${ intersectsTriangle }( ray, a, b, c );
-						triResult.dist *= ${ prefix }rayScalar;
+						triResult.dist *= bvh_rayScalar;
 						if ( triResult.didHit && triResult.dist < bestHit.dist ) {
 
 							bestHit = triResult;
@@ -891,7 +889,7 @@ export class BVHComputeData {
 
 					let len = length( ray.direction );
 					ray.direction /= len;
-					${ prefix }rayScalar = 1.0 / len;
+					bvh_rayScalar = 1.0 / len;
 
 				}
 			`,
@@ -915,7 +913,7 @@ export class BVHComputeData {
 			} ).join( '\n' );
 		fns.sampleTrianglePoint = wgslTagFn/* wgsl */`
 			// fn
-			fn ${ prefix }sampleTrianglePoint( barycoord: vec3f, indices: vec3u ) -> ${ structs.attributes } {
+			fn bvh_sampleTrianglePoint( barycoord: vec3f, indices: vec3u ) -> ${ structs.attributes } {
 
 				var result: ${ structs.attributes };
 				var a0 = ${ storage.attributes }[ indices.x ];

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -458,7 +458,7 @@ export class BVHComputeData {
 		`;
 
 		tlasFn.outputStruct = resultStruct;
-		tlasFn.name = name;
+		tlasFn.functionName = name;
 
 		return tlasFn;
 

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -4,7 +4,7 @@ import { storage, wgsl } from 'three/tsl';
 import { constants } from './wgsl/common.wgsl.js';
 import { rayStruct, bvhNodeStruct, bvhNodeBoundsStruct } from './wgsl/structs.wgsl.js';
 import { wgslTagCode, wgslTagFn } from './nodes/WGSLTagFnNode.js';
-import { GeometryBVH, ObjectBVH, SAH } from 'three-mesh-bvh';
+import { MeshBVH, SkinnedMeshBVH, GeometryBVH, ObjectBVH, SAH } from 'three-mesh-bvh';
 
 // TODO: add ability to easily update a single matrix / scene rearrangement (partial update)
 // TODO: add material support w/ function to easily update material
@@ -269,8 +269,12 @@ export class BVHComputeData {
 
 		const {
 			attributes = { position: 'vec4f' },
+			autogenerateBvh = true,
 		} = options;
 
+		this._bvhCache = new Map();
+
+		this.autogenerateBvh = autogenerateBvh;
 		this.attributes = attributes;
 		this.bvh = bvh;
 
@@ -479,6 +483,12 @@ export class BVHComputeData {
 			const range = { start: 0, count: 0, vertexStart: 0, vertexCount: 0 };
 			const primBvh = this.getBVH( object, instanceId, range );
 
+			if ( ! primBvh ) {
+
+				throw new Error( 'BVHComputeData: BVH not found.' );
+
+			}
+
 			// if we haven't added this bvh, yet
 			if ( ! bvhInfo.find( info => info.bvh === primBvh ) ) {
 
@@ -588,6 +598,7 @@ export class BVHComputeData {
 		this.structs.attributes = attributeStruct;
 
 		this._initFns();
+		this._bvhCache.clear();
 
 		function appendBVHData( bvh, geometryOffset, transformInfo, nodeWriteOffset, target, tlas = false ) {
 
@@ -976,14 +987,22 @@ export class BVHComputeData {
 
 	getBVH( object, instanceId, rangeTarget ) {
 
+		const { autogenerateBvh, _bvhCache } = this;
+
 		let bvh = null;
-		if ( object.boundsTree ) {
+		if ( object.boundsTree || object.isSkinnedMesh ) {
 
 			// this is a case where a mesh has morph targets and skinned meshes
 			const geometry = object.geometry;
 			rangeTarget.count = geometry.index ? geometry.index.count : geometry.attributes.position.count;
 			rangeTarget.vertexCount = geometry.attributes.position.count;
 			bvh = object.boundsTree;
+
+			if ( bvh === null && autogenerateBvh ) {
+
+				// TODO: handle skinned meshes, skeletons, etc
+
+			}
 
 		} else if ( object.isBatchedMesh ) {
 
@@ -992,6 +1011,14 @@ export class BVHComputeData {
 			Object.assign( rangeTarget, range );
 			bvh = object.boundsTrees[ geometryId ];
 
+			if ( bvh === null && autogenerateBvh ) {
+
+				const id = `batched_${ object.geometry.uuid }_${ range.start }_${ range.count }`;
+				bvh = _bvhCache.get( id ) || new MeshBVH( object.geometry, { range: { ...rangeTarget } } );
+				_bvhCache.set( id, bvh );
+
+			}
+
 		} else {
 
 			const geometry = object.geometry;
@@ -999,11 +1026,13 @@ export class BVHComputeData {
 			rangeTarget.vertexCount = geometry.attributes.position.count;
 			bvh = object.geometry.boundsTree;
 
-		}
+			if ( bvh === null && autogenerateBvh ) {
 
-		if ( ! bvh ) {
+				const id = geometry.uuid;
+				bvh = _bvhCache.get( id ) || new MeshBVH( geometry );
+				_bvhCache.set( id, bvh );
 
-			throw new Error( 'BVHComputeData: BVH not found.' );
+			}
 
 		}
 

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -301,15 +301,42 @@ export class BVHComputeData {
 			shapeStruct,
 			resultStruct,
 
-			boundsOrderFn,
+			boundsOrderFn = null,
 			intersectsBoundsFn,
 			intersectRangeFn,
-			transformShapeFn,
-			transformResultFn,
+			transformShapeFn = null,
+			transformResultFn = null,
 		} = options;
 
 		const { storage } = this;
 		const { BVH_STACK_DEPTH, INFINITY } = constants;
+
+		// handle optional functions
+		let transformResultSnippet = '';
+		if ( transformResultFn ) {
+
+			transformResultSnippet = wgslTagCode/* wgsl */`${ transformResultFn }( &bestHit, i );`;
+
+		}
+
+		let transformShapeSnippet = '';
+		if ( transformShapeFn ) {
+
+			transformShapeSnippet = wgslTagCode/* wgsl */`${ transformShapeFn }( &localShape, i );`;
+
+		}
+
+		let leftToRightSnippet = '';
+		if ( boundsOrderFn ) {
+
+			leftToRightSnippet = wgslTagCode/* wgsl */`
+				let leftToRight = ${ boundsOrderFn }( shape, splitAxis, node );
+				c1 = select( rightIndex, leftIndex, leftToRight );
+				c2 = select( leftIndex, rightIndex, leftToRight );
+			`;
+
+		}
+
 		const getFnBody = leafSnippet => {
 
 			// returns a function with a snippet inserted for the leaf intersection test
@@ -357,9 +384,9 @@ export class BVHComputeData {
 						let splitAxis = infoX & 0x0000ffffu;
 						let rightIndex = nodeIndex + infoY;
 
-						let leftToRight = ${ boundsOrderFn }( shape, splitAxis, node );
-						let c1 = select( rightIndex, leftIndex, leftToRight );
-						let c2 = select( leftIndex, rightIndex, leftToRight );
+						var c1 = rightIndex;
+						var c2 = leftIndex;
+						${ leftToRightSnippet }
 
 						pointer = pointer + 1;
 						stack[ pointer ] = c2;
@@ -403,9 +430,9 @@ export class BVHComputeData {
 
 				${ getFnBody( wgslTagCode/* wgsl */`
 
-					for ( var t = offset; t < offset + count; t = t + 1u ) {
+					for ( var i = offset; i < offset + count; i ++ ) {
 
-						let transform = ${ storage.transforms }[ t ];
+						let transform = ${ storage.transforms }[ i ];
 						if ( transform.visible == 0u ) {
 
 							continue;
@@ -413,14 +440,15 @@ export class BVHComputeData {
 						}
 
 						// Transform shape into object local space
-						let localShape = ${ transformShapeFn }( shape, transform.inverseMatrixWorld );
+						var localShape = shape;
+						${ transformShapeSnippet }
 						let blasHit = ${ blasFn( { shape: 'localShape', rootNodeIndex: 'transform.nodeOffset', bestDist: 'bestHit.dist' } ) };
 						if ( blasHit.didHit && blasHit.dist < bestHit.dist ) {
 
 							bestHit = blasHit;
-							bestHit.objectIndex = t;
+							bestHit.objectIndex = i;
 
-							${ transformResultFn }( &bestHit, transform.matrixWorld, transform.inverseMatrixWorld );
+							${ transformResultSnippet }
 
 						}
 
@@ -855,23 +883,22 @@ export class BVHComputeData {
 			transformShapeFn: wgslTagFn/* wgsl */`
 				${ [ scratchRayScalar ] }
 
-				fn transformRay( ray: ${ rayStruct }, toLocal: mat4x4f ) -> ${ rayStruct } {
+				fn transformRay( ray: ptr<function, ${ rayStruct }>, objectIndex: u32 ) -> void {
 
-					var localRay: Ray;
-					localRay.origin = ( toLocal * vec4f( ray.origin, 1.0 ) ).xyz;
-					localRay.direction = ( toLocal * vec4f( ray.direction, 0.0 ) ).xyz;
+					let toLocal = ${ storage.transforms }[ objectIndex ].inverseMatrixWorld;
+					ray.origin = ( toLocal * vec4f( ray.origin, 1.0 ) ).xyz;
+					ray.direction = ( toLocal * vec4f( ray.direction, 0.0 ) ).xyz;
 
-					let len = length( localRay.direction );
-					localRay.direction /= len;
+					let len = length( ray.direction );
+					ray.direction /= len;
 					${ prefix }rayScalar = 1.0 / len;
-
-					return localRay;
 
 				}
 			`,
 			transformResultFn: wgslTagFn/* wgsl */`
-				fn transformResult( hit: ptr<function, ${ intersectionResultStruct }>, toWorld: mat4x4f, toLocal: mat4x4f ) -> void {
+				fn transformResult( hit: ptr<function, ${ intersectionResultStruct }>, objectIndex: u32 ) -> void {
 
+					let toLocal = ${ storage.transforms }[ objectIndex ].inverseMatrixWorld;
 					hit.normal = normalize( ( transpose( toLocal ) * vec4f( hit.normal, 0.0 ) ).xyz );
 
 				}

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -701,18 +701,18 @@ export class BVHComputeData {
 
 						switch ( attr.itemSize ) {
 
-						case 1:
-							_vec.y = _def.y;
-							_vec.z = _def.z;
-							_vec.w = _def.w;
-							break;
-						case 2:
-							_vec.z = _def.z;
-							_vec.w = _def.w;
-							break;
-						case 3:
-							_vec.w = _def.w;
-							break;
+							case 1:
+								_vec.y = _def.y;
+								_vec.z = _def.z;
+								_vec.w = _def.w;
+								break;
+							case 2:
+								_vec.z = _def.z;
+								_vec.w = _def.w;
+								break;
+							case 3:
+								_vec.w = _def.w;
+								break;
 
 						}
 
@@ -965,13 +965,13 @@ export class BVHComputeData {
 
 		switch ( key ) {
 
-		case 'position':
-		case 'color':
-			target.set( 1, 1, 1, 1 );
-			break;
+			case 'position':
+			case 'color':
+				target.set( 1, 1, 1, 1 );
+				break;
 
-		default:
-			target.set( 0, 0, 0, 0 );
+			default:
+				target.set( 0, 0, 0, 0 );
 
 		}
 

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -313,7 +313,7 @@ export class BVHComputeData {
 		let transformResultSnippet = '';
 		if ( transformResultFn ) {
 
-			transformResultSnippet = wgslTagCode/* wgsl */`${ transformResultFn }( bestHit, i );`;
+			transformResultSnippet = wgslTagCode/* wgsl */`${ transformResultFn }( result, i );`;
 
 		}
 
@@ -334,6 +334,9 @@ export class BVHComputeData {
 			`;
 
 		}
+
+		let resultPtrSnippet = resultStruct ? wgslTagCode/* wgsl */`result: ptr<function, ${ resultStruct }>` : '';
+		let resultArg = resultStruct ? 'result' : '';
 
 		const getFnBody = leafSnippet => {
 
@@ -356,7 +359,7 @@ export class BVHComputeData {
 					let node = ${ storage.nodes }[ nodeIndex ];
 					pointer = pointer - 1;
 
-					if ( ${ intersectsBoundsFn }( shape, node.bounds, bestHit ) == 0u ) {
+					if ( ${ intersectsBoundsFn }( shape, node.bounds, ${ resultArg } ) == 0u ) {
 
 						continue;
 
@@ -398,12 +401,12 @@ export class BVHComputeData {
 
 		const blasFn = wgslTagFn/* wgsl */`
 			// fn
-			fn ${ name }_blas( shape: ${ shapeStruct }, rootNodeIndex: u32, bestHit: ptr<function, ${ resultStruct }> ) -> bool {
+			fn ${ name }_blas( shape: ${ shapeStruct }, rootNodeIndex: u32, ${ resultPtrSnippet } ) -> bool {
 
 				var didHit = false;
 				${ getFnBody( wgslTagCode/* wgsl */`
 
-					didHit = ${ intersectRangeFn }( shape, offset, count, bestHit ) || didHit;
+					didHit = ${ intersectRangeFn }( shape, offset, count, ${ resultArg } ) || didHit;
 
 				` ) }
 
@@ -414,7 +417,7 @@ export class BVHComputeData {
 
 		const tlasFn = wgslTagFn/* wgsl */`
 			// fn
-			fn ${ name }( shape: ${ shapeStruct }, bestHit: ptr<function, ${ resultStruct }> ) -> bool {
+			fn ${ name }( shape: ${ shapeStruct }, ${ resultPtrSnippet } ) -> bool {
 
 				const rootNodeIndex = 0u;
 				var didHit = false;
@@ -433,9 +436,9 @@ export class BVHComputeData {
 						var localShape = shape;
 						${ transformShapeSnippet }
 
-						if ( ${ blasFn }( localShape, transform.nodeOffset, bestHit ) ) {
+						if ( ${ blasFn }( localShape, transform.nodeOffset, ${ resultArg } ) ) {
 
-							bestHit.objectIndex = i;
+							${ resultStruct ? 'result.objectIndex = i;' : '' }
 							${ transformResultSnippet }
 
 							didHit = true;

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -335,8 +335,8 @@ export class BVHComputeData {
 
 		}
 
-		let resultPtrSnippet = resultStruct ? wgslTagCode/* wgsl */`result: ptr<function, ${ resultStruct }>` : '';
-		let resultArg = resultStruct ? 'result' : '';
+		const resultPtrSnippet = resultStruct ? wgslTagCode/* wgsl */`result: ptr<function, ${ resultStruct }>` : '';
+		const resultArg = resultStruct ? 'result' : '';
 
 		const getFnBody = leafSnippet => {
 

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -996,7 +996,7 @@ export class BVHComputeData {
 			const geometry = object.geometry;
 			rangeTarget.count = geometry.index ? geometry.index.count : geometry.attributes.position.count;
 			rangeTarget.vertexCount = geometry.attributes.position.count;
-			bvh = object.boundsTree;
+			bvh = object.boundsTree || null;
 
 			if ( bvh === null && autogenerateBvh ) {
 
@@ -1011,7 +1011,7 @@ export class BVHComputeData {
 			const geometryId = object.getGeometryIdAt( instanceId );
 			const range = object.getGeometryRangeAt( geometryId );
 			Object.assign( rangeTarget, range );
-			bvh = object.boundsTrees[ geometryId ];
+			bvh = object.boundsTrees[ geometryId ] || null;
 
 			if ( bvh === null && autogenerateBvh ) {
 
@@ -1026,7 +1026,7 @@ export class BVHComputeData {
 			const geometry = object.geometry;
 			rangeTarget.count = geometry.index ? geometry.index.count : geometry.attributes.position.count;
 			rangeTarget.vertexCount = geometry.attributes.position.count;
-			bvh = object.geometry.boundsTree;
+			bvh = object.geometry.boundsTree || null;
 
 			if ( bvh === null && autogenerateBvh ) {
 

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -1,4 +1,4 @@
-import { Matrix4, Vector4 } from 'three';
+import { Matrix4, SkinnedMesh, Vector4 } from 'three';
 import { Mesh, StorageBufferAttribute, StructTypeNode } from 'three/webgpu';
 import { storage, wgsl } from 'three/tsl';
 import { constants } from './wgsl/common.wgsl.js';
@@ -1000,7 +1000,9 @@ export class BVHComputeData {
 
 			if ( bvh === null && autogenerateBvh ) {
 
-				// TODO: handle skinned meshes, skeletons, etc
+				const id = object.uuid;
+				bvh = _bvhCache.get( id ) || new SkinnedMeshBVH( object );
+				_bvhCache.set( id, bvh );
 
 			}
 

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -438,9 +438,7 @@ export class BVHComputeData {
 
 						if ( ${ blasFn }( localShape, transform.nodeOffset, ${ resultArg } ) ) {
 
-							${ resultStruct ? 'result.objectIndex = i;' : '' }
 							${ transformResultSnippet }
-
 							didHit = true;
 
 						}
@@ -905,6 +903,7 @@ export class BVHComputeData {
 
 					let toLocal = ${ storage.transforms }[ objectIndex ].inverseMatrixWorld;
 					hit.normal = normalize( ( transpose( toLocal ) * vec4f( hit.normal, 0.0 ) ).xyz );
+					hit.objectIndex = objectIndex;
 
 				}
 			`,

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -339,8 +339,6 @@ export class BVHComputeData {
 
 			// returns a function with a snippet inserted for the leaf intersection test
 			return wgslTagCode/* wgsl */`
-				var bestHit: ${ resultStruct };
-				bestHit.dist = bestDist;
 
 				var pointer: i32 = 0;
 				var stack: array<u32, ${ BVH_STACK_DEPTH }>;
@@ -394,20 +392,25 @@ export class BVHComputeData {
 
 				}
 
-				return bestHit;
 			`;
 
 		};
 
 		const blasFn = wgslTagFn/* wgsl */`
 			// fn
-			fn ${ name }_blas( shape: ${ shapeStruct }, rootNodeIndex: u32, bestDist: f32 ) -> ${ resultStruct } {
+			fn ${ name }_blas( shape: ${ shapeStruct }, rootNodeIndex: u32, _bestHit: ptr<function, ${ resultStruct }> ) -> bool {
 
+				var didHit = false;
+				var bestHit = *_bestHit;
 				${ getFnBody( wgslTagCode/* wgsl */`
 
-					${ intersectRangeFn }( shape, offset, count, &bestHit );
+					didHit = ${ intersectRangeFn }( shape, offset, count, &bestHit ) || didHit;
 
 				` ) }
+
+				*_bestHit = bestHit;
+
+				return didHit;
 
 			}
 		`;
@@ -418,6 +421,9 @@ export class BVHComputeData {
 
 				let bestDist = ${ INFINITY };
 				let rootNodeIndex = 0u;
+
+				var bestHit: ${ resultStruct };
+				bestHit.dist = bestDist;
 
 				${ getFnBody( wgslTagCode/* wgsl */`
 
@@ -433,12 +439,10 @@ export class BVHComputeData {
 						// Transform shape into object local space
 						var localShape = shape;
 						${ transformShapeSnippet }
-						let blasHit = ${ blasFn( { shape: 'localShape', rootNodeIndex: 'transform.nodeOffset', bestDist: 'bestHit.dist' } ) };
-						if ( blasHit.didHit && blasHit.dist < bestHit.dist ) {
 
-							bestHit = blasHit;
+						if ( ${ blasFn }( localShape, transform.nodeOffset, &bestHit ) ) {
+
 							bestHit.objectIndex = i;
-
 							${ transformResultSnippet }
 
 						}
@@ -446,6 +450,8 @@ export class BVHComputeData {
 					}
 
 				` ) }
+
+				return bestHit;
 
 			}
 		`;
@@ -847,8 +853,9 @@ export class BVHComputeData {
 			intersectRangeFn: wgslTagFn/* wgsl */`
 				${ [ scratchRayScalar ] }
 
-				fn intersectRange( ray: ${ rayStruct }, offset: u32, count: u32, result: ptr<function, ${ intersectionResultStruct }> ) -> void {
+				fn intersectRange( ray: ${ rayStruct }, offset: u32, count: u32, result: ptr<function, ${ intersectionResultStruct }> ) -> bool {
 
+					var didHit = false;
 					for ( var ti = offset; ti < offset + count; ti = ti + 1u ) {
 
 						let i0 = ${ storage.index }[ ti * 3u ];
@@ -861,7 +868,7 @@ export class BVHComputeData {
 
 						var triResult = ${ intersectsTriangle }( ray, a, b, c );
 						triResult.dist *= bvh_rayScalar;
-						if ( triResult.didHit && triResult.dist < result.dist ) {
+						if ( triResult.didHit && ( ! result.didHit || triResult.dist < result.dist ) ) {
 
 							result.didHit = true;
 							result.dist = triResult.dist;
@@ -870,9 +877,13 @@ export class BVHComputeData {
 							result.barycoord = triResult.barycoord;
 							result.indices = vec4u( i0, i1, i2, ti );
 
+							didHit = true;
+
 						}
 
 					}
+
+					return didHit;
 
 				}
 			`,

--- a/src/webgpu/lib/nodes/WGSLTagFnNode.js
+++ b/src/webgpu/lib/nodes/WGSLTagFnNode.js
@@ -178,7 +178,7 @@ export class WGSLTagFnNode extends FunctionNode {
 
 	static get type() {
 
-		return 'WGSLFnTagNode';
+		return 'WGSLTagFnNode';
 
 	}
 

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -45,14 +45,14 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 		super.update();
 
 		// build material storage
-		const { materials, structs, prefix: name } = this;
+		const { materials, structs } = this;
 
 		const { materialData, textures } = this.writeMaterialsBuffer( materials );
 
 		this.textures = textures;
 
 		const materialAttribute = new StorageBufferAttribute( materialData, structs.material.getLength() );
-		const materialStorage = storage( materialAttribute, structs.material ).toReadOnly().setName( `${ name }materials` );
+		const materialStorage = storage( materialAttribute, structs.material ).toReadOnly().setName( 'bvh_materials' );
 		this.storage.materials = materialStorage;
 
 		this.bvhMap.clear();

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -324,15 +324,15 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 
 				switch ( m.side ) {
 
-				case FrontSide:
-					floatArray[ index ++ ] = 1;
-					break;
-				case BackSide:
-					floatArray[ index ++ ] = - 1;
-					break;
-				case DoubleSide:
-					floatArray[ index ++ ] = 0;
-					break;
+					case FrontSide:
+						floatArray[ index ++ ] = 1;
+						break;
+					case BackSide:
+						floatArray[ index ++ ] = - 1;
+						break;
+					case DoubleSide:
+						floatArray[ index ++ ] = 0;
+						break;
 
 				}
 


### PR DESCRIPTION
- Fix switch indentation
- Make some 'getShapecastFn' functions optional
- Fix visibility flags not working correctly
- Make the "name" optional
- Add "functionName" and "outputStruct" fields to the return function
- Adjust function signatures
- Make return struct optional

**TODO**
- Adjust shapecast API / semantics
  - "transform" functions to "before / after"

**Future**
  - Taking a TSL Fn may not work. We'll need to wrap the Fn or expand it to run inline.
  - Verify "Fn" functions can be called from "wgslTagFn" nodes or wrap them so they can.
