### PR TITLE
WebGPU: Fix lost energy and rays due to shading normal and geometry normal mismatch

### DIFF
--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -132,15 +132,16 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						material.color *= object.color.rgb;
 						material.opacity *= object.color.a;
 
+						let view = - ray.direction;
 						var vertexData = ${ sampleTrianglePointFn }( hitResult.barycoord, hitResult.indices.xyz );
 						vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 						vertexData.position = object.matrixWorld * vertexData.position;
 
-						let surface = ${ getSurfaceRecordFn }( material, vertexData, hitResult.side, hitResult.normal );
+						let surface = ${ getSurfaceRecordFn }( material, vertexData, hitResult.side, hitResult.normal, view );
 
 						resultColor += vec4f( throughputColor * surface.emission, 0.0 );
 
-						let scatterRec = ${ bsdfSampleFn }( - ray.direction, surface );
+						let scatterRec = ${ bsdfSampleFn }( view, surface );
 
 						if ( ${ isTerminatingScatterFunc }( scatterRec ) ) {
 

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -82,7 +82,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 				vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 				vertexData.position = object.matrixWorld * vertexData.position;
 
-				let surface = ${ getSurfaceRecordFn }( material, vertexData, input.side, input.normal );
+				let surface = ${ getSurfaceRecordFn }( material, vertexData, input.side, input.normal, input.view );
 
 				let scatterRec = ${ bsdfSampleFn }( input.view, surface );
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -225,7 +225,8 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				result.direction = normalize( normalBasis * wi );
 
 				// TODO: This will need to be removed or changed to support transmission
-				// Flip the reflected vector if it was scattered below the geometry normal
+				// Flip the reflected vector if it was scattered below the geometry normal with glossy
+				// reflections
 				let geomDotDir = dot( result.direction, surf.faceNormal );
 				if ( geomDotDir < 0.0 ) {
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -153,7 +153,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				// Also, this will be an invalid condition when transmission is implemented
 				if ( wo.z < 0.0 || woClearcoat.z < 0.0 ) {
 
-					return result;
+					// return result;
 
 				}
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -145,18 +145,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				let wo = normalize( invBasis * worldWo );
 				let woClearcoat = normalize( invClearcoatBasis * worldWo );
-
-				// TODO: handle such intersections better;
-				// Sometimes .z < 0.0 on a pretty round surface e.g. sphere
-				// Disabling this condition leads to more fireflies on ClearCoatCarPaint example
-				// This could also be fixed by offsetting rays by 1e-1
-				// Also, this will be an invalid condition when transmission is implemented
-				if ( wo.z < 0.0 || woClearcoat.z < 0.0 ) {
-
-					// return result;
-
-				}
-
 				let weights = ${ getLobeWeightsFunc }( wo, woClearcoat, vec3( 0, 0, 1 ), ${ CLEARCOAT_IOR }, surf );
 
 				var cdf: vec4f;

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -241,7 +241,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let geomDotDir = dot( result.direction, surf.faceNormal );
 				if ( geomDotDir < 0.0 ) {
 
-					result.direction = normalize( result.direction - 2.0 * NgDotDir * surf.faceNormal );
+					result.direction = normalize( result.direction - 2.0 * geomDotDir * surf.faceNormal );
 
 				}
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -236,6 +236,15 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				result.color *= max( 0.0, wi.z );
 				result.direction = normalize( normalBasis * wi );
 
+				// TODO: This will need to be removed or changed to support transmission
+				// Flip the reflected vector if it was scattered below the geometry normal
+				let geomDotDir = dot( result.direction, surf.faceNormal );
+				if ( geomDotDir < 0.0 ) {
+
+					result.direction = normalize( result.direction - 2.0 * NgDotDir * surf.faceNormal );
+
+				}
+
 				return result;
 
 			}

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -19,21 +19,65 @@ import { constants, surfaceRecordStruct } from './structs.wgsl.js';
 import { rngInit, rand2, RNG_INDEX_SCATTER_DIRECTION } from './random.wgsl.js';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
 
-const bendNormalFn = wgslTagFn/* wgsl */`
+// Correct the shading normal to prevent scattering rays below the geometry surface by bending
+// the normal towards the geometry normal such that the perfect reflection ray is just above the
+// geometry surface. Ported verbatim from Blender Cycles "ensure_valid_specular_reflection"
+// (src/kernel/closure/bsdf_util.h), which is derived from from the Iray paper (Keller et al. 2017, A.3).
+//
+// This only guarantees perfect reflection rays are above surface - other diffuse rays, for example,
+// flipped when sampling.
+const ensureValidReflectionNormal = wgslTagFn/* wgsl */`
 
-	fn bendNormal( normal: vec3f, geoNormal: vec3f, view: vec3f ) -> vec3f {
+	fn ensureValidReflectionNormal( n: vec3f, ng: vec3f, i: vec3f ) -> vec3f {
 
-		let nDot = dot( normal, view );
-		let gDot = dot( geoNormal, view );
-		if ( nDot < 0.0 ) {
+		// reflected ray
+		let R = 2.0 * dot( n, i ) * n - i;
 
-			let t = saturate( gDot / ( gDot - nDot ) );
-			let N_c = mix( geoNormal, normal, t );
-			return normalize( N_c );
+		let Iz = dot( i, ng );
+
+		// reflection rays may always be at least as shallow as the incoming ray
+		let threshold = min( 0.9 * Iz, 0.01 );
+		if ( dot( ng, R ) >= threshold ) {
+
+			return n;
 
 		}
 
-		return normal;
+		// Form coordinate system with Ng as the Z axis and N inside the X-Z-plane.
+   		// The X axis is found by normalizing the component of N that's orthogonal to Ng.
+   		// The Y axis isn't actually needed.
+		let orthoN = n - dot( n, ng ) * ng;
+		let orthoLen = length( orthoN );
+		let X = select( n, orthoN / orthoLen, orthoLen != 0.0 );
+
+		// Calculate N.z and N.x in the local coordinate system.
+		//
+		// The goal of this computation is to find a N' that is rotated towards Ng just enough
+   		// to lift R' above the threshold (here called t), therefore dot(R', Ng) = t.
+		//
+		// Se the Blender implementation for a full description of the solution.
+		let Ix = dot( i, X );
+
+		let a = Ix * Ix + Iz * Iz;
+		let b = 2.0 * ( a + Iz * threshold );
+		let c = ( threshold + Iz ) * ( threshold + Iz );
+
+		// only one root is valid; the sign of Ix selects it
+		var Nz2: f32;
+		if ( Ix < 0.0 ) {
+
+			Nz2 = 0.25 * ( b + sqrt( max( b * b - 4.0 * a * c, 0.0 ) ) ) / a;
+
+		} else {
+
+			Nz2 = 0.25 * ( b - sqrt( max( b * b - 4.0 * a * c, 0.0 ) ) ) / a;
+
+		}
+
+		let Nx = sqrt( max( 1.0 - Nz2, 0.0 ) );
+		let Nz = sqrt( max( Nz2, 0.0 ) );
+
+		return Nx * X + Nz * ng;
 
 	}
 
@@ -51,9 +95,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 	) -> SurfaceRecord {
 
 		var material = _material;
-
-		let geoNormal = normalize( faceNormal * side );
-		var normal = geoNormal;
+		var normal = faceNormal;
 		if ( material.flatShading == 0 ) {
 
 			normal = normalize( vertexData.normal.xyz ) * side;
@@ -77,13 +119,13 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 				var texNormal = sampleTexel( uvPrime.xy, material.normalMap, 0 ).xyz;
 				texNormal = texNormal * 2.0 - 1.0;
 				texNormal = texNormal * vec3f( material.normalScale, 1.0 );
-				normal = normalize( vTBN * texNormal ) * side;
+				normal = normalize( vTBN * texNormal );
 
 			}
 
 		}
 
-		normal = bendNormal( normal, geoNormal, view );
+		normal = ensureValidReflectionNormal( normal, faceNormal, view );
 
 		var albedo = vec4( material.color, material.opacity );
 		if ( material.vertexColors == 1 ) {
@@ -172,13 +214,13 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 				var texNormal = sampleTexel( uvPrime.xy, material.clearcoatNormalMap, 0 ).xyz;
 				texNormal = texNormal * 2.0 - 1.0;
 				texNormal = texNormal * vec3f( material.clearcoatNormalScale, 1.0 );
-				clearcoatNormal = normalize( vTBN * texNormal ) * side;
+				clearcoatNormal = normalize( vTBN * texNormal );
 
 			}
 
 		}
 
-		clearcoatNormal = bendNormal( clearcoatNormal, geoNormal, view );
+		clearcoatNormal = ensureValidReflectionNormal( clearcoatNormal, faceNormal, view );
 
 		var sheenColor = material.sheenColor;
 		if ( material.sheenColorMap != -1 ) {
@@ -345,7 +387,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 	getColor,
 	surfaceRecordStruct,
 	constants,
-	bendNormalFn,
+	ensureValidReflectionNormal,
 ] );
 
 /*

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -55,7 +55,7 @@ const ensureValidReflectionNormal = wgslTagFn/* wgsl */`
 		// The goal of this computation is to find a N' that is rotated towards Ng just enough
    		// to lift R' above the threshold (here called t), therefore dot(R', Ng) = t.
 		//
-		// Se the Blender implementation for a full description of the solution.
+		// See the Blender implementation for a full description of the solution.
 		let Ix = dot( i, X );
 
 		let a = Ix * Ix + Iz * Iz;

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -83,6 +83,47 @@ const ensureValidReflectionNormal = wgslTagFn/* wgsl */`
 
 `;
 
+// Adjusts the shading normal such that the provided view normal is guaranteed to be in
+// positive hemisphere by rotating it towards the view direction just enough so view is
+// just glancing the surface as a small epsilon if needed.
+const ensureValidViewNormal = wgslTagFn/* wgsl */`
+
+	fn ensureValidViewNormal( n: vec3f, ng: vec3f, view: vec3f ) -> vec3f {
+
+		// ensure the view is at least slightly above the surface normal hemisphere
+		const MIN_VIEW_COS = 1e-6;
+
+		// if we're positive already then early out
+		let c = dot( n, view );
+		if ( c > MIN_VIEW_COS ) {
+
+			return n;
+
+		}
+
+		// perpendicular vector to normal and view
+		var perp = n - c * view;
+		let perpLen = length( perp );
+
+		// if we reach here that means that he view is nearly the opposite direction and
+		// we can't derive plan to rotate on towards the view, so just use the geometry
+		// normal. This could likely only really happen with a severe normal map application.
+		if ( perpLen <= 1e-6 ) {
+
+			return ng;
+
+		}
+
+		perp = perp / perpLen;
+
+		// rotate the normal to be at larger than the above threshold - pythagorean
+		// theorem for generating normal with threshold*view component
+		return MIN_VIEW_COS * view + sqrt( 1.0 - MIN_VIEW_COS * MIN_VIEW_COS ) * perp;
+
+	}
+
+`;
+
 // Builds getSurfaceRecord using the given per-instance sampleTexel and uv channel lookup
 export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) => wgslFn( /* wgsl */ `
 
@@ -124,6 +165,8 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 			}
 
 		}
+
+		normal = ensureValidViewNormal( normal, faceNormal, view );
 
 		normal = ensureValidReflectionNormal( normal, faceNormal, view );
 
@@ -219,6 +262,8 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 			}
 
 		}
+
+		clearcoatNormal = ensureValidViewNormal( clearcoatNormal, faceNormal, view );
 
 		clearcoatNormal = ensureValidReflectionNormal( clearcoatNormal, faceNormal, view );
 
@@ -388,6 +433,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 	surfaceRecordStruct,
 	constants,
 	ensureValidReflectionNormal,
+	ensureValidViewNormal,
 ] );
 
 /*

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -128,14 +128,13 @@ const ensureValidViewNormal = wgslTagFn/* wgsl */`
 export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) => wgslFn( /* wgsl */ `
 
 	fn getSurfaceRecord(
-		_material: Material,
+		material: Material,
 		vertexData: bvh_GeometryStruct,
 		side: f32,
 		faceNormal: vec3f,
 		view: vec3f,
 	) -> SurfaceRecord {
 
-		var material = _material;
 		var normal = faceNormal;
 		if ( material.flatShading == 0 ) {
 

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -19,25 +19,48 @@ import { constants, surfaceRecordStruct } from './structs.wgsl.js';
 import { rngInit, rand2, RNG_INDEX_SCATTER_DIRECTION } from './random.wgsl.js';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
 
+const bendNormalFn = wgslTagFn/* wgsl */`
+
+	fn bendNormal( normal: vec3f, geoNormal: vec3f, view: vec3f ) -> vec3f {
+
+		let nDot = dot( normal, view );
+		let gDot = dot( geoNormal, view );
+		if ( nDot < 0.0 ) {
+
+			let t = saturate( gDot / ( gDot - nDot ) );
+			let N_c = mix( geoNormal, normal, t );
+			return normalize( N_c );
+
+		}
+
+		return normal;
+
+	}
+
+`;
+
 // Builds getSurfaceRecord using the given per-instance sampleTexel and uv channel lookup
 export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) => wgslFn( /* wgsl */ `
 
 	fn getSurfaceRecord(
-		material: Material,
+		_material: Material,
 		vertexData: bvh_GeometryStruct,
 		side: f32,
 		faceNormal: vec3f,
+		view: vec3f,
 	) -> SurfaceRecord {
 
-		var normal = faceNormal * side;
+		var material = _material;
+
+		let geoNormal = normalize( faceNormal * side );
+		var normal = geoNormal;
 		if ( material.flatShading == 0 ) {
 
-			normal = vertexData.normal.xyz;
+			normal = normalize( vertexData.normal.xyz ) * side;
 
 		}
-		normal = normalize( normal );
-		let baseNormal = normal;
 
+		var baseNormal = normal;
 		if ( material.normalMap != -1 ) {
 
 			// some provided tangents can be malformed (0, 0, 0) causing the normal to be degenerate
@@ -54,16 +77,15 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 				var texNormal = sampleTexel( uvPrime.xy, material.normalMap, 0 ).xyz;
 				texNormal = texNormal * 2.0 - 1.0;
 				texNormal = texNormal * vec3f( material.normalScale, 1.0 );
-				normal = normalize( vTBN * texNormal );
+				normal = normalize( vTBN * texNormal ) * side;
 
 			}
 
 		}
 
-		normal *= side;
+		normal = bendNormal( normal, geoNormal, view );
 
 		var albedo = vec4( material.color, material.opacity );
-
 		if ( material.vertexColors == 1 ) {
 
 			let vertexColor = getColor( vertexData ).xyz;
@@ -150,12 +172,13 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 				var texNormal = sampleTexel( uvPrime.xy, material.clearcoatNormalMap, 0 ).xyz;
 				texNormal = texNormal * 2.0 - 1.0;
 				texNormal = texNormal * vec3f( material.clearcoatNormalScale, 1.0 );
-				clearcoatNormal = normalize( vTBN * texNormal );
+				clearcoatNormal = normalize( vTBN * texNormal ) * side;
 
 			}
 
 		}
-		clearcoatNormal *= side;
+
+		clearcoatNormal = bendNormal( clearcoatNormal, geoNormal, view );
 
 		var sheenColor = material.sheenColor;
 		if ( material.sheenColorMap != -1 ) {
@@ -322,6 +345,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 	getColor,
 	surfaceRecordStruct,
 	constants,
+	bendNormalFn,
 ] );
 
 /*


### PR DESCRIPTION
Related to #777 

After a few tries, this PR fixes the lost rays (and energy) when view rays enter from below the shading normal or are scattered below the geometry normal. There are also some changes to make sure that normal "side" inversion isn't applied multiple times.

**Scattered Rays**

To handle rays scattered below the geometry surface, the shading normal is pre-adjusted to ensure that a perfectly specular reflected scatter will be guaranteed to be above the geometry surface. This is done by rotating the existing surface normal (from normal map, vertex, etc) toward the geometry norma until the reflection ray is above the surface. This is what Blender does with [this ensure_valid_specular_reflection function](https://github.com/blender/cycles/blob/97dbe6f57cdf4ede2d2b75ebdda507c8712edb7a/src/kernel/closure/bsdf_util.h#L322) and is where the implementation in this PR comes from.

**Below Surface Rays**

Glossy reflection rays can still scatter below the surface, though, so in that case the scattered direction is reflected across the geometry normal to be above it while preserving the pdf from the original scatter. This solution I'm a bit iff-y on but it feels better than just discarding the rays entirely.

**Below Shading Normal View Rays**

Similar to the Blender approach above, this fix will rotate the shading normal so the view vector is in the positive hemisphere.

--

It will probably take some care to preserve these things when adding transmission support but I think it improves the quality of the renders quite a bit. Note the black artifacts in the "before" images below.

| Before | After |
|---|---|
| <img width="300" src="https://github.com/user-attachments/assets/a589f068-9633-47f7-a0b6-d97fbcab20b7" /> | <img width="300" src="https://github.com/user-attachments/assets/c0c04926-bdd3-4799-a7f5-37329f7f98a2" /> |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/64192505-f03f-456e-9a0c-e4b7acd51e70" /> | <img width="300" src="https://github.com/user-attachments/assets/10da4890-496d-49cc-8c4b-51fdb01898b2" /> |

<img width="3194" height="1577" alt="image" src="https://github.com/user-attachments/assets/f0105688-aa94-48f7-b7df-16f565598334" />

<img width="2328" height="1289" alt="image" src="https://github.com/user-attachments/assets/d3706b03-02a4-4a1f-9870-73d30cf97f98" />
