### PR TITLE
WebGPU: Merge TLAS and BLAS traversal

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -98,6 +98,7 @@ const params = {
 	checkerboardTransparency: true,
 
 	enable: true,
+	useMegakernel: false,
 	bounces: 5,
 	filterGlossyFactor: 0.5,
 	pause: false,
@@ -160,6 +161,7 @@ async function init() {
 	pathTracer.tiles.set( params.tiles, params.tiles );
 	pathTracer.multipleImportanceSampling = params.multipleImportanceSampling;
 	pathTracer.transmissiveBounces = 10;
+	pathTracer.useMegakernel( params.useMegakernel );
 
 	// camera
 	const aspect = window.innerWidth / window.innerHeight;
@@ -370,6 +372,13 @@ function buildGui() {
 	const pathTracingFolder = gui.addFolder( 'Path Tracer' );
 	pathTracingFolder.add( params, 'enable' );
 	pathTracingFolder.add( params, 'pause' );
+	pathTracingFolder.add( params, 'useMegakernel' ).onChange( () => {
+
+		pathTracer.useMegakernel( params.useMegakernel );
+		pathTracer.setScene( scene, activeCamera );
+		pathTracer.reset();
+
+	} );
 	pathTracingFolder.add( params, 'multipleImportanceSampling' ).onChange( onParamsChange );
 	pathTracingFolder.add( params, 'acesToneMapping' ).onChange( v => {
 

--- a/src/webgpu/lib/three-mesh-bvh/shapecastFns/getShapecastFn.js
+++ b/src/webgpu/lib/three-mesh-bvh/shapecastFns/getShapecastFn.js
@@ -4,8 +4,8 @@ import { wgslTagCode, wgslTagFn } from '../nodes/WGSLTagFnNode.js';
 import { BVH_STACK_DEPTH } from '../tsl/constants.js';
 
 /**
- * Builds a pair of WGSL shapecast functions (BLAS + TLAS traversal) for a custom shape
- * type. The returned TLAS function signature is:
+ * Builds a WGSL shapecast function that traverses the TLAS and per-object BLAS in a single
+ * merged stack/loop for a custom shape type. The returned function signature is:
  * `fn name( shape: ShapeStruct[, result: ptr<function, ResultStruct>] ) -> bool`
  *
  * @private
@@ -20,7 +20,7 @@ import { BVH_STACK_DEPTH } from '../tsl/constants.js';
  * @param {Function|null} [options.transformShapeFn] - function node that transforms the shape into object local space.
  * @param {Function|null} [options.transformResultFn] - function node that transforms a hit result back to world space.
  * @param {Function|null} [options.resetShapeFn] - function node called after each BLAS traversal to reset any per-object state set by `transformShapeFn`.
- * @returns {Function} TSL function node for the TLAS traversal.
+ * @returns {Function} TSL function node for the traversal.
  */
 export function getShapecastFn( bvhData, options ) {
 
@@ -49,21 +49,21 @@ export function getShapecastFn( bvhData, options ) {
 	let transformResultSnippet = '';
 	if ( transformResultFn ) {
 
-		transformResultSnippet = wgslTagCode/* wgsl */`${ transformResultFn }( result, i );`;
+		transformResultSnippet = wgslTagCode/* wgsl */`${ transformResultFn }( result, objectIndex );`;
 
 	}
 
 	let transformShapeSnippet = '';
 	if ( transformShapeFn ) {
 
-		transformShapeSnippet = wgslTagCode/* wgsl */`${ transformShapeFn }( &localShape, i );`;
+		transformShapeSnippet = wgslTagCode/* wgsl */`${ transformShapeFn }( &localShape, objectIndex );`;
 
 	}
 
 	let resetShapeSnippet = '';
 	if ( resetShapeFn ) {
 
-		resetShapeSnippet = wgslTagCode/* wgsl */`${ resetShapeFn }( i );`;
+		resetShapeSnippet = wgslTagCode/* wgsl */`${ resetShapeFn }( objectIndex );`;
 
 	}
 
@@ -71,7 +71,7 @@ export function getShapecastFn( bvhData, options ) {
 	if ( boundsOrderFn ) {
 
 		leftToRightSnippet = wgslTagCode/* wgsl */`
-			let leftToRight = ${ boundsOrderFn }( shape, splitAxis, node );
+			let leftToRight = ${ boundsOrderFn }( localShape, splitAxis, node );
 			c1 = select( rightIndex, leftIndex, leftToRight );
 			c2 = select( leftIndex, rightIndex, leftToRight );
 		`;
@@ -81,17 +81,82 @@ export function getShapecastFn( bvhData, options ) {
 	const resultPtrSnippet = resultStruct ? wgslTagCode/* wgsl */`result: ptr<function, ${ resultStruct }>` : '';
 	const resultArg = resultStruct ? 'result' : '';
 
-	const getFnBody = leafSnippet => {
+	// The TLAS and per-object BLAS are traversed with a single shared stack and loop. A thread
+	// inside a BLAS ( using its transformed localShape ) and a thread still in the TLAS run the
+	// same loop body, keeping SIMD lanes converged instead of recursing into a separate BLAS fn.
+	const tlasFn = wgslTagFn/* wgsl */`
+		// fn
+		fn ${ name }( shape: ${ shapeStruct }, ${ resultPtrSnippet } ) -> bool {
 
-		// returns a function with a snippet inserted for the leaf intersection test
-		return wgslTagCode/* wgsl */`
+			var didHit = false;
 
+			var isTLAS = true;
 			var pointer: i32 = 0;
 			var stack: array<u32, ${ BVH_STACK_DEPTH }>;
-			stack[ 0 ] = rootNodeIndex;
+			stack[ 0 ] = 0u;
+
+			var blasDidHit: bool = false;
+			var objectIndex: u32 = 0;
+			var localShape: ${ shapeStruct } = shape;
+
+			// A single TLAS leaf can reference multiple object so these track which object within the
+			// current leaf is being traversed.
+			var tlasReset: i32 = 0;
+			var leafOffset: u32 = 0u;
+			var leafCount: u32 = 0u;
+			var leafCursor: u32 = 0u;
 
 			loop {
 
+				// An object's BLAS has drained back to its TLAS leaf. Finalize the object that was
+				// just traversed and advance to the next object in the leaf, or fall back to the TLAS.
+				if ( ! isTLAS && tlasReset == pointer ) {
+
+					if ( blasDidHit ) {
+
+						blasDidHit = false;
+						didHit = true;
+						${ transformResultSnippet }
+
+					}
+
+					${ resetShapeSnippet }
+
+					// March to the next visible object in the leaf, skipping invisible ones, and push
+					// its BLAS root, or resume the TLAS once the leaf is complete.
+					loop {
+
+						if ( leafCursor >= leafCount ) {
+
+							// resume the TLAS traversal
+							objectIndex = 0;
+							isTLAS = true;
+							localShape = shape;
+							break;
+
+						}
+
+						objectIndex = leafOffset + leafCursor;
+						leafCursor = leafCursor + 1u;
+
+						let transform = ${ transforms }[ objectIndex ];
+						if ( transform.visible != 0u ) {
+
+							pointer = pointer + 1;
+							stack[ pointer ] = transform.nodeOffset;
+
+							// Transform shape into object local space
+							localShape = shape;
+							${ transformShapeSnippet }
+							break;
+
+						}
+
+					}
+
+				}
+
+				// check if we've finished all nodes on the stack (or overrun the stack)
 				if ( pointer < 0 || pointer >= i32( ${ BVH_STACK_DEPTH } ) ) {
 
 					break;
@@ -102,7 +167,8 @@ export function getShapecastFn( bvhData, options ) {
 				let node = ${ nodes }[ nodeIndex ];
 				pointer = pointer - 1;
 
-				if ( ${ intersectsBoundsFn }( shape, node.bounds, ${ resultArg } ) == 0u ) {
+				// skip the node if we don't intersect the bounds
+				if ( ${ intersectsBoundsFn }( localShape, node.bounds, ${ resultArg } ) == 0u ) {
 
 					continue;
 
@@ -116,7 +182,23 @@ export function getShapecastFn( bvhData, options ) {
 
 					let count = infoX & 0x0000ffffu;
 					let offset = infoY;
-					${ leafSnippet }
+
+					if ( isTLAS ) {
+
+						// Record the leaf's object range which we will march through over the
+						// following iterations.
+						leafOffset = offset;
+						leafCount = count;
+						leafCursor = 0u;
+						tlasReset = pointer;
+						isTLAS = false;
+						blasDidHit = false;
+
+					} else {
+
+						blasDidHit = ${ intersectRangeFn }( localShape, offset, count, ${ resultArg } ) || blasDidHit;
+
+					}
 
 				} else {
 
@@ -137,60 +219,6 @@ export function getShapecastFn( bvhData, options ) {
 				}
 
 			}
-
-		`;
-
-	};
-
-	const blasFn = wgslTagFn/* wgsl */`
-		// fn
-		fn ${ name }_blas( shape: ${ shapeStruct }, rootNodeIndex: u32, ${ resultPtrSnippet } ) -> bool {
-
-			var didHit = false;
-			${ getFnBody( wgslTagCode/* wgsl */`
-
-				didHit = ${ intersectRangeFn }( shape, offset, count, ${ resultArg } ) || didHit;
-
-			` ) }
-
-			return didHit;
-
-		}
-	`;
-
-	const tlasFn = wgslTagFn/* wgsl */`
-		// fn
-		fn ${ name }( shape: ${ shapeStruct }, ${ resultPtrSnippet } ) -> bool {
-
-			const rootNodeIndex = 0u;
-			var didHit = false;
-			${ getFnBody( wgslTagCode/* wgsl */`
-
-				for ( var i = offset; i < offset + count; i ++ ) {
-
-					let transform = ${ transforms }[ i ];
-					if ( transform.visible == 0u ) {
-
-						continue;
-
-					}
-
-					// Transform shape into object local space
-					var localShape = shape;
-					${ transformShapeSnippet }
-
-					if ( ${ blasFn }( localShape, transform.nodeOffset, ${ resultArg } ) ) {
-
-						${ transformResultSnippet }
-						didHit = true;
-
-					}
-
-					${ resetShapeSnippet }
-
-				}
-
-			` ) }
 
 			return didHit;
 


### PR DESCRIPTION
Related to #769

This PR adjusts the BVH traversal to merge the TLAS and the BLAS into a single traversal. It's shaped a bit oddly because with the way we pack the BVH it's possible for TLAS leaves to have multiple children - so we have to iterate over all them. With some of the triangle clustering changes I'm looking at this should become more simple but I think it's useful to see the performance impact of some of these individual changes.

With this change my framerate goes from ***~40-50 fps*** to ***~80-85 fps*** when rendering the rover model in #768.

Also updates main example to include a megakernel option.

**Next to try**
- Replace global material copy with a material index uint
- Move traversal stack to private / workgroup space
- Use a ClusteredBVH to reduce bounding box overlap