### PR TITLE
Sample UI: Throttle sampling UI updates

### DIFF
--- a/example/utils/LoaderElement.js
+++ b/example/utils/LoaderElement.js
@@ -104,6 +104,11 @@ export class LoaderElement {
 		this._credits = creditsEl;
 		this._samples = samplesEl;
 		this._container = container;
+		this._lastSampleUpdateTime = - Infinity;
+
+		// Keep path tracing independent from DOM updates. This can be tuned by hosts
+		// that need a more or less responsive progress display.
+		this.sampleUpdateInterval = 100;
 
 		this.setPercentage( 0 );
 
@@ -144,6 +149,15 @@ export class LoaderElement {
 
 	setSamples( count, detailedSamples = null ) {
 
+		const now = performance.now();
+
+		// Rendering can run every animation frame, but updating text at that rate
+		if ( now - this._lastSampleUpdateTime < this.sampleUpdateInterval ) {
+
+			return;
+
+		}
+
 		if ( detailedSamples !== null ) {
 
 			const {
@@ -167,6 +181,8 @@ export class LoaderElement {
 			this._samples.innerText = `~${ Math.floor( count ) } samples`;
 
 		}
+
+		this._lastSampleUpdateTime = now;
 
 	}
 


### PR DESCRIPTION
This PR introduces a throttling mechanism for the HTML sampling UI updates and makes the throttle interval fully configurable (defaulting to `100ms`).

Currently, updating the DOM on every single frame can cause unnecessary CPU overhead and potential layout thrashing, especially during high-frame-rate rendering or on low-end devices. 

By throttling these UI updates, we can significantly reduce DOM manipulation frequency without compromising the user experience. This aligns with standard industry practices; for instance, Blender employs a similar throttled/interval-based approach for updating its viewport sample counters.

I'm not sure if you consider this completely necessary...