### PR TITLE
WebGPU: Correctly check for degenerate tangents

### DIFF
--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -45,7 +45,7 @@ export const getSurfaceRecordFunc = wgslFn( /* wgsl */ `
 
 			// some provided tangents can be malformed (0, 0, 0) causing the normal to be degenerate
 			// resulting in NaNs and slow path tracing.
-			if ( length( vertexData.tangent ) > 0.0 ) {
+			if ( length( vertexData.tangent.xyz ) > 0.0 && vertexData.tangent.w != 0.0 ) {
 
 				let tangent = normalize( vertexData.tangent.xyz );
 				let bitangent = normalize( cross( baseNormal, tangent ) * vertexData.tangent.w );
@@ -139,7 +139,7 @@ export const getSurfaceRecordFunc = wgslFn( /* wgsl */ `
 
 			// some provided tangents can be malformed (0, 0, 0) causing the normal to be degenerate
 			// resulting in NaNs and slow path tracing.
-			if ( length( vertexData.tangent ) > 0.0 ) {
+			if ( length( vertexData.tangent.xyz ) > 0.0 && vertexData.tangent.w != 0.0 ) {
 
 				let tangent = normalize( vertexData.tangent.xyz );
 				let bitangent = normalize( cross( baseNormal, tangent ) * vertexData.tangent.w );


### PR DESCRIPTION
Related to #768

After trying a bunch of different fixes for the M2020 path tracer performance and seeing no difference, I finally tracked down that degenerate tangents weren't being caught correctly, likely resulting in NaN calculations during tracing & impacting performance.

This PR adjusts the tangent check to check for a degenerate length of the xyz component and w component separately since w is often set to 1 or -1. In the branch for #768 this raises the wavefront pathtracer framerate from ~7-10fps to ~40-50fps when drawing the M2020 Rover model. There's still more performance to be gained with other strategies but this issue seemed to be overshadowing everything.

What I plan to do next:
- Update the BVHComputeData classes here to align with three-mesh-bvh's latest version
- Consolidate TLAS and BLAS traversal into a single function to increase parallelism
- Try moving variables to different different global / workgroups spaces etc (discussed in #770)
- Continue adding a "cluster"-style BVH to reduce bounding box overlap further

I'll plan to do all of these in individual PRs so it's easier to independently evaluate the changes.
