### PR TITLE
WebGPUPathtracer: Fixes rare NaN issues

### DIFF
--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -157,7 +157,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				} else if ( r <= cdf.y ) { // specular
 
 					wh = ${ ggxDirectionFunc }( wo, vec2( alpha ), ${ pcgRand2 }() );
-					wi = - reflect( wo, wh );
+					wi = - normalize( reflect( wo, wh ) );
 
 					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
 					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
@@ -165,7 +165,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				} else if ( r <= cdf.z ) { // clearcoat
 
 					whClearcoat = ${ ggxDirectionFunc }( woClearcoat, vec2( clearcoatAlpha ), ${ pcgRand2 }() );
-					wiClearcoat = - reflect( woClearcoat, whClearcoat );
+					wiClearcoat = - normalize( reflect( woClearcoat, whClearcoat ) );
 
 					wi = normalize( invBasis * clearcoatBasis * wiClearcoat );
 					wh = normalize( invBasis * clearcoatBasis * whClearcoat );

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -312,7 +312,7 @@ export const diffuseBrdfFunc = wgslFn( /* wgsl */ `
 		let fv = schlickFresnel( NdotV, 0.0 );
 
 		let alpha = surf.roughness * surf.roughness;
-		let bias = mix( 0.0, 0.5, alpha) - 1;
+		let bias = mix( 0.0, 0.5, alpha ) - 1;
 		let energyFactor = mix( 1.0, 1.0 / 1.51, alpha );
 
 		let rr = 2.0 * alpha * VdotH * VdotH;


### PR DESCRIPTION
@gkjohnson 

On my machine there were few rare NaN pixels that were appearing over time:
<img width="770" height="770" alt="image" src="https://github.com/user-attachments/assets/d17b939e-f4b1-43f9-826f-39136a683c11" />

This was due to `cos` function in `schlickFresnel` receiving a negative value because `NdotL` was bigger than 1. This is fixed by renormalizing a vector after reflect function. Or maybe we should just clamp the `NdotL` calculation? 