### PR TITLE
WebGPU: Add support for anisotropic materials

### DIFF
--- a/example/viewerTest.js
+++ b/example/viewerTest.js
@@ -26,7 +26,7 @@ const urlParams = new URLSearchParams( window.location.search );
 const maxSamples = parseInt( urlParams.get( 'samples' ) ) || - 1;
 const hideUI = urlParams.get( 'hideUI' ) === 'true';
 const tiles = parseInt( urlParams.get( 'tiles' ) ) || 2;
-const scale = parseInt( urlParams.get( 'scale' ) ) || 1 / window.devicePixelRatio;
+const scale = parseInt( urlParams.get( 'scale' ) ) || 1;
 
 const params = {
 
@@ -286,15 +286,6 @@ function buildGui() {
 
 	} );
 
-	const pathTracingFolder = gui.addFolder( 'Path Tracer' );
-	pathTracingFolder.add( params, 'useMegakernel' ).onChange( () => {
-
-		pathTracer.useMegakernel( params.useMegakernel );
-		pathTracer.reset();
-		detailedSampleCount = null;
-
-	} );
-
 	// build the atlas page dropdown dynamically from the current atlas
 	const atlasOptions = { hide: - 1 };
 	const pageCount = pathTracer.textureAtlas.pageCount;
@@ -311,10 +302,17 @@ function buildGui() {
 
 	}
 
-	pathTracingFolder.add( params, 'showAtlas', atlasOptions );
-
+	const pathTracingFolder = gui.addFolder( 'Path Tracer' );
 	pathTracingFolder.add( params, 'enable' );
 	pathTracingFolder.add( params, 'pause' );
+	pathTracingFolder.add( params, 'useMegakernel' ).onChange( () => {
+
+		pathTracer.useMegakernel( params.useMegakernel );
+		pathTracer.reset();
+		detailedSampleCount = null;
+
+	} );
+	pathTracingFolder.add( params, 'showAtlas', atlasOptions );
 	pathTracingFolder.add( params, 'scale', 0.1, 1 ).onChange( onParamsChange );
 	pathTracingFolder.add( params, 'multipleImportanceSampling' ).onChange( onParamsChange );
 	pathTracingFolder.add( params, 'acesToneMapping' ).onChange( v => {

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -99,7 +99,7 @@ export class WebGPUPathTracer {
 		this._backgroundColorTexture.minFilter = LinearFilter;
 		this._backgroundColorTexture.magFilter = LinearFilter;
 
-		this._resetTime = 0;
+		this._resetTime = - 1;
 		this._fadeState = 0;
 		this._size = new Vector2();
 		this._blitQuad = new FullScreenQuad( new RenderToScreenNodeMaterial() );
@@ -263,7 +263,7 @@ export class WebGPUPathTracer {
 	reset() {
 
 		this._pathTracer.reset();
-		this._resetTime = 0;
+		this._resetTime = - 1;
 		this._fadeState = 0;
 		this._timer.update();
 
@@ -307,7 +307,14 @@ export class WebGPUPathTracer {
 
 		}
 
-		const delta = 1000 * timer.getDelta();
+		let delta = 1000 * timer.getDelta();
+		if ( this._resetTime === - 1 ) {
+
+			this._resetTime = 0;
+			delta = 0.0;
+
+		}
+
 		this._resetTime += delta;
 
 		const originalTarget = renderer.getRenderTarget();

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -90,8 +90,12 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
 				let alpha = vec2( alphaT, alphaB );
 
+				let NdotV = ctx.V.z;
+				let NdotVc = ctx.Vc.z;
+				let NdotL = ctx.L.z;
+
 				let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
-				let diffuse = ${ this.diffuseBrdf }( ctx.V.z, ctx.L.z, ctx.VdotH, surf );
+				let diffuse = ${ this.diffuseBrdf }( NdotV, NdotL, ctx.VdotH, surf );
 				let dielectricBase = ${ this.fresnelMix }( ctx.VdotH, surf.ior, diffuse, specular );
 
 				let dielectric = ${ this.iridescentDielectricLayer }(
@@ -100,7 +104,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				);
 
 				// TODO: this only handles non-anisotropic surfaces
-				let metallicBase = ${ this.conductorFresnel }( ctx.V.z, ctx.VdotH, surf.color, specular, alpha.y );
+				let metallicBase = ${ this.conductorFresnel }( NdotV, ctx.VdotH, surf.color, specular, alpha.y );
 
 				let metallic = ${ this.iridescentConductorLayer }(
 					metallicBase, specular, surf.color, ctx.VdotH, /* outsideIor */ 1.0,
@@ -112,7 +116,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
 				let clearcoat = ${ this.specularBrdf }( ctx.Vc, ctx.Lc, ctx.Hc, vec2( clearcoatAlpha ) );
 
-				let coatedMaterial = ${ this.fresnelCoat }( max( ctx.Vc.z, ${ MIN_INCIDENT_COS } ), ${ CLEARCOAT_IOR }, material, clearcoat, surf.clearcoat );
+				let coatedMaterial = ${ this.fresnelCoat }( max( NdotVc, ${ MIN_INCIDENT_COS } ), ${ CLEARCOAT_IOR }, material, clearcoat, surf.clearcoat );
 
 				return coatedMaterial;
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -85,10 +85,13 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 			fn bsdfEval( ctx: ${ bxdfContextStruct }, surf: ${ surfaceRecordStruct } ) -> vec3f {
 
-				let alpha = surf.roughness * surf.roughness;
+				// anisotropic roughness along tangent, bitangent
+				let alphaB = surf.roughness * surf.roughness;
+				let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+				let alpha = vec2( alphaT, alphaB );
 
-				let specular = ${ this.specularBrdf }( ctx.NdotL, ctx.NdotV, ctx.NdotH, alpha );
-				let diffuse = ${ this.diffuseBrdf }( ctx.NdotV, ctx.NdotL, ctx.VdotH, surf );
+				let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
+				let diffuse = ${ this.diffuseBrdf }( ctx.V.z, ctx.L.z, ctx.VdotH, surf );
 				let dielectricBase = ${ this.fresnelMix }( ctx.VdotH, surf.ior, diffuse, specular );
 
 				let dielectric = ${ this.iridescentDielectricLayer }(
@@ -96,7 +99,8 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					surf.ior, surf.iridescenceIor, surf.iridescenceThickness, surf.iridescence
 				);
 
-				let metallicBase = ${ this.conductorFresnel }( ctx.NdotV, ctx.VdotH, surf.color, specular, alpha );
+				// TODO: this only handles non-anisotropic surfaces
+				let metallicBase = ${ this.conductorFresnel }( ctx.V.z, ctx.VdotH, surf.color, specular, alpha.y );
 
 				let metallic = ${ this.iridescentConductorLayer }(
 					metallicBase, specular, surf.color, ctx.VdotH, /* outsideIor */ 1.0,
@@ -106,9 +110,9 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let material = mix( dielectric, metallic, surf.metalness );
 
 				let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
-				let clearcoat = ${ this.specularBrdf }( ctx.LdotNc, ctx.VdotNc, ctx.HdotNc, clearcoatAlpha );
+				let clearcoat = ${ this.specularBrdf }( ctx.Vc, ctx.Lc, ctx.Hc, vec2( clearcoatAlpha ) );
 
-				let coatedMaterial = ${ this.fresnelCoat }( ctx.VdotNc, ${ CLEARCOAT_IOR }, material, clearcoat, surf.clearcoat );
+				let coatedMaterial = ${ this.fresnelCoat }( max( ctx.Vc.z, ${ MIN_INCIDENT_COS } ), ${ CLEARCOAT_IOR }, material, clearcoat, surf.clearcoat );
 
 				return coatedMaterial;
 
@@ -123,7 +127,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				var result: ${ scatterRecordStruct };
 				result.pdf = 0.0;
 
-				let alpha = surf.roughness * surf.roughness;
+				// anisotropic roughness along tangent, bitangent
+				let alphaB = surf.roughness * surf.roughness;
+				let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+				let alpha = vec2( alphaT, alphaB );
+
 				let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
 
 				let normalBasis = surf.normalBasis;
@@ -171,7 +179,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				} else if ( r <= cdf.y ) { // specular
 
-					wh = ${ ggxDirectionFunc }( wo, vec2( alpha ), directionUV );
+					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
 					wi = - normalize( reflect( wo, wh ) );
 
 					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
@@ -196,14 +204,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				ctx.L = wi;
 				ctx.H = wh;
 
-				ctx.NdotV = max( wo.z, ${ MIN_INCIDENT_COS } );
-				ctx.NdotL = max( wi.z, ${ MIN_INCIDENT_COS } );
-				ctx.NdotH = saturate( wh.z );
 				ctx.VdotH = saturate( dot( wo, wh ) );
 
-				ctx.VdotNc = max( woClearcoat.z, ${ MIN_INCIDENT_COS } );
-				ctx.LdotNc = max( wiClearcoat.z, ${ MIN_INCIDENT_COS } );
-				ctx.HdotNc = saturate( whClearcoat.z );
+				ctx.Vc = woClearcoat;
+				ctx.Lc = wiClearcoat;
+				ctx.Hc = whClearcoat;
 
 				if ( weights.diffuse > 0.0 ) {
 
@@ -213,13 +218,13 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				if ( weights.specular > 0.0 && wi.z > 0.0 ) {
 
-					result.pdf += weights.specular * ${ ggxReflectionAdjustedPDFFunc }( ctx.NdotV, ctx.NdotH, alpha );
+					result.pdf += weights.specular * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
 
 				}
 
 				if ( weights.clearcoat > 0.0 && wiClearcoat.z > 0.0 ) {
 
-					result.pdf += weights.clearcoat * ${ ggxReflectionAdjustedPDFFunc }( ctx.VdotNc, ctx.HdotNc, clearcoatAlpha );
+					result.pdf += weights.clearcoat * ${ ggxReflectionAdjustedPDFFunc }( woClearcoat, whClearcoat, vec2( clearcoatAlpha ) );
 
 				}
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -192,6 +192,10 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				}
 
 				var ctx: ${ bxdfContextStruct };
+				ctx.V = wo;
+				ctx.L = wi;
+				ctx.H = wh;
+
 				ctx.NdotV = max( wo.z, ${ MIN_INCIDENT_COS } );
 				ctx.NdotL = max( wi.z, ${ MIN_INCIDENT_COS } );
 				ctx.NdotH = saturate( wh.z );

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -605,57 +605,64 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 			intArray[ index ++ ] = Number( m.transparent );
 			intArray[ index ++ ] = 0;
 
-			// anisotropy, anisotropyRotation
+			// anisotropy, anisotropyRotation, anisotropyMap - offset 66
 			floatArray[ index ++ ] = getField( m, 'anisotropy', 0.0 );
 			floatArray[ index ++ ] = getField( m, 'anisotropyRotation', 0.0 );
+			intArray[ index ++ ] = getTexture( m, 'anisotropyMap' );
+			index ++; // padding for mat3 alignment
+			index ++;
+			index ++;
 
-			// map transform - offset 68
+			// map transform - offset 72
 			index += writeTextureMatrixToArray( m, 'map', floatArray, index );
 
-			// metalnessMap transform - offset 80
+			// metalnessMap transform - offset 84
 			index += writeTextureMatrixToArray( m, 'metalnessMap', floatArray, index );
 
-			// roughnessMap transform - offset 92
+			// roughnessMap transform - offset 96
 			index += writeTextureMatrixToArray( m, 'roughnessMap', floatArray, index );
 
-			// transmissionMap transform - offset 104
+			// transmissionMap transform - offset 108
 			index += writeTextureMatrixToArray( m, 'transmissionMap', floatArray, index );
 
-			// emissiveMap transform - offset 116
+			// emissiveMap transform - offset 120
 			index += writeTextureMatrixToArray( m, 'emissiveMap', floatArray, index );
 
-			// normalMap transform - offset 128
+			// normalMap transform - offset 132
 			index += writeTextureMatrixToArray( m, 'normalMap', floatArray, index );
 
-			// clearcoatMap transform - offset 140
+			// clearcoatMap transform - offset 144
 			index += writeTextureMatrixToArray( m, 'clearcoatMap', floatArray, index );
 
-			// clearcoatNormalMap transform - offset 152
+			// clearcoatNormalMap transform - offset 156
 			index += writeTextureMatrixToArray( m, 'clearcoatNormalMap', floatArray, index );
 
-			// clearcoatRoughnessMap transform - offset 164
+			// clearcoatRoughnessMap transform - offset 168
 			index += writeTextureMatrixToArray( m, 'clearcoatRoughnessMap', floatArray, index );
 
-			// sheenColorMap transform - offset 176
+			// sheenColorMap transform - offset 180
 			index += writeTextureMatrixToArray( m, 'sheenColorMap', floatArray, index );
 
-			// sheenRoughnessMap transform - offset 188
+			// sheenRoughnessMap transform - offset 192
 			index += writeTextureMatrixToArray( m, 'sheenRoughnessMap', floatArray, index );
 
-			// iridescenceMap transform - offset 200
+			// iridescenceMap transform - offset 204
 			index += writeTextureMatrixToArray( m, 'iridescenceMap', floatArray, index );
 
-			// iridescenceThicknessMap transform - offset 212
+			// iridescenceThicknessMap transform - offset 216
 			index += writeTextureMatrixToArray( m, 'iridescenceThicknessMap', floatArray, index );
 
-			// specularColorMap transform - offset 224
+			// specularColorMap transform - offset 228
 			index += writeTextureMatrixToArray( m, 'specularColorMap', floatArray, index );
 
-			// specularIntensityMap transform - offset 236
+			// specularIntensityMap transform - offset 240
 			index += writeTextureMatrixToArray( m, 'specularIntensityMap', floatArray, index );
 
-			// alphaMap transform - offset 248
+			// alphaMap transform - offset 252
 			index += writeTextureMatrixToArray( m, 'alphaMap', floatArray, index );
+
+			// anisotropyMap transform - offset 264
+			index += writeTextureMatrixToArray( m, 'anisotropyMap', floatArray, index );
 
 		}
 

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -604,8 +604,10 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 			// transparent, fogVolume - offset 64
 			intArray[ index ++ ] = Number( m.transparent );
 			intArray[ index ++ ] = 0;
-			index ++;
-			index ++;
+
+			// anisotropy, anisotropyRotation
+			floatArray[ index ++ ] = getField( m, 'anisotropy', 0.0 );
+			floatArray[ index ++ ] = getField( m, 'anisotropyRotation', 0.0 );
 
 			// map transform - offset 68
 			index += writeTextureMatrixToArray( m, 'map', floatArray, index );

--- a/src/webgpu/nodes/ggx.wgsl.js
+++ b/src/webgpu/nodes/ggx.wgsl.js
@@ -85,7 +85,8 @@ export const ggxLambdaFunc = wgslFn( /* wgsl */ `
 		let alphaT = alpha.x;
 		let alphaB = alpha.y;
 
-		let cos2 = V.z * V.z;
+		let NdotV = max( V.z, MIN_INCIDENT_COS );
+		let cos2 = NdotV * NdotV;
 		let t = ( alphaT * alphaT * V.x * V.x + alphaB * alphaB * V.y * V.y ) / cos2;
 		let numerator = - 1.0 + sqrt( 1.0 + t );
 		return numerator / 2.0;
@@ -114,8 +115,8 @@ export const ggxSmithVisibilityFunc = wgslFn( /* wgsl */ `
 		let alphaT = alpha.x;
 		let alphaB = alpha.y;
 
-		let NdotV = V.z;
-		let NdotL = L.z;
+		let NdotV = max( V.z, MIN_INCIDENT_COS );
+		let NdotL = max( L.z, MIN_INCIDENT_COS );
 
 		let TdotV = V.x;
 		let TdotL = L.x;
@@ -163,7 +164,7 @@ export const ggxReflectionAdjustedPDFFunc = wgslFn( /* wgsl */ `
 
 	fn ggxReflectionAdjustedPDF( V: vec3f, H: vec3f, alpha: vec2f ) -> f32 {
 
-		let NdotV = V.z;
+		let NdotV = max( V.z, MIN_INCIDENT_COS );
 		let D = ggxDistribution( H, alpha );
 		let G1 = ggxShadowMaskG1( V, alpha );
 

--- a/src/webgpu/nodes/ggx.wgsl.js
+++ b/src/webgpu/nodes/ggx.wgsl.js
@@ -3,7 +3,10 @@ import { constants } from './structs.wgsl.js';
 
 // See sampling.wgsl for vector shorthand explanations
 // The GGX functions provide sampling and distribution information for normals as output so
-// in order to get probability of scatter direction the half vector must be computed and provided.
+// in order to get probability of scatter direction the half vector must be computed and
+// provided. Anisotropic surfaces are represented with a 2-dimensional alpha storing the
+// roughness along the tangent (x) and bitangent (y) in the TBN frame.
+
 // [0] https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf
 // [1] https://hal.archives-ouvertes.fr/hal-01509746/document
 // [2] http://jcgt.org/published/0007/04/01/
@@ -68,13 +71,6 @@ export const ggxDirectionFunc = wgslFn( /* wgsl */ `
 	}
 
 `, [ constants ] );
-
-// PDF and related functions for use in a Monte Carlo path tracer.
-// The GGX terms are anisotropic ( Filament's D / V ); isotropic callers pass the same alpha for
-// both alphaT and alphaB, which reduces these to the isotropic GGX exactly. Direction vectors are
-// in the surface frame ( x = tangent, y = bitangent, z = normal ), so the tangent / bitangent dots
-// are just their .xy components.
-// D / V: https://google.github.io/filament/Filament.md.html#materialsystem/anisotropicmodel/anisotropicspecularbrdf
 
 // Smith masking lambda for a single direction, used to build the G1 term for the pdf
 // See equation (34) from [0] and equation (43) from [7]

--- a/src/webgpu/nodes/ggx.wgsl.js
+++ b/src/webgpu/nodes/ggx.wgsl.js
@@ -9,6 +9,9 @@ import { constants } from './structs.wgsl.js';
 // [2] http://jcgt.org/published/0007/04/01/
 // [4] http://jcgt.org/published/0003/02/03/
 // [5] https://seblagarde.wordpress.com/wp-content/uploads/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
+// [6] https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md
+// [7] https://google.github.io/filament/Filament.md.html#materialsystem/anisotropicmodel/anisotropicspecularbrdf
+
 // trowbridge-reitz === GGX === GTR
 export const ggxDirectionFunc = wgslFn( /* wgsl */ `
 
@@ -21,9 +24,13 @@ export const ggxDirectionFunc = wgslFn( /* wgsl */ `
 		// orthonormal basis
 		var T1: vec3f;
 		if ( V.z < 0.9999 ) {
+
 			T1 = normalize( cross( V, vec3( 0.0, 0.0, 1.0 ) ) );
+
 		} else {
+
 			T1 = vec3( 1.0, 0.0, 0.0 );
+
 		}
 
 		let T2 = cross( T1, V );
@@ -33,14 +40,21 @@ export const ggxDirectionFunc = wgslFn( /* wgsl */ `
 		let r = sqrt( uv.x );
 		var phi: f32;
 		if ( uv.y < a ) {
+
 			phi = uv.y / a * PI;
+
 		} else {
+
 			phi = PI + ( uv.y - a ) / ( 1.0 - a ) * PI;
+
 		}
+
 		let P1 = r * cos( phi );
 		var P2 = r * sin( phi );
 		if ( uv.y >= a ) {
+
 			P2 *= V.z;
+
 		}
 
 		// compute normal
@@ -55,82 +69,103 @@ export const ggxDirectionFunc = wgslFn( /* wgsl */ `
 
 `, [ constants ] );
 
-// Below are PDF and related functions for use in a Monte Carlo path tracer
-// as specified in Appendix B of the following paper
-// See equation (34) from reference [0]
-export const ggxLamdaFunc = wgslFn( /* wgsl */ `
+// PDF and related functions for use in a Monte Carlo path tracer.
+// The GGX terms are anisotropic ( Filament's D / V ); isotropic callers pass the same alpha for
+// both alphaT and alphaB, which reduces these to the isotropic GGX exactly. Direction vectors are
+// in the surface frame ( x = tangent, y = bitangent, z = normal ), so the tangent / bitangent dots
+// are just their .xy components.
+// D / V: https://google.github.io/filament/Filament.md.html#materialsystem/anisotropicmodel/anisotropicspecularbrdf
 
-	fn ggxLamda( theta: f32, alpha: f32 ) -> f32 {
+// Smith masking lambda for a single direction, used to build the G1 term for the pdf
+// See equation (34) from [0] and equation (43) from [7]
+export const ggxLambdaFunc = wgslFn( /* wgsl */ `
 
-		let tanTheta = tan( theta );
-		let tanTheta2 = tanTheta * tanTheta;
-		let alpha2 = alpha * alpha;
+	fn ggxLambda( V: vec3f, alpha: vec2f ) -> f32 {
 
-		let numerator = - 1.0 + sqrt( 1.0 + alpha2 * tanTheta2 );
+		let alphaT = alpha.x;
+		let alphaB = alpha.y;
+
+		let cos2 = V.z * V.z;
+		let t = ( alphaT * alphaT * V.x * V.x + alphaB * alphaB * V.y * V.y ) / cos2;
+		let numerator = - 1.0 + sqrt( 1.0 + t );
 		return numerator / 2.0;
 
 	}
 
 ` );
 
-// Based on equation (34) from reference [0]
+// Based on equation (2) from reference [1]
 export const ggxShadowMaskG1Func = wgslFn( /* wgsl */ `
 
-	fn ggxShadowMaskG1( cosTheta: f32, alpha: f32 ) -> f32 {
+	fn ggxShadowMaskG1( V: vec3f, alpha: vec2f ) -> f32 {
 
-		let a2 = alpha * alpha;
-		let cosTheta2 = cosTheta * cosTheta;
-		let denom = cosTheta + sqrt( cosTheta2 * ( 1 - a2 ) + a2 );
-		return 2.0 * cosTheta / denom;
+		return 1.0 / ( 1.0 + ggxLambda( V, alpha ) );
 
 	}
 
-`, [ ggxLamdaFunc ] );
+`, [ ggxLambdaFunc ] );
 
-// See listing 2 from reference [5]
+// Smith height-correlated visibility term = G / ( 4 * NdotV * NdotL )
+// See (listing 16) in [7] and from [6]
 export const ggxSmithVisibilityFunc = wgslFn( /* wgsl */ `
 
-	fn ggxSmithVisibility( NdotV: f32, NdotL: f32, alpha: f32 ) -> f32 {
+	fn ggxSmithVisibility( V: vec3f, L: vec3f, alpha: vec2f ) -> f32 {
 
-		// Original formulation of G_SmithGGX Correlated
-		// lambda_v = ( -1 + sqrt ( alphaG2 * (1 - NdotL2 ) / NdotL2 + 1)) * 0.5 f;
-		// lambda_l = ( -1 + sqrt ( alphaG2 * (1 - NdotV2 ) / NdotV2 + 1)) * 0.5 f;
-		// G_SmithGGXCorrelated = 1 / (1 + lambda_v + lambda_l );
-		// V_SmithGGXCorrelated = G_SmithGGXCorrelated / (4.0 f * NdotL * NdotV );
+		let alphaT = alpha.x;
+		let alphaB = alpha.y;
 
-		// This is an optimized version
-		let alpha2 = alpha * alpha;
-		// Caution: the "NdotL *" and "NdotV *" are explicitely inversed , this is not a mistake.
-		let Lambda_GGXV = NdotL * sqrt (( - NdotV * alpha2 + NdotV ) * NdotV + alpha2 );
-		let Lambda_GGXL = NdotV * sqrt (( - NdotL * alpha2 + NdotL ) * NdotL + alpha2 );
+		let NdotV = V.z;
+		let NdotL = L.z;
 
-		return 0.5 / ( Lambda_GGXV + Lambda_GGXL );
+		let TdotV = V.x;
+		let TdotL = L.x;
+
+		let BdotV = V.y;
+		let BdotL = L.y;
+
+		let GGXV = NdotL * length( vec3f( alphaT * TdotV, alphaB * BdotV, NdotV ) );
+		let GGXL = NdotV * length( vec3f( alphaT * TdotL, alphaB * BdotL, NdotL ) );
+
+		return 0.5 / ( GGXV + GGXL );
 
 	}
 
-`, [ ggxLamdaFunc ] );
+` );
 
-
-// See listing 2 from reference [5]
+// Trowbridge-Reitz ( GGX ) normal distribution
+// See (listing 15) in [7]
 export const ggxDistributionFunc = wgslFn( /* wgsl */ `
-	fn ggxDistribution( NdotH: f32, alpha: f32 ) -> f32 {
 
-		let a2 = max( alpha * alpha, EPSILON );
-		let denom = NdotH * NdotH * ( a2 - 1 ) + 1;
+	fn ggxDistribution( H: vec3f, alpha: vec2f ) -> f32 {
 
-		return ( a2 / ( PI * denom * denom ) );
+		let alphaT = alpha.x;
+		let alphaB = alpha.y;
+
+		let NdotH = H.z;
+		let TdotH = H.x;
+		let BdotH = H.y;
+
+		let a2 = alphaT * alphaB;
+		let v = vec3f( alphaB * TdotH, alphaT * BdotH, a2 * NdotH );
+		let v2 = dot( v, v );
+		let w2 = a2 / v2;
+
+		return a2 * w2 * w2 / PI;
 
 	}
-`, );
+
+` );
 
 // ggxPDF, divided by the Jacobian of reflection operation
-// See equation (17) from [2]
+// PDF: See equation (17) from reference [2]
 // Note: HdotV cancel out bc its guaranteed to be > 0
 export const ggxReflectionAdjustedPDFFunc = wgslFn( /* wgsl */ `
-	fn ggxReflectionAdjustedPDF( NdotV: f32, NdotH: f32, alpha: f32 ) -> f32 {
 
-		let D = ggxDistribution( NdotH, alpha );
-		let G1 = ggxShadowMaskG1( NdotV, alpha );
+	fn ggxReflectionAdjustedPDF( V: vec3f, H: vec3f, alpha: vec2f ) -> f32 {
+
+		let NdotV = V.z;
+		let D = ggxDistribution( H, alpha );
+		let G1 = ggxShadowMaskG1( V, alpha );
 
 		return D * G1 / ( 4 * NdotV );
 

--- a/src/webgpu/nodes/ggx.wgsl.js
+++ b/src/webgpu/nodes/ggx.wgsl.js
@@ -96,6 +96,7 @@ export const ggxShadowMaskG1Func = wgslFn( /* wgsl */ `
 
 	fn ggxShadowMaskG1( V: vec3f, alpha: vec2f ) -> f32 {
 
+		// TODO: this could be collapsed to a simpler form as an optimization
 		return 1.0 / ( 1.0 + ggxLambda( V, alpha ) );
 
 	}

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -45,6 +45,8 @@ export const getSurfaceRecordFunc = sampleTexel => wgslFn( /* wgsl */ `
 			// resulting in NaNs and slow path tracing.
 			if ( length( vertexData.tangent.xyz ) > 0.0 && vertexData.tangent.w != 0.0 ) {
 
+				// TODO: consider re-orthonormalizing against the normal here since attribute
+				// interpolation could result in drift.
 				let tangent = normalize( vertexData.tangent.xyz );
 				let bitangent = normalize( cross( baseNormal, tangent ) * vertexData.tangent.w );
 				let vTBN = mat3x3f( tangent, bitangent, baseNormal );
@@ -139,6 +141,8 @@ export const getSurfaceRecordFunc = sampleTexel => wgslFn( /* wgsl */ `
 			// resulting in NaNs and slow path tracing.
 			if ( length( vertexData.tangent.xyz ) > 0.0 && vertexData.tangent.w != 0.0 ) {
 
+				// TODO: consider re-orthonormalizing against the normal here since attribute
+				// interpolation could result in drift.
 				let tangent = normalize( vertexData.tangent.xyz );
 				let bitangent = normalize( cross( baseNormal, tangent ) * vertexData.tangent.w );
 				let vTBN = mat3x3f( tangent, bitangent, baseNormal );
@@ -213,6 +217,48 @@ export const getSurfaceRecordFunc = sampleTexel => wgslFn( /* wgsl */ `
 
 		}
 
+		// extract the anisotropy magnitude vector in tangent space
+		var anisotropyDirVec = material.anisotropy * vec2f( cos( material.anisotropyRotation ), sin( material.anisotropyRotation ) );
+		if ( material.anisotropyMap != -1 ) {
+
+			let uvPrime = material.anisotropyMapTransform * vec3f( uv, 1.0 );
+			let aniTex = sampleTexel( uvPrime.xy, material.anisotropyMap, 0 );
+
+			// map rg encode the direction ([-1,1]), b the strength; rotate + scale by the material anisotropy.
+			let mapDir = aniTex.rg * 2.0 - vec2f( 1.0 );
+			let mapStr = aniTex.b;
+			let mapLen = length( mapDir );
+			if ( mapLen > EPSILON ) {
+
+				anisotropyDirVec = mat2x2f(
+					anisotropyDirVec.x, anisotropyDirVec.y,
+					- anisotropyDirVec.y, anisotropyDirVec.x
+				) * mapStr * mapDir / mapLen;
+
+			}
+
+		}
+
+		// adjust the surface basis to be oriented along the anisotropic vector
+		let anisotropyStrength = length( anisotropyDirVec );
+		var surfaceBasis = getBasisFromNormal( normal );
+		if ( anisotropyStrength > 0.0 && length( vertexData.tangent.xyz ) > 0.0 && vertexData.tangent.w != 0.0 ) {
+
+			let anisotropyDir = anisotropyDirVec / anisotropyStrength;
+
+			// re-orthonormalize the tangent against the shading normal so the frame stays orthonormal -
+			// normal map adjustments will cause the normal and tangent to become non-orthonormal.
+			let tangent = normalize( vertexData.tangent.xyz - normal * dot( normal, vertexData.tangent.xyz ) );
+			let bitangent = cross( normal, tangent ) * vertexData.tangent.w;
+
+			surfaceBasis = mat3x3f(
+				tangent * anisotropyDir.x + bitangent * anisotropyDir.y,
+				bitangent * anisotropyDir.x - tangent * anisotropyDir.y,
+				normal
+			);
+
+		}
+
 		var surf: SurfaceRecord;
 
 		surf.volumeParticle = false;
@@ -242,19 +288,24 @@ export const getSurfaceRecordFunc = sampleTexel => wgslFn( /* wgsl */ `
 		surf.roughness = clamp( roughness, MIN_ROUGHNESS, 1.0 );
 		surf.clearcoatRoughness = clamp( clearcoatRoughness, MIN_ROUGHNESS, 1.0 );
 		surf.sheenRoughness = clamp( sheenRoughness, MIN_ROUGHNESS, 1.0 );
+		surf.anisotropy = saturate( anisotropyStrength );
 
 		// frontFace is used to determine transmissive properties and PDF. If no transmission is used
 		// then we can just always assume this is a front face.
 		surf.frontFace = side == 1.0 || transmission == 0.0;
 		if ( material.thinFilm == 1 || surf.frontFace ) {
+
 			surf.eta = 1.0 / material.ior;
+
 		} else {
+
 			surf.eta = material.ior;
+
 		}
 		surf.f0 = iorToF0( surf.eta );
 
 		// get the normal frames
-		surf.normalBasis = getBasisFromNormal( surf.normal );
+		surf.normalBasis = surfaceBasis;
 		surf.normalInvBasis = inverse( surf.normalBasis );
 
 		surf.clearcoatBasis = getBasisFromNormal( surf.clearcoatNormal );
@@ -312,10 +363,13 @@ export const diffuseBrdfFunc = wgslFn( /* wgsl */ `
 
 export const specularBrdfFunc = wgslFn( /* wgsl */ `
 
-	fn specularBrdf( NdotL: f32, NdotV: f32, NdotH: f32, alpha: f32 ) -> vec3f {
+	fn specularBrdf( V: vec3f, L: vec3f, H: vec3f, alpha: vec2f ) -> vec3f {
 
-		let Vis = ggxSmithVisibility( NdotV, NdotL, alpha );
-		let D = ggxDistribution( NdotH, alpha );
+		let alphaT = alpha.x;
+		let alphaB = alpha.y;
+
+		let Vis = ggxSmithVisibility( V, L, alpha );
+		let D = ggxDistribution( H, alpha );
 
 		return vec3f( D * Vis );
 
@@ -529,12 +583,10 @@ export const albedoIntegralMetallic = wgslTagFn/* wgsl */ `
 			let wh = ${ ggxDirectionFunc }( wo, vec2( alpha ), ${ rand2 }(${ RNG_INDEX_SCATTER_DIRECTION }) );
 			var wi = - reflect( wo, wh );
 
-			let NdotV = max( wo.z, EPSILON );
-			let NdotL = saturate( wi.z );
-			let NdotH = saturate( wh.z );
+			let NdotL = wi.z;
 
-			let specular = ${ specularBrdfFunc }( NdotL, NdotV, NdotH, alpha );
-			let pdf = ${ ggxReflectionAdjustedPDFFunc }( NdotV, NdotH, alpha );
+			let specular = ${ specularBrdfFunc }( wo, wi, wh, vec2f( alpha ) );
+			let pdf = ${ ggxReflectionAdjustedPDFFunc }( wo, wh, vec2f( alpha ) );
 
 			var weight = 0.0;
 			if ( pdf != 0.0 ) {

--- a/src/webgpu/nodes/structs.wgsl.js
+++ b/src/webgpu/nodes/structs.wgsl.js
@@ -221,13 +221,10 @@ export const bxdfContextStruct = new StructTypeNode( {
 	L: 'vec3f', // light dir
 	H: 'vec3f', // half dir
 
-	NdotV: 'float',
-	NdotL: 'float',
-	NdotH: 'float',
-	VdotH: 'float',
+	Vc: 'vec3f', // clearcoat view dir
+	Lc: 'vec3f', // clearcoat light dir
+	Hc: 'vec3f', // clearcoat half dir
 
-	VdotNc: 'float',
-	LdotNc: 'float',
-	HdotNc: 'float',
+	VdotH: 'float',
 
 }, 'BxDFContext' );

--- a/src/webgpu/nodes/structs.wgsl.js
+++ b/src/webgpu/nodes/structs.wgsl.js
@@ -7,6 +7,7 @@ export const constants = wgsl( /* wgsl */ `
 	const PI: f32 = 3.141592653589793;
 	const EPSILON: f32 = 1e-5;
 	const MIN_ROUGHNESS: f32 = 1e-3;
+	const MIN_INCIDENT_COS: f32 = 1e-3;
 
 ` );
 
@@ -109,40 +110,45 @@ export const materialStruct = new StructTypeNode( {
 	// offset 66 floats
 	anisotropy: 'float',
 	anisotropyRotation: 'float',
-
 	// offset 68 floats
+	anisotropyMap: 'int',
+
+	// offset 72 floats
 	mapTransform: 'mat3',
-	// offset 80 floats
+	// offset 84 floats
 	metalnessMapTransform: 'mat3',
-	// offset 92 floats
+	// offset 96 floats
 	roughnessMapTransform: 'mat3',
-	// offset 104 floats
+	// offset 108 floats
 	transmissionMapTransform: 'mat3',
-	// offset 116 floats
+	// offset 120 floats
 	emissiveMapTransform: 'mat3',
-	// offset 128 floats
+	// offset 132 floats
 	normalMapTransform: 'mat3',
-	// offset 140 floats
+	// offset 144 floats
 	clearcoatMapTransform: 'mat3',
-	// offset 152 floats
+	// offset 156 floats
 	clearcoatNormalMapTransform: 'mat3',
-	// offset 164 floats
+	// offset 168 floats
 	clearcoatRoughnessMapTransform: 'mat3',
-	// offset 176 floats
+	// offset 180 floats
 	sheenColorMapTransform: 'mat3',
-	// offset 188 floats
+	// offset 192 floats
 	sheenRoughnessMapTransform: 'mat3',
-	// offset 200 floats
+	// offset 204 floats
 	iridescenceMapTransform: 'mat3',
-	// offset 212 floats
+	// offset 216 floats
 	iridescenceThicknessMapTransform: 'mat3',
-	// offset 224 floats
+	// offset 228 floats
 	specularColorMapTransform: 'mat3',
-	// offset 236 floats
+	// offset 240 floats
 	specularIntensityMapTransform: 'mat3',
-	// offset 248 floats
+	// offset 252 floats
 	alphaMapTransform: 'mat3',
-	// total size = 260
+
+	// offset 264 floats
+	anisotropyMapTransform: 'mat3',
+	// total size = 276
 }, 'Material' );
 
 export const surfaceRecordStruct = new StructTypeNode( {

--- a/src/webgpu/nodes/structs.wgsl.js
+++ b/src/webgpu/nodes/structs.wgsl.js
@@ -106,6 +106,9 @@ export const materialStruct = new StructTypeNode( {
 	// offset 64 floats
 	transparent: 'int',
 	fogVolume: 'int',
+	// offset 66 floats
+	anisotropy: 'float',
+	anisotropyRotation: 'float',
 
 	// offset 68 floats
 	mapTransform: 'mat3',
@@ -160,6 +163,7 @@ export const surfaceRecordStruct = new StructTypeNode( {
 	// material
 	roughness: 'f32',
 	metalness: 'f32',
+	anisotropy: 'f32',
 	color: 'vec3f',
 	emission: 'vec3f',
 

--- a/src/webgpu/nodes/structs.wgsl.js
+++ b/src/webgpu/nodes/structs.wgsl.js
@@ -210,6 +210,11 @@ export const lobeWeightsStruct = new StructTypeNode( {
 }, 'LobeWeights' );
 
 export const bxdfContextStruct = new StructTypeNode( {
+
+	V: 'vec3f', // view dir
+	L: 'vec3f', // light dir
+	H: 'vec3f', // half dir
+
 	NdotV: 'float',
 	NdotL: 'float',
 	NdotH: 'float',


### PR DESCRIPTION
- Adds support for anisotropic settings from MeshPhysicalMaterial based on the glTF model.
- Adjusts the BXDFContext to store "H", "L", and "V" directly instead of individual dot products. Guards are now apply in-place, instead.
- Adjust the viewer test page to default to 1-to-1 pixel scale by default
- Fix WebGPUPathTracer displaying stale content when disabling and enabling it
- Tried to update some of the comments and references in the ggx file

| before | after | three.js |
|---|---|---|
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/87f5b84f-b703-436f-b781-2a274145a420" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/69c03854-2855-4ea9-a923-dae2f988fcaa" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/ee3e67da-1b95-43c8-9c81-6313c3309021" /> |