### PR TITLE
WebGPU: Remove need for color attribute, support vertex color alpha

### DIFF
--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -118,7 +118,7 @@ export class WebGPUPathTracer {
 		this.renderScale = 1;
 		this.synchronizeRenderSize = true;
 		this.generateMissingAttributes = true;
-		this.commonAttributes = [ 'normal', 'tangent', 'color' ];
+		this.commonAttributes = [ 'normal', 'tangent' ];
 		this.stableNoise = false;
 		this.pause = false;
 

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -49,7 +49,7 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 	updateUvAttributesFromScene() {
 
 		const { attributes, bvh } = this;
-		const keys = new Set();
+		const keys = new Set( [ 'color' ] );
 		for ( let i = 0; i < 8; i ++ ) {
 
 			const key = i === 0 ? 'uv' : 'uv' + i;
@@ -133,6 +133,36 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 
 	}
 
+	updateColorSampleFn() {
+
+		// create a function for retrieving the color from the vertex data instance. If the struct does not include
+		// color then return white.
+		const { structs, fns } = this;
+		const hasColor = Boolean( structs.attributes.membersLayout.find( ( { name } ) => name === 'color' ) );
+		if ( hasColor ) {
+
+			fns.getColor = wgslTagFn/* wgsl */`
+				fn getColor( vertexData: ${ structs.attributes } ) -> vec4f {
+
+					return vertexData.color;
+
+				}
+			`;
+
+		} else {
+
+			fns.getColor = wgslTagFn/* wgsl */`
+				fn getColor( vertexData: ${ structs.attributes } ) -> vec4f {
+
+					return vec4f( 1.0 );
+
+				}
+			`;
+
+		}
+
+	}
+
 	useTransparencyRaycastFn() {
 
 		const { textureAtlas, storage, structs, fns } = this;
@@ -144,7 +174,7 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 
 		// getSurfaceRecord shares the same sampleTexel, so the surface shading and
 		// the transparency raycast resolve to one textureInfo binding per pipeline
-		fns.getSurfaceRecord = getSurfaceRecordFunc( sampleTexel, fns.getUvFromChannel );
+		fns.getSurfaceRecord = getSurfaceRecordFunc( sampleTexel, fns.getUvFromChannel, fns.getColor );
 
 		// raycast first hit
 		const currentMaterial = new StructNode( structs.material ).toVar( 'bvh_material' );
@@ -234,6 +264,19 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 							if ( material.transparent != 0 || material.alphaTest > 0.0 ) {
 
 								var opacity = ${ baseOpacityScalar };
+
+								// add support for vertex color opacity
+								if ( material.vertexColors == 1 ) {
+
+									let barycoord = triResult.barycoord;
+									let a = ${ fns.getColor }( ${ storage.attributes }[ i0 ] );
+									let b = ${ fns.getColor }( ${ storage.attributes }[ i1 ] );
+									let c = ${ fns.getColor }( ${ storage.attributes }[ i2 ] );
+									let col = barycoord.x * a + barycoord.y * b + barycoord.z * c;
+
+									opacity *= col.a;
+
+								}
 
 								// account for alpha component of albedo map
 								if ( material.map != - 1 ) {
@@ -347,6 +390,7 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 
 		// build the channel -> uv lookup now that the geometry struct (and its uv members) exist
 		this.updateUvSampleFunction();
+		this.updateColorSampleFn();
 
 		// build material storage
 		const { materials, structs } = this;

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -20,7 +20,7 @@ import { rngInit, rand2, RNG_INDEX_SCATTER_DIRECTION } from './random.wgsl.js';
 import { wgslTagFn } from '../lib/three-mesh-bvh/index.js';
 
 // Builds getSurfaceRecord using the given per-instance sampleTexel and uv channel lookup
-export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel ) => wgslFn( /* wgsl */ `
+export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) => wgslFn( /* wgsl */ `
 
 	fn getSurfaceRecord(
 		material: Material,
@@ -64,7 +64,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel ) => wgslFn(
 
 		if ( material.vertexColors == 1 ) {
 
-			let vertexColor = vertexData.color.xyz;
+			let vertexColor = getColor( vertexData ).xyz;
 			albedo *= vec4f( vertexColor, 1.0 );
 
 		}
@@ -268,6 +268,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel ) => wgslFn(
 	getBasisFromNormalFunc,
 	sampleTexel,
 	getUvFromChannel,
+	getColor,
 	surfaceRecordStruct,
 	constants,
 ] );


### PR DESCRIPTION
The color attribute is stripped from the uploaded data if possible, saving 4x 32bit floats per vertex of memory when vertex colors are not used. Also adds support for vertex color alpha