### PR TITLE
Webgpu: Add support for "sheen", "specular color", "specular intensity"

### DIFF
--- a/src/shader/bsdf/bsdf_functions.glsl.js
+++ b/src/shader/bsdf/bsdf_functions.glsl.js
@@ -233,7 +233,6 @@ export const bsdf_functions = /* glsl */`
 		// See equation (1) in http://www.aconty.com/pdf/s2017_pbs_imageworks_sheen.pdf
 		vec3 color = surf.sheenColor;
 		color *= D * G / ( 4.0 * abs( cosThetaO * cosThetaI ) );
-		color *= wi.z;
 
 		return color;
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -3,6 +3,7 @@ import { StorageTexture, RedFormat, LinearFilter, TextureLoader, HalfFloatType }
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { PathtracingMaterial } from './PathtracingMaterial';
 import { specularBrdfFunc, diffuseBrdfFunc, fresnelMixFunc, conductorFresnelFunc, albedoIntegralMetallic, fresnelCoatFunc, iridescentDielectricLayerFunc, iridescentConductorLayerFunc } from '../nodes/material.wgsl.js';
+import { sheenColorFunc, sheenAlbedoScalingFunc } from '../nodes/sheen.wgsl.js';
 import { diffuseDirectionFunc, getLobeWeightsFunc } from '../nodes/sampling.wgsl.js';
 import { ggxDirectionFunc, ggxReflectionAdjustedPDFFunc } from '../nodes/ggx.wgsl.js';
 import { bxdfContextStruct, scatterRecordStruct, surfaceRecordStruct } from '../nodes/structs.wgsl.js';
@@ -111,7 +112,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					surf.iridescenceIor, surf.iridescenceThickness, surf.iridescence
 				);
 
-				let material = mix( dielectric, metallic, surf.metalness );
+				let baseMaterial = mix( dielectric, metallic, surf.metalness );
+
+				// sheen
+				let sheenScale = mix( 1.0, ${ sheenAlbedoScalingFunc }( ctx.V, ctx.L, surf ), surf.sheen );
+				let material = baseMaterial * sheenScale + ${ sheenColorFunc }( ctx.V, ctx.L, ctx.H, surf ) * surf.sheen;
 
 				let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
 				let clearcoat = ${ this.specularBrdf }( ctx.Vc, ctx.Lc, ctx.Hc, vec2( clearcoatAlpha ) );

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -97,7 +97,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
 				let diffuse = ${ this.diffuseBrdf }( NdotV, NdotL, ctx.VdotH, surf );
-				let dielectricBase = ${ this.fresnelMix }( ctx.VdotH, surf.ior, diffuse, specular );
+				let dielectricBase = ${ this.fresnelMix }( ctx.VdotH, surf.specularColor, surf.ior, surf.specularIntensity, diffuse, specular );
 
 				let dielectric = ${ this.iridescentDielectricLayer }(
 					dielectricBase, diffuse, specular, ctx.VdotH, /* outsideIor */ 1.0,

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -381,18 +381,24 @@ export const specularBrdfFunc = wgslFn( /* wgsl */ `
 
 `, [ ggxSmithVisibilityFunc, ggxDistributionFunc ] );
 
+// Dielectric layer fresnel operator that supports custom f0 color, specular weight.
+// Based on the specular color specification:
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular
 export const fresnelMixFunc = wgslFn( /* wgsl */ `
 
-	fn fresnelMix( VdotH: f32, ior: f32, base: vec3f, layer: vec3f ) -> vec3f {
+	fn fresnelMix( VdotH: f32, f0Color: vec3f, ior: f32, weight: f32, base: vec3f, layer: vec3f ) -> vec3f {
 
-		let f0 = iorToF0( ior );
-  	let F = schlickFresnel( abs( VdotH ), f0 );
+		var f0 = iorToF0( ior ) * f0Color;
+		f0 = min( f0, vec3f( 1.0 ) );
 
-  	return base + F * layer;
+		let fr = schlickFresnelVec( abs( VdotH ), f0, vec3f( 1.0 ) );
+		let maxFr = max( max( fr.r, fr.g ), fr.b );
+
+		return ( 1.0 - weight * maxFr ) * base + weight * fr * layer;
 
 	}
 
-`, [ schlickFresnelFunc, iorToF0Func ] );
+`, [ schlickFresnelVecFunc, iorToF0Func ] );
 
 const XYZ_TO_REC709 = mat3(
 	3.2404542, - 0.9692660, 0.0556434,

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -212,7 +212,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 
 			let uvPrime = material.specularIntensityMapTransform * vec3f( getUvFromChannel( vertexData, material.specularIntensityMap ), 1 );
 			let texColor = sampleTexel( uvPrime.xy, material.specularIntensityMap, 0 );
-			specularIntensity *= texColor.r;
+			specularIntensity *= texColor.a;
 
 		}
 

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -284,6 +284,9 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 		surf.specularColor = specularColor;
 		surf.specularIntensity = specularIntensity;
 
+		surf.sheen = material.sheen;
+		surf.sheenColor = sheenColor;
+
 		surf.roughness = clamp( roughness, MIN_ROUGHNESS, 1.0 );
 		surf.clearcoatRoughness = clamp( clearcoatRoughness, MIN_ROUGHNESS, 1.0 );
 		surf.sheenRoughness = clamp( sheenRoughness, MIN_ROUGHNESS, 1.0 );

--- a/src/webgpu/nodes/sheen.wgsl.js
+++ b/src/webgpu/nodes/sheen.wgsl.js
@@ -1,0 +1,149 @@
+import { wgslFn } from 'three/tsl';
+import { constants, surfaceRecordStruct } from './structs.wgsl.js';
+
+// TODO: LTC sheen (Zeltner et al. 2022, "Practical Multiple-Scattering Sheen Using Linearly
+// Transformed Cosines") is likely a better model and is what OpenPBR / Blender Cycles use to
+// support sheen BRDF importance sampling & energy conservation.
+
+// "Charlie" velvet, Estevez & Kulla, Imageworks 2017
+// http://www.aconty.com/pdf/s2017_pbs_imageworks_sheen.pdf
+
+// See equation (2)
+const velvetDFunc = wgslFn( /* wgsl */ `
+
+	fn velvetD( cosThetaH: f32, roughness: f32 ) -> f32 {
+
+		var alpha = max( roughness, 0.07 );
+		alpha = alpha * alpha;
+
+		let invAlpha = 1.0 / alpha;
+		let sqrCosThetaH = cosThetaH * cosThetaH;
+		let sinThetaH = max( 1.0 - sqrCosThetaH, 0.001 );
+
+		return ( 2.0 + invAlpha ) * pow( sinThetaH, 0.5 * invAlpha ) / ( 2.0 * PI );
+
+	}
+
+`, [ constants ] );
+
+const velvetParamsInterpolateFunc = wgslFn( /* wgsl */ `
+
+	fn velvetParamsInterpolate( i: i32, oneMinusAlphaSquared: f32 ) -> f32 {
+
+		let p0 = array<f32, 5>( 25.3245, 3.32435, 0.16801, - 1.27393, - 4.85967 );
+		let p1 = array<f32, 5>( 21.5473, 3.82987, 0.19823, - 1.97760, - 4.32054 );
+
+		return mix( p1[ i ], p0[ i ], oneMinusAlphaSquared );
+
+	}
+
+` );
+
+const velvetLFunc = wgslFn( /* wgsl */ `
+
+	fn velvetL( x: f32, alpha: f32 ) -> f32 {
+
+		let oneMinusAlpha = 1.0 - alpha;
+		let oneMinusAlphaSquared = oneMinusAlpha * oneMinusAlpha;
+
+		let a = velvetParamsInterpolate( 0, oneMinusAlphaSquared );
+		let b = velvetParamsInterpolate( 1, oneMinusAlphaSquared );
+		let c = velvetParamsInterpolate( 2, oneMinusAlphaSquared );
+		let d = velvetParamsInterpolate( 3, oneMinusAlphaSquared );
+		let e = velvetParamsInterpolate( 4, oneMinusAlphaSquared );
+
+		return a / ( 1.0 + b * pow( abs( x ), c ) ) + d * x + e;
+
+	}
+
+`, [ velvetParamsInterpolateFunc ] );
+
+// See equation (3)
+const velvetLambdaFunc = wgslFn( /* wgsl */ `
+
+	fn velvetLambda( cosTheta: f32, alpha: f32 ) -> f32 {
+
+		if ( abs( cosTheta ) < 0.5 ) {
+
+			return exp( velvetL( cosTheta, alpha ) );
+
+		} else {
+
+			return exp( 2.0 * velvetL( 0.5, alpha ) - velvetL( 1.0 - cosTheta, alpha ) );
+
+		}
+
+	}
+
+`, [ velvetLFunc ] );
+
+// See Section 3, Shadowing Term
+const velvetGFunc = wgslFn( /* wgsl */ `
+
+	fn velvetG( cosThetaO: f32, cosThetaI: f32, roughness: f32 ) -> f32 {
+
+		var alpha = max( roughness, 0.07 );
+		alpha = alpha * alpha;
+
+		return 1.0 / ( 1.0 + velvetLambda( cosThetaO, alpha ) + velvetLambda( cosThetaI, alpha ) );
+
+	}
+
+`, [ velvetLambdaFunc ] );
+
+// analytic directional albedo fit, used for energy compensation when layering ( Section 5 )
+const directionalAlbedoSheenFunc = wgslFn( /* wgsl */ `
+
+	fn directionalAlbedoSheen( cosThetaIn: f32, alpha: f32 ) -> f32 {
+
+		let cosTheta = saturate( cosThetaIn );
+		let c = 1.0 - cosTheta;
+		let c3 = c * c * c;
+
+		return 0.65584461 * c3 + 1.0 / ( 4.16526551 + exp( -7.97291361 * sqrt( alpha ) + 6.33516894 ) );
+
+	}
+
+` );
+
+// See Section 5, Layering - the factor the base lobes are attenuated by so the sheen layer
+// does not add energy on top of a fully reflective base
+export const sheenAlbedoScalingFunc = wgslFn( /* wgsl */ `
+
+	fn sheenAlbedoScaling( wo: vec3f, wi: vec3f, surf: SurfaceRecord ) -> f32 {
+
+		var alpha = max( surf.sheenRoughness, 0.07 );
+		alpha = alpha * alpha;
+
+		let maxSheenColor = max( max( surf.sheenColor.r, surf.sheenColor.g ), surf.sheenColor.b );
+
+		let eWo = directionalAlbedoSheen( clamp( wo.z, 0.001, 1.0 ), alpha );
+		let eWi = directionalAlbedoSheen( clamp( wi.z, 0.001, 1.0 ), alpha );
+
+		return min( 1.0 - maxSheenColor * eWo, 1.0 - maxSheenColor * eWi );
+
+	}
+
+`, [ directionalAlbedoSheenFunc, surfaceRecordStruct ] );
+
+export const sheenColorFunc = wgslFn( /* wgsl */ `
+
+	fn sheenColor( wo: vec3f, wi: vec3f, wh: vec3f, surf: SurfaceRecord ) -> vec3f {
+
+		let cosThetaO = clamp( wo.z, 0.001, 1.0 );
+		let cosThetaI = clamp( wi.z, 0.001, 1.0 );
+		let cosThetaH = wh.z;
+
+		let D = velvetD( cosThetaH, surf.sheenRoughness );
+		let G = velvetG( cosThetaO, cosThetaI, surf.sheenRoughness );
+
+		// See equation (1) in http://www.aconty.com/pdf/s2017_pbs_imageworks_sheen.pdf
+		var color = surf.sheenColor;
+		color *= D * G / ( 4.0 * abs( cosThetaO * cosThetaI ) );
+		color *= wi.z;
+
+		return color;
+
+	}
+
+`, [ velvetDFunc, velvetGFunc, surfaceRecordStruct ] );

--- a/src/webgpu/nodes/sheen.wgsl.js
+++ b/src/webgpu/nodes/sheen.wgsl.js
@@ -140,7 +140,6 @@ export const sheenColorFunc = wgslFn( /* wgsl */ `
 		// See equation (1) in http://www.aconty.com/pdf/s2017_pbs_imageworks_sheen.pdf
 		var color = surf.sheenColor;
 		color *= D * G / ( 4.0 * abs( cosThetaO * cosThetaI ) );
-		color *= wi.z;
 
 		return color;
 

--- a/src/webgpu/nodes/sheen.wgsl.js
+++ b/src/webgpu/nodes/sheen.wgsl.js
@@ -1,5 +1,5 @@
-import { wgslFn } from 'three/tsl';
-import { constants, surfaceRecordStruct } from './structs.wgsl.js';
+import { wgslTagFn } from 'three-mesh-bvh/webgpu';
+import { surfaceRecordStruct } from './structs.wgsl.js';
 
 // TODO: LTC sheen (Zeltner et al. 2022, "Practical Multiple-Scattering Sheen Using Linearly
 // Transformed Cosines") is likely a better model and is what OpenPBR / Blender Cycles use to
@@ -9,7 +9,7 @@ import { constants, surfaceRecordStruct } from './structs.wgsl.js';
 // http://www.aconty.com/pdf/s2017_pbs_imageworks_sheen.pdf
 
 // See equation (2)
-const velvetDFunc = wgslFn( /* wgsl */ `
+const velvetDFunc = wgslTagFn/* wgsl */`
 
 	fn velvetD( cosThetaH: f32, roughness: f32 ) -> f32 {
 
@@ -24,9 +24,9 @@ const velvetDFunc = wgslFn( /* wgsl */ `
 
 	}
 
-`, [ constants ] );
+`;
 
-const velvetParamsInterpolateFunc = wgslFn( /* wgsl */ `
+const velvetParamsInterpolateFunc = wgslTagFn/* wgsl */`
 
 	fn velvetParamsInterpolate( i: i32, oneMinusAlphaSquared: f32 ) -> f32 {
 
@@ -37,62 +37,62 @@ const velvetParamsInterpolateFunc = wgslFn( /* wgsl */ `
 
 	}
 
-` );
+`;
 
-const velvetLFunc = wgslFn( /* wgsl */ `
+const velvetLFunc = wgslTagFn/* wgsl */`
 
 	fn velvetL( x: f32, alpha: f32 ) -> f32 {
 
 		let oneMinusAlpha = 1.0 - alpha;
 		let oneMinusAlphaSquared = oneMinusAlpha * oneMinusAlpha;
 
-		let a = velvetParamsInterpolate( 0, oneMinusAlphaSquared );
-		let b = velvetParamsInterpolate( 1, oneMinusAlphaSquared );
-		let c = velvetParamsInterpolate( 2, oneMinusAlphaSquared );
-		let d = velvetParamsInterpolate( 3, oneMinusAlphaSquared );
-		let e = velvetParamsInterpolate( 4, oneMinusAlphaSquared );
+		let a = ${ velvetParamsInterpolateFunc }( 0, oneMinusAlphaSquared );
+		let b = ${ velvetParamsInterpolateFunc }( 1, oneMinusAlphaSquared );
+		let c = ${ velvetParamsInterpolateFunc }( 2, oneMinusAlphaSquared );
+		let d = ${ velvetParamsInterpolateFunc }( 3, oneMinusAlphaSquared );
+		let e = ${ velvetParamsInterpolateFunc }( 4, oneMinusAlphaSquared );
 
 		return a / ( 1.0 + b * pow( abs( x ), c ) ) + d * x + e;
 
 	}
 
-`, [ velvetParamsInterpolateFunc ] );
+`;
 
 // See equation (3)
-const velvetLambdaFunc = wgslFn( /* wgsl */ `
+const velvetLambdaFunc = wgslTagFn/* wgsl */`
 
 	fn velvetLambda( cosTheta: f32, alpha: f32 ) -> f32 {
 
 		if ( abs( cosTheta ) < 0.5 ) {
 
-			return exp( velvetL( cosTheta, alpha ) );
+			return exp( ${ velvetLFunc }( cosTheta, alpha ) );
 
 		} else {
 
-			return exp( 2.0 * velvetL( 0.5, alpha ) - velvetL( 1.0 - cosTheta, alpha ) );
+			return exp( 2.0 * ${ velvetLFunc }( 0.5, alpha ) - ${ velvetLFunc }( 1.0 - cosTheta, alpha ) );
 
 		}
 
 	}
 
-`, [ velvetLFunc ] );
+`;
 
 // See Section 3, Shadowing Term
-const velvetGFunc = wgslFn( /* wgsl */ `
+const velvetGFunc = wgslTagFn/* wgsl */`
 
 	fn velvetG( cosThetaO: f32, cosThetaI: f32, roughness: f32 ) -> f32 {
 
 		var alpha = max( roughness, 0.07 );
 		alpha = alpha * alpha;
 
-		return 1.0 / ( 1.0 + velvetLambda( cosThetaO, alpha ) + velvetLambda( cosThetaI, alpha ) );
+		return 1.0 / ( 1.0 + ${ velvetLambdaFunc }( cosThetaO, alpha ) + ${ velvetLambdaFunc }( cosThetaI, alpha ) );
 
 	}
 
-`, [ velvetLambdaFunc ] );
+`;
 
 // analytic directional albedo fit, used for energy compensation when layering ( Section 5 )
-const directionalAlbedoSheenFunc = wgslFn( /* wgsl */ `
+const directionalAlbedoSheenFunc = wgslTagFn/* wgsl */`
 
 	fn directionalAlbedoSheen( cosThetaIn: f32, alpha: f32 ) -> f32 {
 
@@ -104,38 +104,38 @@ const directionalAlbedoSheenFunc = wgslFn( /* wgsl */ `
 
 	}
 
-` );
+`;
 
 // See Section 5, Layering - the factor the base lobes are attenuated by so the sheen layer
 // does not add energy on top of a fully reflective base
-export const sheenAlbedoScalingFunc = wgslFn( /* wgsl */ `
+export const sheenAlbedoScalingFunc = wgslTagFn/* wgsl */`
 
-	fn sheenAlbedoScaling( wo: vec3f, wi: vec3f, surf: SurfaceRecord ) -> f32 {
+	fn sheenAlbedoScaling( wo: vec3f, wi: vec3f, surf: ${ surfaceRecordStruct } ) -> f32 {
 
 		var alpha = max( surf.sheenRoughness, 0.07 );
 		alpha = alpha * alpha;
 
 		let maxSheenColor = max( max( surf.sheenColor.r, surf.sheenColor.g ), surf.sheenColor.b );
 
-		let eWo = directionalAlbedoSheen( clamp( wo.z, 0.001, 1.0 ), alpha );
-		let eWi = directionalAlbedoSheen( clamp( wi.z, 0.001, 1.0 ), alpha );
+		let eWo = ${ directionalAlbedoSheenFunc }( clamp( wo.z, 0.001, 1.0 ), alpha );
+		let eWi = ${ directionalAlbedoSheenFunc }( clamp( wi.z, 0.001, 1.0 ), alpha );
 
 		return min( 1.0 - maxSheenColor * eWo, 1.0 - maxSheenColor * eWi );
 
 	}
 
-`, [ directionalAlbedoSheenFunc, surfaceRecordStruct ] );
+`;
 
-export const sheenColorFunc = wgslFn( /* wgsl */ `
+export const sheenColorFunc = wgslTagFn/* wgsl */`
 
-	fn sheenColor( wo: vec3f, wi: vec3f, wh: vec3f, surf: SurfaceRecord ) -> vec3f {
+	fn sheenColor( wo: vec3f, wi: vec3f, wh: vec3f, surf: ${ surfaceRecordStruct } ) -> vec3f {
 
 		let cosThetaO = clamp( wo.z, 0.001, 1.0 );
 		let cosThetaI = clamp( wi.z, 0.001, 1.0 );
 		let cosThetaH = wh.z;
 
-		let D = velvetD( cosThetaH, surf.sheenRoughness );
-		let G = velvetG( cosThetaO, cosThetaI, surf.sheenRoughness );
+		let D = ${ velvetDFunc }( cosThetaH, surf.sheenRoughness );
+		let G = ${ velvetGFunc }( cosThetaO, cosThetaI, surf.sheenRoughness );
 
 		// See equation (1) in http://www.aconty.com/pdf/s2017_pbs_imageworks_sheen.pdf
 		var color = surf.sheenColor;
@@ -145,4 +145,4 @@ export const sheenColorFunc = wgslFn( /* wgsl */ `
 
 	}
 
-`, [ velvetDFunc, velvetGFunc, surfaceRecordStruct ] );
+`;


### PR DESCRIPTION
Adds support for sheen, specular color, and specular intensity features, based on the WebGL implementation which just adjusts colors in the evaluate function rather than providing a separate sample-able BRDF lobe for sheen (I've added a note that it's something that could be added in the future).

The "specular color" and "specular intensity" application has also been adjusted compared to the WebGLPathTracer version to better align with the gltf spec.

Some test models:

| Before | After | 
|---|---|
| <img width="200" src="https://github.com/user-attachments/assets/d91101ed-b7af-4dc7-a475-015048a71227" /> | <img width="200" src="https://github.com/user-attachments/assets/cd06b23b-cf7f-427d-885e-b696e62f2e64" /> |
| <img width="200" src="https://github.com/user-attachments/assets/fe98e2c8-8fa4-4de6-8505-2bff06b95893" /> | <img width="200" src="https://github.com/user-attachments/assets/6114613f-4531-45e4-a459-ad02430911e4" /> |
| <img width="200" src="https://github.com/user-attachments/assets/9a0599ab-3f94-44f0-895e-766f78184e5f" /> | <img width="200" src="https://github.com/user-attachments/assets/e824a7be-b487-442e-a3ac-edcbdb1134fa" /> |
| <img width="200" src="https://github.com/user-attachments/assets/fd858b84-e482-4127-9de0-69b2ce043053" /> | <img width="200" src="https://github.com/user-attachments/assets/00eaf0ae-d435-49e4-9f38-95d315c1b735" /> |
| <img width="200" src="https://github.com/user-attachments/assets/c008d219-296a-4d6f-94b9-12a071c4182f" /> | <img width="200" src="https://github.com/user-attachments/assets/9cf69569-0509-42c2-b9c6-fdf1c235bbc7" /> |

There are some visible artifacts in the toy car demo but these were present previously and I expect will be addressed with #792.

<img width="279" height="283" alt="image" src="https://github.com/user-attachments/assets/2a5ec42d-17e0-4172-bea5-4517cb0c2a16" />

