### PR TITLE
Add support for component from maps

### DIFF
--- a/src/webgpu/RenderTarget2DArray.js
+++ b/src/webgpu/RenderTarget2DArray.js
@@ -7,6 +7,7 @@ import {
 	NoToneMapping,
 	QuadMesh,
 	NoBlending,
+	MeshBasicMaterial,
 } from 'three/webgpu';
 import { RenderToScreenNodeMaterial } from './materials/RenderToScreenMaterial.js';
 
@@ -64,7 +65,7 @@ export class RenderTarget2DArray {
 		this.texture.isArrayTexture = true;
 
 		this.hashes = [];
-		this.quadMesh = new QuadMesh( new RenderToScreenNodeMaterial() );
+		this.quadMesh = new QuadMesh( new MeshBasicMaterial() );
 		this.quadMesh.material.blending = NoBlending;
 
 	}
@@ -115,7 +116,7 @@ export class RenderTarget2DArray {
 				texture.matrixAutoUpdate = false;
 				texture.matrix.identity();
 
-				quadMesh.material.texture = texture;
+				quadMesh.material.map = texture;
 
 				renderer.setRenderTarget( this.renderTarget, i );
 				quadMesh.render( renderer );

--- a/src/webgpu/RenderTarget2DArray.js
+++ b/src/webgpu/RenderTarget2DArray.js
@@ -9,7 +9,6 @@ import {
 	NoBlending,
 	MeshBasicMaterial,
 } from 'three/webgpu';
-import { RenderToScreenNodeMaterial } from './materials/RenderToScreenMaterial.js';
 
 function getTextureHash( texture ) {
 

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -1,4 +1,4 @@
-import { DataTexture, LinearFilter, Vector2, Scene, PerspectiveCamera, Color, NoToneMapping, FloatType, Timer, StorageTexture } from 'three/webgpu';
+import { DataTexture, LinearFilter, Vector2, Scene, PerspectiveCamera, Color, NoToneMapping, FloatType, Timer, StorageTexture, Vector3, Triangle } from 'three/webgpu';
 import { SkinnedMeshBVH, MeshBVH, SAH } from 'three-mesh-bvh';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { RenderToScreenNodeMaterial } from './materials/RenderToScreenMaterial.js';
@@ -133,7 +133,7 @@ export class WebGPUPathTracer {
 		// Build TLAS and compute functions
 		const bvhData = new PathtracerBVHComputeData( scene );
 		bvhData.update();
-		bvhData.useTransparencyRaycastFn();
+		bvhData.useTransparencyRaycastFn( this.textureArray.texture );
 
 		this.textureArray.setTextures( this._renderer, bvhData.textures );
 		this._pathTracer.setTextures( this.textureArray.texture );

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -1,4 +1,4 @@
-import { DataTexture, LinearFilter, Vector2, Scene, PerspectiveCamera, Color, NoToneMapping, FloatType, Timer, StorageTexture, Vector3, Triangle } from 'three/webgpu';
+import { DataTexture, LinearFilter, Vector2, Scene, PerspectiveCamera, Color, NoToneMapping, FloatType, Timer, StorageTexture } from 'three/webgpu';
 import { SkinnedMeshBVH, MeshBVH, SAH } from 'three-mesh-bvh';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { RenderToScreenNodeMaterial } from './materials/RenderToScreenMaterial.js';

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -149,8 +149,9 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 									let b = ${ storage.attributes }[ i1 ].uv.xy;
 									let c = ${ storage.attributes }[ i2 ].uv.xy;
 									let uv = barycoord.x * a + barycoord.y * b + barycoord.z * c;
+									let uvPrime = material.mapTransform * vec3f( uv, 1 );
 
-									opacity *= ${ sampleTexelFunc }( ${ texturesNode }, ${ samplerNode }, uv, material.map, 0 ).a;
+									opacity *= ${ sampleTexelFunc }( ${ texturesNode }, ${ samplerNode }, uvPrime.xy, material.map, 0 ).a;
 
 								}
 
@@ -162,8 +163,9 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 									let b = ${ storage.attributes }[ i1 ].uv.xy;
 									let c = ${ storage.attributes }[ i2 ].uv.xy;
 									let uv = barycoord.x * a + barycoord.y * b + barycoord.z * c;
+									let uvPrime = material.alphaMapTransform * vec3f( uv, 1 );
 
-									opacity *= ${ sampleTexelFunc }( ${ texturesNode }, ${ samplerNode }, uv, material.alphaMap, 0 ).g;
+									opacity *= ${ sampleTexelFunc }( ${ texturesNode }, ${ samplerNode }, uvPrime.xy, material.alphaMap, 0 ).g;
 
 								}
 

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -1,12 +1,13 @@
 import { BackSide, FrontSide, DoubleSide, BufferAttribute, BufferGeometry, StorageBufferAttribute, StructTypeNode, Vector4, SkinnedMesh, StructNode, RepeatWrapping, ClampToEdgeWrapping, MirroredRepeatWrapping, NearestFilter } from 'three/webgpu';
 import { BVHComputeData, intersectionResultStruct, intersectsTriangle } from '../lib/BVHComputeData.js';
-import { storage, float } from 'three/tsl';
+import { storage, float, sampler, texture } from 'three/tsl';
 import { SkinnedMeshBVH, MeshBVH, SAH } from 'three-mesh-bvh';
 import { materialStruct } from './structs.wgsl.js';
 import { getTextureHash } from '../../core/utils/sceneUpdateUtils.js';
 import { bvhNodeBoundsStruct, bvhNodeStruct, rayStruct } from '../lib/wgsl/structs.wgsl.js';
 import { wgslTagFn } from '../lib/nodes/WGSLTagFnNode.js';
 import { pcgRand } from './random.wgsl.js';
+import { sampleTexelFunc } from './utils.wgsl.js';
 
 const _colorVec = new Vector4();
 const transformStruct = new StructTypeNode( {
@@ -44,7 +45,10 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 
 	}
 
-	useTransparencyRaycastFn() {
+	useTransparencyRaycastFn( textures ) {
+
+		const texturesNode = texture( textures );
+		const samplerNode = sampler( textures );
 
 		const { prefix, storage, structs, fns } = this;
 
@@ -135,8 +139,34 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 
 							if ( material.transparent != 0 || material.alphaTest > 0.0 ) {
 
-								// TODO: sample albedo + alphaMap alpha
-								let opacity = ${ baseOpacityScalar };
+								var opacity = ${ baseOpacityScalar };
+
+								// account for alpha component of albedo map
+								if ( material.map != - 1 ) {
+
+									let barycoord = triResult.barycoord;
+									let a = ${ storage.attributes }[ i0 ].uv.xy;
+									let b = ${ storage.attributes }[ i1 ].uv.xy;
+									let c = ${ storage.attributes }[ i2 ].uv.xy;
+									let uv = barycoord.x * a + barycoord.y * b + barycoord.z * c;
+
+									opacity *= ${ sampleTexelFunc }( ${ texturesNode }, ${ samplerNode }, uv, material.map, 0 ).a;
+
+								}
+
+								// account for green component of alpha map
+								if ( material.alphaMap != - 1 ) {
+
+									let barycoord = triResult.barycoord;
+									let a = ${ storage.attributes }[ i0 ].uv.xy;
+									let b = ${ storage.attributes }[ i1 ].uv.xy;
+									let c = ${ storage.attributes }[ i2 ].uv.xy;
+									let uv = barycoord.x * a + barycoord.y * b + barycoord.z * c;
+
+									opacity *= ${ sampleTexelFunc }( ${ texturesNode }, ${ samplerNode }, uv, material.alphaMap, 0 ).g;
+
+								}
+
 								if ( material.transparent != 0 && opacity < ${ pcgRand }() ) {
 
 									continue;


### PR DESCRIPTION
Testing with the "khronos-AlphaBlendModeTest" model:

| Before | After |
|---|---|
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/b37ea231-dce7-4936-8628-d67adda7dd07" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/8f061aac-feb1-41aa-b3f4-997e3b1b041b" /> |

- Sample the alpha contribution during BVH traversal
- Adjust the render target 2d array generation to use a mesh basic material skip any alpha premultiplication

Note the UVs are generated separately since we'll need to account for the use of different UV channels in the future.

cc @theblek