### PR TITLE
Transparent bg update

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "puppeteer": "^24.42.0",
         "rollup": "^2.70.0",
         "simple-git": "^3.10.0",
-        "three": "^0.184.0",
+        "three": "^0.185.0",
         "three-mesh-bvh": "^0.9.9",
         "typescript": "^5.9.2",
         "vite": "^6.2.2",
@@ -3801,9 +3801,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.184.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
-      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "version": "0.185.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.0.tgz",
+      "integrity": "sha512-+yRrcRO2iZa8uzvNNl0d7cL4huhgKgBvVJ0njcTe8xFqZ6DMAFZdCKDP91SEAuj25bNAj7k1QQdf+srZywVK6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6742,9 +6742,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.184.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
-      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "version": "0.185.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.0.tgz",
+      "integrity": "sha512-+yRrcRO2iZa8uzvNNl0d7cL4huhgKgBvVJ0njcTe8xFqZ6DMAFZdCKDP91SEAuj25bNAj7k1QQdf+srZywVK6w==",
       "dev": true
     },
     "three-mesh-bvh": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "puppeteer": "^24.42.0",
     "rollup": "^2.70.0",
     "simple-git": "^3.10.0",
-    "three": "^0.184.0",
+    "three": "^0.185.0",
     "three-mesh-bvh": "^0.9.9",
     "typescript": "^5.9.2",
     "vite": "^6.2.2",

--- a/src/webgpu/lib/BVHComputeData.js
+++ b/src/webgpu/lib/BVHComputeData.js
@@ -11,21 +11,6 @@ import { MeshBVH, SkinnedMeshBVH, GeometryBVH, ObjectBVH, SAH } from 'three-mesh
 // 		- add a callback for writing a property for a geometry to a range
 // TODO: Add support for other geometry types (tris, lines, custom BVHs etc)
 
-// temporary shim so StructTypeNodes can be passed to storage functions until
-// this is fixed in three.js
-Object.defineProperty( StructTypeNode.prototype, 'layout', {
-
-	get() {
-
-		return this;
-
-	}
-
-} );
-StructTypeNode.prototype.isStruct = true;
-
-//
-
 const isVisible = object => {
 
 	let curr = object;

--- a/src/webgpu/lib/nodes/NodeProxy.js
+++ b/src/webgpu/lib/nodes/NodeProxy.js
@@ -1,4 +1,4 @@
-import { Node } from 'three/webgpu';
+import { Node, TSL } from 'three/webgpu';
 
 class ProxyCallNode extends Node {
 
@@ -119,7 +119,6 @@ export const proxyFn = ( ...args ) => {
 
 	const nodeProxy = new NodeProxy( ...args );
 	const fn = ( ...params ) => new ProxyCallNode( nodeProxy, params );
-	fn.functionNode = nodeProxy;
-	return fn;
+	return TSL.nodeProxyConstructor( fn, nodeProxy );
 
 };

--- a/src/webgpu/lib/nodes/WGSLTagFnNode.js
+++ b/src/webgpu/lib/nodes/WGSLTagFnNode.js
@@ -60,16 +60,6 @@ function extractIncludes( args ) {
 
 			}
 
-		} else {
-
-			// WGSLTagCodeNodes should be inlined if found in a template so skip it here
-			if ( ! ( arg instanceof WGSLTagCodeNode ) ) {
-
-				const node = getIncludeNode( arg );
-				if ( node ) includes.push( node );
-
-			}
-
 		}
 
 	}

--- a/src/webgpu/lib/nodes/WGSLTagFnNode.js
+++ b/src/webgpu/lib/nodes/WGSLTagFnNode.js
@@ -70,7 +70,6 @@ function extractIncludes( args ) {
 
 // normalize args so generate can resolve them uniformly with build():
 // - callable wrappers > PropertyRefNode (emits just the function name)
-// - struct callables > StructTypeNode (emits the type name via build)
 function normalizeArgs( args ) {
 
 	return args.map( arg => {

--- a/src/webgpu/lib/nodes/WGSLTagFnNode.js
+++ b/src/webgpu/lib/nodes/WGSLTagFnNode.js
@@ -1,4 +1,4 @@
-import { CodeNode, FunctionNode, Node } from 'three/webgpu';
+import { CodeNode, FunctionNode, Node, TSL } from 'three/webgpu';
 
 // minimal node that outputs a raw WGSL expression verbatim when built
 class LiteralExpression extends Node {
@@ -37,43 +37,11 @@ class PropertyRefNode extends Node {
 
 }
 
-// wraps a FunctionCallNode so that build() returns the inline call expression,
-// bypassing TempNode's variable wrapping
-class InlineCallNode extends Node {
-
-	constructor( node ) {
-
-		super();
-		this.node = node;
-
-	}
-
-	build( builder ) {
-
-		return this.node.generate( builder );
-
-	}
-
-}
-
 // returns the node that should be registered as an include for the given arg
 function getIncludeNode( arg ) {
 
-	if ( typeof arg === 'function' ) {
-
-		if ( arg.functionNode ) return arg.functionNode;
-		if ( arg.isStruct ) return arg.layout;
-		else return null;
-
-	} else if ( arg.isNode ) {
-
-		return new PropertyRefNode( arg );
-
-	} else {
-
-		return null;
-
-	}
+	if ( arg.isNode ) return new PropertyRefNode( arg );
+	return null;
 
 }
 
@@ -113,14 +81,10 @@ function extractIncludes( args ) {
 // normalize args so generate can resolve them uniformly with build():
 // - callable wrappers > PropertyRefNode (emits just the function name)
 // - struct callables > StructTypeNode (emits the type name via build)
-// - FunctionCallNodes > InlineCallNode (emits inline call)
 function normalizeArgs( args ) {
 
 	return args.map( arg => {
 
-		if ( typeof arg === 'function' && arg.functionNode ) return new PropertyRefNode( arg.functionNode );
-		if ( typeof arg === 'function' && arg.isStruct ) return arg.layout;
-		if ( arg && arg.isNode && arg.functionNode ) return new InlineCallNode( arg );
 		if ( arg && arg.isNode ) {
 
 			if ( arg instanceof WGSLTagCodeNode ) {
@@ -337,8 +301,7 @@ const getFn = functionNode => {
 
 	};
 
-	fn.functionNode = functionNode;
-	return fn;
+	return TSL.nodeProxyConstructor( fn, functionNode );
 
 };
 

--- a/src/webgpu/materials/RenderToScreenMaterial.js
+++ b/src/webgpu/materials/RenderToScreenMaterial.js
@@ -139,7 +139,7 @@ export class RenderToScreenNodeMaterial extends MeshBasicNodeMaterial {
 		// NOTE: alpha is being multiplied twice here to accommodate some odd blending in three.js
 		// See mrdoob/three.js#33104. It's possible this should be removed or rethought once fixed.
 		this.transparent = true;
-		this.colorNode = vec4( toneMappingNode.rgb.mul( toneMappingNode.a ), toneMappingNode.a );
+		this.colorNode = vec4( toneMappingNode.rgb, toneMappingNode.a );
 
 		this.setValues( params );
 


### PR DESCRIPTION
cc @theBlek - getting ahead of the next r185 release, this removes some of the hacks we had around background transparency and simplifies some of the template tag nodes, which is a nice side effect of some of the other three.js changes. I'll wait to merge this until r185 is released but transparent backgrounds are looking pretty good, now, with no dark or blown out fringes.

<img width="926" height="453" alt="image" src="https://github.com/user-attachments/assets/c80b7691-c0f3-482a-9425-40a863c3e4eb" />

--

The transparent bg rendering issue in three was fixed in mrdoob/three.js#33104