### PR TITLE
WebGPU: Use global workgroup stack

### DIFF
--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -1,9 +1,9 @@
 import { DataTexture, Matrix3, Matrix4, Vector2, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from './ComputeKernel.js';
-import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
+import { texture, sampler, uniform, globalId, textureStore, localId, vec3 } from 'three/tsl';
 import { rngInit, rngNextBounce, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../nodes/random.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
-import { ndcToCameraRay, proxy, proxyFn, wgslTagFn } from '../lib/three-mesh-bvh/index.js';
+import { ndcToCameraRay, proxy, proxyFn, wgslTagFn, wgslTagCode } from '../lib/three-mesh-bvh/index.js';
 import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
@@ -44,6 +44,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 			// compute variables
 			globalId: globalId,
+			localId: localId,
 		};
 
 		const raycastOutput = proxy( 'bvhData.value.fns.raycastFirstHit.outputType', params );
@@ -51,13 +52,17 @@ export class PathTracerMegaKernel extends ComputeKernel {
 		const sampleTrianglePointFn = proxyFn( 'bvhData.value.fns.sampleTrianglePoint', params );
 		const getSurfaceRecordFn = proxyFn( 'bvhData.value.fns.getSurfaceRecord', params );
 		const bsdfSampleFn = proxyFn( 'material.value.bsdfSample', params );
+		const threadIdVarSnippet = wgslTagCode/* wgsl */`var<private> threadId: u32;`;
 
 		const shader = wgslTagFn/* wgsl */`
+
+			${ [ threadIdVarSnippet ] }
 
 			fn compute(
 
 				// indices and target
 				globalId: vec3u,
+				localId: vec3u,
 
 				// tiles
 				offset: vec2u,
@@ -82,6 +87,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				backgroundBlurriness: f32,
 
 			) -> void {
+
+				threadId = localId.y * 8 + localId.x;
 
 				let transforms = &${ proxy( 'bvhData.value.storage.transforms', params ) };
 				let materials = &${ proxy( 'bvhData.value.storage.materials', params ) };

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -1,6 +1,6 @@
 import { DataTexture, Matrix3, Matrix4, Vector2, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from './ComputeKernel.js';
-import { texture, sampler, uniform, globalId, textureStore, localId, vec3 } from 'three/tsl';
+import { texture, sampler, uniform, globalId, textureStore, localId } from 'three/tsl';
 import { rngInit, rngNextBounce, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../nodes/random.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
 import { ndcToCameraRay, proxy, proxyFn, wgslTagFn, wgslTagCode } from '../lib/three-mesh-bvh/index.js';

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -1,9 +1,9 @@
 import { DataTexture, Matrix3, IndirectStorageBufferAttribute, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from '../ComputeKernel.js';
-import { uniform, texture, sampler, storage, textureStore, globalId } from 'three/tsl';
+import { uniform, texture, sampler, storage, textureStore, globalId, localId, vec3 } from 'three/tsl';
 import { rngInit, rand2, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../../nodes/random.wgsl.js';
 import { queuedRayStruct, queuedHitStruct } from './structs.js';
-import { proxy, wgslTagFn } from '../../lib/three-mesh-bvh/index.js';
+import { proxy, wgslTagFn, wgslTagCode } from '../../lib/three-mesh-bvh/index.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
 
 export class RayIntersectionKernel extends ComputeKernel {
@@ -35,12 +35,16 @@ export class RayIntersectionKernel extends ComputeKernel {
 			backgroundBlurriness: uniform( 0 ),
 
 			globalId: globalId,
+			localId: localId,
 		};
 
 		const raycastOutput = proxy( 'bvhData.value.fns.raycastFirstHit.outputType', params );
 		const raycastFirstHitFn = proxy( 'bvhData.value.fns.raycastFirstHit', params );
+		const threadIdVarSnippet = wgslTagCode/* wgsl */`var<private> threadId: u32;`;
 
 		const fn = wgslTagFn /* wgsl */`
+
+			${ [ threadIdVarSnippet ] }
 
 			fn compute(
 				// environment
@@ -55,8 +59,11 @@ export class RayIntersectionKernel extends ComputeKernel {
 				backgroundIntensity: f32,
 				backgroundBlurriness: f32,
 
-				globalId: vec3u
+				globalId: vec3u,
+				localId: vec3u,
 			) -> void {
+
+				threadId = localId.x;
 
 				let rayQueue = &${ params.rayQueue };
 				let hitQueue = &${ params.hitQueue };

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -1,6 +1,6 @@
 import { DataTexture, Matrix3, IndirectStorageBufferAttribute, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from '../ComputeKernel.js';
-import { uniform, texture, sampler, storage, textureStore, globalId, localId, vec3 } from 'three/tsl';
+import { uniform, texture, sampler, storage, textureStore, globalId, localId } from 'three/tsl';
 import { rngInit, rand2, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../../nodes/random.wgsl.js';
 import { queuedRayStruct, queuedHitStruct } from './structs.js';
 import { proxy, wgslTagFn, wgslTagCode } from '../../lib/three-mesh-bvh/index.js';

--- a/src/webgpu/lib/three-mesh-bvh/shapecastFns/getShapecastFn.js
+++ b/src/webgpu/lib/three-mesh-bvh/shapecastFns/getShapecastFn.js
@@ -80,25 +80,31 @@ export function getShapecastFn( bvhData, options ) {
 
 	const resultPtrSnippet = resultStruct ? wgslTagCode/* wgsl */`result: ptr<function, ${ resultStruct }>` : '';
 	const resultArg = resultStruct ? 'result' : '';
+	const stackSnippet = wgslTagCode/* wgsl */`
+		var<private> pointer: i32 = 0;
+		// var<workgroup> stack: array<u32, 64 * ${ BVH_STACK_DEPTH }>;
+		var<private> stack: array<u32, ${ BVH_STACK_DEPTH }>;
+	`;
 
 	const getFnBody = leafSnippet => {
 
 		// returns a function with a snippet inserted for the leaf intersection test
 		return wgslTagCode/* wgsl */`
 
-			var pointer: i32 = 0;
-			var stack: array<u32, ${ BVH_STACK_DEPTH }>;
-			stack[ 0 ] = rootNodeIndex;
+			var offset = 0; //i32( threadId * ${ BVH_STACK_DEPTH } );
+			var reset = pointer + 1;
+			pointer = pointer + 1;
+			stack[ offset + pointer ] = rootNodeIndex;
 
 			loop {
 
-				if ( pointer < 0 || pointer >= i32( ${ BVH_STACK_DEPTH } ) ) {
+				if ( pointer < reset || pointer >= i32( ${ BVH_STACK_DEPTH } ) ) {
 
 					break;
 
 				}
 
-				let nodeIndex = stack[ pointer ];
+				let nodeIndex = stack[ offset + pointer ];
 				let node = ${ nodes }[ nodeIndex ];
 				pointer = pointer - 1;
 
@@ -129,10 +135,10 @@ export function getShapecastFn( bvhData, options ) {
 					${ leftToRightSnippet }
 
 					pointer = pointer + 1;
-					stack[ pointer ] = c2;
+					stack[ offset + pointer ] = c2;
 
 					pointer = pointer + 1;
-					stack[ pointer ] = c1;
+					stack[ offset + pointer ] = c1;
 
 				}
 
@@ -159,8 +165,12 @@ export function getShapecastFn( bvhData, options ) {
 	`;
 
 	const tlasFn = wgslTagFn/* wgsl */`
+		${ [ stackSnippet ] }
+
 		// fn
 		fn ${ name }( shape: ${ shapeStruct }, ${ resultPtrSnippet } ) -> bool {
+
+			pointer = 0;
 
 			const rootNodeIndex = 0u;
 			var didHit = false;

--- a/src/webgpu/lib/three-mesh-bvh/shapecastFns/getShapecastFn.js
+++ b/src/webgpu/lib/three-mesh-bvh/shapecastFns/getShapecastFn.js
@@ -82,8 +82,8 @@ export function getShapecastFn( bvhData, options ) {
 	const resultArg = resultStruct ? 'result' : '';
 	const stackSnippet = wgslTagCode/* wgsl */`
 		var<private> pointer: i32 = 0;
-		// var<workgroup> stack: array<u32, 64 * ${ BVH_STACK_DEPTH }>;
-		var<private> stack: array<u32, ${ BVH_STACK_DEPTH }>;
+		var<workgroup> stack: array<u32, 64 * ${ BVH_STACK_DEPTH }>;
+		// var<private> stack: array<u32, ${ BVH_STACK_DEPTH }>;
 	`;
 
 	const getFnBody = leafSnippet => {
@@ -91,7 +91,7 @@ export function getShapecastFn( bvhData, options ) {
 		// returns a function with a snippet inserted for the leaf intersection test
 		return wgslTagCode/* wgsl */`
 
-			var offset = 0; //i32( threadId * ${ BVH_STACK_DEPTH } );
+			var offset = i32( threadId * ${ BVH_STACK_DEPTH } );
 			var reset = pointer + 1;
 			pointer = pointer + 1;
 			stack[ offset + pointer ] = rootNodeIndex;


### PR DESCRIPTION
Related to #774, #770

This PR adjusts the node traversal to use a global "workgroup" space buffer as a set of stacks for use across the threads, as suggested in #770. There are technically two changes here: the TLAS and BLAS now share a common stack for traversal, and the stack is packed packed into a workgroup buffer. The stack is still 60 elements deep, accommodating both TLAS and BLAS.

I've also tried just moving the staack to a module level variable (commented out here) and I'm actually seeing that that's _faster_ than the workgroup version. Here is some timing using the rover model on my machine (performance changes based on whether it's plugged in, which is why the baseline may be different from before):

| | baseline | workgroup space | private space |
|---|---|---|---|
| timing | ~53-60 fps | ~40-43 fps | ~55-63 fps |

So I _am_ seeing some improvement but it's only when using a private space variable. And so far it's not clear if it's due to sharing a single stack (eg less memory allocated) or if it's due to moving the stack to a module level variable. It will probably be better to test after #773 is merged. If we adjust the stack depth to 40 I'm seeing that workgroup space and private space start run at a more comparable framerate.

@TheBlek is this lining up with what you're seeing? Or have I missed something in the implementation?