### PR TITLE
WebGPU: viewerTest example improvements

### DIFF
--- a/example/viewerTest.js
+++ b/example/viewerTest.js
@@ -47,6 +47,8 @@ const params = {
 	tiles: tiles,
 	scale: scale,
 
+	samplesPerFrame: 1,
+
 	model: '',
 	checkerboardTransparency: true,
 	displayImage: false,
@@ -210,7 +212,11 @@ function animate() {
 		pathTracer.enablePathTracing = params.enable;
 		pathTracer.pausePathTracing = params.pause || pathTracer.samples > maxSamples && maxSamples !== - 1;
 
-		pathTracer.renderSample();
+		for ( let i = 0; i < params.samplesPerFrame; i ++ ) {
+
+			pathTracer.renderSample();
+
+		}
 
 	} else if ( ( delaySamples > 0 || ! params.enable ) && renderer.initialized !== false ) {
 
@@ -250,7 +256,7 @@ function onHashChange() {
 
 function onParamsChange() {
 
-	if ( pathTracer.tiles.x * pathTracer.tiles.y !== 1.0 ) {
+	if ( pathTracer.tiles !== 1.0 ) {
 
 		delaySamples = 1;
 
@@ -353,6 +359,8 @@ function buildGui() {
 	} );
 	pathTracingFolder.add( params, 'bounces', 1, 20, 1 ).onChange( onParamsChange );
 	pathTracingFolder.add( params, 'transmissiveBounces', 1, 20, 1 ).onChange( onParamsChange );
+
+	pathTracingFolder.add( params, 'samplesPerFrame', 1, 30, 1 );
 
 	const comparisonFolder = gui.addFolder( 'Comparison' );
 	comparisonFolder.add( params, 'displayImage' );

--- a/example/viewerTest.js
+++ b/example/viewerTest.js
@@ -47,7 +47,7 @@ const params = {
 	tiles: tiles,
 	scale: scale,
 
-	samplesPerFrame: 1,
+	iterationsPerFrame: 1,
 
 	model: '',
 	checkerboardTransparency: true,
@@ -212,7 +212,7 @@ function animate() {
 		pathTracer.enablePathTracing = params.enable;
 		pathTracer.pausePathTracing = params.pause || pathTracer.samples > maxSamples && maxSamples !== - 1;
 
-		for ( let i = 0; i < params.samplesPerFrame; i ++ ) {
+		for ( let i = 0; i < params.iterationsPerFrame; i ++ ) {
 
 			pathTracer.renderSample();
 
@@ -360,7 +360,7 @@ function buildGui() {
 	pathTracingFolder.add( params, 'bounces', 1, 20, 1 ).onChange( onParamsChange );
 	pathTracingFolder.add( params, 'transmissiveBounces', 1, 20, 1 ).onChange( onParamsChange );
 
-	pathTracingFolder.add( params, 'samplesPerFrame', 1, 30, 1 );
+	pathTracingFolder.add( params, 'iterationsPerFrame', 1, 30, 1 );
 
 	const comparisonFolder = gui.addFolder( 'Comparison' );
 	comparisonFolder.add( params, 'displayImage' );

--- a/example/viewerTest.js
+++ b/example/viewerTest.js
@@ -128,6 +128,11 @@ async function createRenderer( isWebGPU ) {
 		// path tracer - WebGPU version
 		pathTracer = new WebGPUPathTracer( renderer );
 		pathTracer.useMegakernel( params.useMegakernel );
+		if ( params.useMegakernel ) {
+
+			pathTracer._pathTracer.tiles.set( params.tiles, params.tiles );
+
+		}
 
 	} else {
 
@@ -141,11 +146,13 @@ async function createRenderer( isWebGPU ) {
 		// path tracer
 		pathTracer = new WebGLPathTracer( renderer );
 		pathTracer.filterGlossyFactor = 0.5;
-		pathTracer.tiles.set( params.tiles );
+		pathTracer.tiles.set( params.tiles, params.tiles );
 		pathTracer.setBVHWorker( new ParallelMeshBVHWorker() );
 		pathTracer.multipleImportanceSampling = params.multipleImportanceSampling;
 
 	}
+
+	detailedSampleCount = null;
 
 }
 
@@ -243,7 +250,7 @@ function onHashChange() {
 
 function onParamsChange() {
 
-	if ( pathTracer.tiles !== 1.0 ) {
+	if ( pathTracer.tiles.x * pathTracer.tiles.y !== 1.0 ) {
 
 		delaySamples = 1;
 
@@ -320,6 +327,7 @@ function buildGui() {
 
 		pathTracer.useMegakernel( params.useMegakernel );
 		pathTracer.reset();
+		detailedSampleCount = null;
 
 	} );
 	webgpuOptions.show( params.isWebGPU );
@@ -335,7 +343,12 @@ function buildGui() {
 	} );
 	pathTracingFolder.add( params, 'tiles', 1, 10, 1 ).onChange( v => {
 
-		pathTracer.tiles.set( v, v );
+		const tiles = pathTracer.tiles ?? pathTracer._pathTracer.tiles;
+		if ( tiles ) {
+
+			tiles.set( v, v );
+
+		}
 
 	} );
 	pathTracingFolder.add( params, 'bounces', 1, 20, 1 ).onChange( onParamsChange );

--- a/src/core/WebGLPathTracer.js
+++ b/src/core/WebGLPathTracer.js
@@ -524,4 +524,20 @@ export class WebGLPathTracer {
 
 	}
 
+	getRenderTime() {
+
+		return this._clock.getElapsedTime() * 1e3;
+
+	}
+
+	async getDetailedSampleCount() {
+
+		return {
+			min: this.samples,
+			max: this.samples,
+			avg: this.samples,
+		};
+
+	}
+
 }

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -12,6 +12,7 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 		// options
 		this.tiles = new Vector2( 2, 2 );
 		this.envInfo = new EquirectHdrInfoUniform();
+		this.samples = 0;
 
 		// kernels
 		this.kernel = new PathTracerMegaKernel().setWorkgroupSize( 8, 8, 1 );


### PR DESCRIPTION
@gkjohnson
Made some changes/improvement to viewerTest example to help compare performance between implementations:
- Added samplesPerFrame variable to try computing multiple samples on one requestAnimationFrame. Because of tiling, sample calculation is often pretty fast, so I think there should be an option to calculate multiple samples. It seems like an easy enough detail to leave to the user. Ideally, we would have a way to automatically determine this number to maximize gpu usage. What do you think? Should this be part of the pathtracer API?
- Fixed `tiles` not setting correctly for webgl pathtracer and webgpu/megakernel
- Implemented getRenderTime and getDetailedSampleCount for webgl pathtracer. Detailed sample counts from are difficult to get here as they are not saved or calculated anywhere. I've tried an approach with keeping 1x1 texture with sample count value and increment it after each sample - it turned out to differ only by a couple of frames. This I think is acceptable price for not increasing complexity of existing system. Or should sample counts be calculated precisely here too?