### PR TITLE
Add dynamic scene editing support for WebGPU

### DIFF
--- a/example/dynamicScene.html
+++ b/example/dynamicScene.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Dynamic Scene Editing Example</title>
+		<title>Dynamic Scene Editing</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<style>
 			body { margin: 0; overflow: hidden; background: #222; }

--- a/example/dynamicScene.html
+++ b/example/dynamicScene.html
@@ -4,21 +4,10 @@
 		<title>Dynamic Scene Editing Example</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<style>
-			body { margin: 0; overflow: hidden; background: #222; font: 13px sans-serif; }
-			#ui { position: fixed; z-index: 1; margin: 10px; padding: 10px; color: white; background: #222c; }
-			label { display: block; margin: 6px 0; }
-			button, select, input { vertical-align: middle; }
+			body { margin: 0; overflow: hidden; background: #222; }
 		</style>
 	</head>
 	<body>
-		<div id="ui">
-			<button id="add">Add</button> <button id="remove">Delete</button>
-			<select id="shape"><option>Box</option><option>Sphere</option></select>
-			<label>Color <input id="color" type="color" value="#44aaff"></label>
-			<label>Roughness <input id="roughness" type="range" min="0" max="1" step="0.01" value="0.25"></label>
-			<label>Metalness <input id="metalness" type="range" min="0" max="1" step="0.01" value="0"></label>
-			<div>Drag a model to move it</div>
-		</div>
 		<script src="./dynamicScene.js" type="module"></script>
 	</body>
 </html>

--- a/example/dynamicScene.html
+++ b/example/dynamicScene.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Dynamic Scene Editing Example</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<style>
+			body { margin: 0; overflow: hidden; background: #222; font: 13px sans-serif; }
+			#ui { position: fixed; z-index: 1; margin: 10px; padding: 10px; color: white; background: #222c; }
+			label { display: block; margin: 6px 0; }
+			button, select, input { vertical-align: middle; }
+		</style>
+	</head>
+	<body>
+		<div id="ui">
+			<button id="add">Add</button> <button id="remove">Delete</button>
+			<select id="shape"><option>Box</option><option>Sphere</option></select>
+			<label>Color <input id="color" type="color" value="#44aaff"></label>
+			<label>Roughness <input id="roughness" type="range" min="0" max="1" step="0.01" value="0.25"></label>
+			<label>Metalness <input id="metalness" type="range" min="0" max="1" step="0.01" value="0"></label>
+			<div>Drag a model to move it</div>
+		</div>
+		<script src="./dynamicScene.js" type="module"></script>
+	</body>
+</html>

--- a/example/dynamicScene.html
+++ b/example/dynamicScene.html
@@ -4,10 +4,39 @@
 		<title>Dynamic Scene Editing</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<style>
-			body { margin: 0; overflow: hidden; background: #222; }
+			html, body {
+				margin: 0;
+				overflow: hidden;
+				background: #222;
+			}
+
+			#description {
+				position: absolute;
+				top: 0;
+				left: 0;
+				right: 260px;
+				padding: 8px 16px;
+				box-sizing: border-box;
+				color: white;
+				font: 14px/1.4 monospace;
+				text-align: center;
+				text-shadow: 0 1px 2px #000;
+				pointer-events: none;
+			}
+
+			@media (max-width: 520px) {
+				#description {
+					top: 180px;
+					right: 0;
+					padding: 8px 12px;
+					background: rgba( 0, 0, 0, 0.35 );
+					text-align: left;
+				}
+			}
 		</style>
 	</head>
 	<body>
+		<div id="description">Click an object to select it. Press T / R / S for Translate / Rotate / Scale.</div>
 		<script src="./dynamicScene.js" type="module"></script>
 	</body>
 </html>

--- a/example/dynamicScene.js
+++ b/example/dynamicScene.js
@@ -209,15 +209,14 @@ function animate() {
 
 function resize() {
 
-	renderer.setSize( innerWidth, innerHeight );
-	renderer.setPixelRatio( devicePixelRatio );
-	camera.aspect = innerWidth / innerHeight;
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.setPixelRatio( window.devicePixelRatio );
+	camera.aspect = window.innerWidth / window.innerHeight;
 	camera.updateProjectionMatrix();
 	pathTracer.updateCamera();
 
 }
 
-add();
 add();
 resize();
 window.addEventListener( 'resize', resize );

--- a/example/dynamicScene.js
+++ b/example/dynamicScene.js
@@ -1,13 +1,16 @@
 import {
 	ACESFilmicToneMapping, BoxGeometry, Mesh, MeshStandardMaterial, PerspectiveCamera,
-	PlaneGeometry, Scene, SphereGeometry, WebGPURenderer,
+	PlaneGeometry, Raycaster, Scene, SphereGeometry, Vector2, WebGPURenderer,
 } from 'three/webgpu';
+
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import { DragControls } from 'three/addons/controls/DragControls.js';
+import { TransformControls } from 'three/addons/controls/TransformControls.js';
 import { GradientEquirectTexture } from 'three-gpu-pathtracer';
 import { WebGPUPathTracer } from 'three-gpu-pathtracer/webgpu';
 
 const scene = new Scene();
+const transformScene = new Scene();
 const camera = new PerspectiveCamera( 50, 1, 0.1, 100 );
 camera.position.set( 5, 4, 7 );
 
@@ -32,60 +35,114 @@ floor.rotation.x = - Math.PI / 2;
 scene.add( floor );
 
 const objects = [];
-let selected, dragging = false;
+let selected;
 const orbit = new OrbitControls( camera, renderer.domElement );
 orbit.target.y = 0.5;
 orbit.addEventListener( 'change', () => pathTracer.updateCamera() );
 orbit.update();
 
-const drag = new DragControls( objects, camera, renderer.domElement );
-drag.addEventListener( 'dragstart', e => {
+const transformControls = new TransformControls( camera, renderer.domElement );
+transformScene.add( transformControls.getHelper() );
+transformControls.addEventListener( 'mouseDown', () => orbit.enabled = false );
+transformControls.addEventListener( 'change', () => pathTracer.updateTransforms() );
+transformControls.addEventListener( 'mouseUp', () => {
 
-	select( e.object );
-	dragging = true;
-	orbit.enabled = false;
-
-} );
-drag.addEventListener( 'dragend', () => {
-
-	dragging = false;
 	orbit.enabled = true;
-	pathTracer.setScene( scene, camera );
+	pathTracer.updateTransforms();
 
 } );
 
-const ui = Object.fromEntries( [ 'add', 'remove', 'shape', 'color', 'roughness', 'metalness' ].map( id => [ id, document.getElementById( id ) ] ) );
-ui.add.onclick = add;
-ui.remove.onclick = () => {
-
-	if ( ! selected ) return;
-	scene.remove( selected );
-	objects.splice( objects.indexOf( selected ), 1 );
-	selected.geometry.dispose();
-	selected.material.dispose();
-	selected = objects.at( - 1 );
-	if ( selected ) select( selected );
-	pathTracer.setScene( scene, camera );
-
+const transformModes = {
+	KeyT: 'translate',
+	KeyR: 'rotate',
+	KeyS: 'scale',
 };
 
-for ( const key of [ 'color', 'roughness', 'metalness' ] ) {
+window.addEventListener( 'keydown', event => {
 
-	ui[ key ].oninput = () => {
+	if ( event.target?.closest?.( 'input, select, textarea' ) || event.target?.isContentEditable ) return;
 
-		if ( ! selected ) return;
-		if ( key === 'color' ) selected.material.color.set( ui[ key ].value );
-		else selected.material[ key ] = Number( ui[ key ].value );
-		pathTracer.updateMaterials();
+	const mode = transformModes[ event.code ];
+	if ( mode !== undefined ) {
 
-	};
+		transformControls.setMode( mode );
+		event.preventDefault();
+
+	}
+
+} );
+
+const raycaster = new Raycaster();
+const pointer = new Vector2();
+const pointerStart = new Vector2();
+const pointerEnd = new Vector2();
+
+const params = {
+	add,
+	remove,
+	shape: 'Box',
+	color: '#44aaff',
+	roughness: 0.25,
+	metalness: 0,
+};
+
+const gui = new GUI();
+gui.add( params, 'add' ).name( 'Add' );
+gui.add( params, 'remove' ).name( 'Delete' );
+gui.add( params, 'shape', [ 'Box', 'Sphere' ] );
+const colorController = gui.addColor( params, 'color' ).onChange( updateMaterial );
+const roughnessController = gui.add( params, 'roughness', 0, 1, 0.01 ).onChange( updateMaterial );
+const metalnessController = gui.add( params, 'metalness', 0, 1, 0.01 ).onChange( updateMaterial );
+
+renderer.domElement.addEventListener( 'pointerdown', event => pointerStart.set( event.clientX, event.clientY ) );
+renderer.domElement.addEventListener( 'pointerup', event => {
+
+	pointerEnd.set( event.clientX, event.clientY );
+	if ( transformControls.dragging || pointerStart.distanceTo( pointerEnd ) > 4 ) return;
+
+	const rect = renderer.domElement.getBoundingClientRect();
+	pointer.set(
+		( ( event.clientX - rect.left ) / rect.width ) * 2 - 1,
+		- ( ( event.clientY - rect.top ) / rect.height ) * 2 + 1,
+	);
+	raycaster.setFromCamera( pointer, camera );
+	select( raycaster.intersectObjects( objects )[ 0 ]?.object || null );
+
+} );
+
+function remove() {
+
+	if ( ! selected ) return;
+	const object = selected;
+	transformControls.detach();
+	scene.remove( object );
+	objects.splice( objects.indexOf( object ), 1 );
+	object.geometry.dispose();
+	object.material.dispose();
+	selected = objects.at( - 1 );
+	select( selected );
+	pathTracer.setScene( scene, camera );
+
+}
+
+function updateMaterial() {
+
+	if ( ! selected ) return;
+	selected.material.color.set( params.color );
+	selected.material.roughness = params.roughness;
+	selected.material.metalness = params.metalness;
+	pathTracer.updateMaterials();
 
 }
 
 function add() {
 
-	const geometry = ui.shape.value === 'Box' ? new BoxGeometry() : new SphereGeometry( 0.6, 32, 16 );
-	const object = new Mesh( geometry, new MeshStandardMaterial( { color: ui.color.value, roughness: 0.25 } ) );
+	const geometry = params.shape === 'Box' ? new BoxGeometry() : new SphereGeometry( 0.6, 32, 16 );
+	const object = new Mesh( geometry, new MeshStandardMaterial( {
+		color: params.color,
+		roughness: params.roughness,
+		metalness: params.metalness,
+	} ) );
 	object.position.set( ( objects.length % 4 ) - 1.5, 0.6, 0 );
 	objects.push( object );
 	scene.add( object );
@@ -97,16 +154,38 @@ function add() {
 function select( object ) {
 
 	selected = object;
-	ui.color.value = `#${ object.material.color.getHexString() }`;
-	ui.roughness.value = object.material.roughness;
-	ui.metalness.value = object.material.metalness;
+	if ( object ) {
+
+		transformControls.attach( object );
+		params.color = `#${ object.material.color.getHexString() }`;
+		params.roughness = object.material.roughness;
+		params.metalness = object.material.metalness;
+
+	} else {
+
+		transformControls.detach();
+
+	}
+
+	colorController.updateDisplay();
+	roughnessController.updateDisplay();
+	metalnessController.updateDisplay();
 
 }
 
 function animate() {
 
-	if ( dragging ) renderer.render( scene, camera );
-	else pathTracer.renderSample();
+	pathTracer.renderSample();
+
+	if ( selected ) {
+
+		const originalAutoClear = renderer.autoClear;
+		renderer.autoClear = false;
+		renderer.clearDepth();
+		renderer.render( transformScene, camera );
+		renderer.autoClear = originalAutoClear;
+
+	}
 
 }
 

--- a/example/dynamicScene.js
+++ b/example/dynamicScene.js
@@ -36,6 +36,10 @@ scene.add( floor );
 
 const objects = [];
 let selected;
+
+let transformNeedsUpdate = false;
+let materialNeedsUpdate = false;
+
 const orbit = new OrbitControls( camera, renderer.domElement );
 orbit.target.y = 0.5;
 orbit.addEventListener( 'change', () => pathTracer.updateCamera() );
@@ -44,11 +48,11 @@ orbit.update();
 const transformControls = new TransformControls( camera, renderer.domElement );
 transformScene.add( transformControls.getHelper() );
 transformControls.addEventListener( 'mouseDown', () => orbit.enabled = false );
-transformControls.addEventListener( 'change', () => pathTracer.updateTransforms() );
+transformControls.addEventListener( 'change', () => transformNeedsUpdate = true );
 transformControls.addEventListener( 'mouseUp', () => {
 
 	orbit.enabled = true;
-	pathTracer.updateTransforms();
+	transformNeedsUpdate = true;
 
 } );
 
@@ -131,7 +135,7 @@ function updateMaterial() {
 	selected.material.color.set( params.color );
 	selected.material.roughness = params.roughness;
 	selected.material.metalness = params.metalness;
-	pathTracer.updateMaterials();
+	materialNeedsUpdate = true;
 
 }
 
@@ -174,6 +178,20 @@ function select( object ) {
 }
 
 function animate() {
+
+	if ( transformNeedsUpdate ) {
+
+		transformNeedsUpdate = false;
+		pathTracer.updateTransforms();
+
+	}
+
+	if ( materialNeedsUpdate ) {
+
+		materialNeedsUpdate = false;
+		pathTracer.updateMaterials();
+
+	}
 
 	pathTracer.renderSample();
 

--- a/example/dynamicScene.js
+++ b/example/dynamicScene.js
@@ -1,0 +1,126 @@
+import {
+	ACESFilmicToneMapping, BoxGeometry, Mesh, MeshStandardMaterial, PerspectiveCamera,
+	PlaneGeometry, Scene, SphereGeometry, WebGPURenderer,
+} from 'three/webgpu';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { DragControls } from 'three/addons/controls/DragControls.js';
+import { GradientEquirectTexture } from 'three-gpu-pathtracer';
+import { WebGPUPathTracer } from 'three-gpu-pathtracer/webgpu';
+
+const scene = new Scene();
+const camera = new PerspectiveCamera( 50, 1, 0.1, 100 );
+camera.position.set( 5, 4, 7 );
+
+const renderer = new WebGPURenderer( { antialias: true } );
+renderer.init();
+renderer.toneMapping = ACESFilmicToneMapping;
+renderer.setAnimationLoop( animate );
+document.body.appendChild( renderer.domElement );
+
+const pathTracer = new WebGPUPathTracer( renderer );
+const environment = new GradientEquirectTexture();
+environment.topColor.set( 0x88aacc );
+environment.bottomColor.set( 0xffffff );
+environment.update();
+scene.background = scene.environment = environment;
+
+const floor = new Mesh(
+	new PlaneGeometry( 20, 20 ),
+	new MeshStandardMaterial( { color: 0x888888, roughness: 0.8 } ),
+);
+floor.rotation.x = - Math.PI / 2;
+scene.add( floor );
+
+const objects = [];
+let selected, dragging = false;
+const orbit = new OrbitControls( camera, renderer.domElement );
+orbit.target.y = 0.5;
+orbit.addEventListener( 'change', () => pathTracer.updateCamera() );
+orbit.update();
+
+const drag = new DragControls( objects, camera, renderer.domElement );
+drag.addEventListener( 'dragstart', e => {
+
+	select( e.object );
+	dragging = true;
+	orbit.enabled = false;
+
+} );
+drag.addEventListener( 'dragend', () => {
+
+	dragging = false;
+	orbit.enabled = true;
+	pathTracer.setScene( scene, camera );
+
+} );
+
+const ui = Object.fromEntries( [ 'add', 'remove', 'shape', 'color', 'roughness', 'metalness' ].map( id => [ id, document.getElementById( id ) ] ) );
+ui.add.onclick = add;
+ui.remove.onclick = () => {
+
+	if ( ! selected ) return;
+	scene.remove( selected );
+	objects.splice( objects.indexOf( selected ), 1 );
+	selected.geometry.dispose();
+	selected.material.dispose();
+	selected = objects.at( - 1 );
+	if ( selected ) select( selected );
+	pathTracer.setScene( scene, camera );
+
+};
+
+for ( const key of [ 'color', 'roughness', 'metalness' ] ) {
+
+	ui[ key ].oninput = () => {
+
+		if ( ! selected ) return;
+		if ( key === 'color' ) selected.material.color.set( ui[ key ].value );
+		else selected.material[ key ] = Number( ui[ key ].value );
+		pathTracer.updateMaterials();
+
+	};
+
+}
+
+function add() {
+
+	const geometry = ui.shape.value === 'Box' ? new BoxGeometry() : new SphereGeometry( 0.6, 32, 16 );
+	const object = new Mesh( geometry, new MeshStandardMaterial( { color: ui.color.value, roughness: 0.25 } ) );
+	object.position.set( ( objects.length % 4 ) - 1.5, 0.6, 0 );
+	objects.push( object );
+	scene.add( object );
+	select( object );
+	pathTracer.setScene( scene, camera );
+
+}
+
+function select( object ) {
+
+	selected = object;
+	ui.color.value = `#${ object.material.color.getHexString() }`;
+	ui.roughness.value = object.material.roughness;
+	ui.metalness.value = object.material.metalness;
+
+}
+
+function animate() {
+
+	if ( dragging ) renderer.render( scene, camera );
+	else pathTracer.renderSample();
+
+}
+
+function resize() {
+
+	renderer.setSize( innerWidth, innerHeight );
+	renderer.setPixelRatio( devicePixelRatio );
+	camera.aspect = innerWidth / innerHeight;
+	camera.updateProjectionMatrix();
+	pathTracer.updateCamera();
+
+}
+
+add();
+add();
+resize();
+window.addEventListener( 'resize', resize );

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -279,6 +279,13 @@ export class WebGPUPathTracer {
 		bvhData.update();
 		bvhData.textureAtlas.setTextures( this._renderer, bvhData.textures );
 
+		if ( this._bvhData ) {
+
+			this._bvhData.dispose();
+			this._bvhData.textureAtlas.dispose();
+
+		}
+
 		this.scene = scene;
 		this._bvhData = bvhData;
 		this._pathTracer.setBVHData( bvhData );
@@ -360,6 +367,14 @@ export class WebGPUPathTracer {
 		const { _bvhData, _renderer } = this;
 		_bvhData.updateMaterials();
 		_bvhData.textureAtlas.setTextures( _renderer, _bvhData.textures );
+		this.reset();
+
+	}
+
+	updateTransforms() {
+
+		this.scene.updateMatrixWorld( true );
+		this._bvhData.updateTransforms();
 		this.reset();
 
 	}
@@ -660,10 +675,12 @@ export class WebGPUPathTracer {
 	dispose() {
 
 		this._pathTracer.dispose();
+		this._bvhData.dispose();
+		this._bvhData.textureAtlas.dispose();
+		this._environmentCache.dispose();
+		this._backgroundCache.dispose();
 		this._blitQuad.dispose();
 		this._lowResTarget.dispose();
-		this._envColorTexture.dispose();
-		this._backgroundColorTexture.dispose();
 		this._atlasDebugQuad?.dispose();
 
 		if ( this._debugBoundsQuad !== undefined ) {


### PR DESCRIPTION
Related to #777 

This PR adds support for editing a WebGPU path-traced scene at runtime and introduces a `dynamicScene` example demonstrating the complete workflow.

The example allows users to create, select, transform, delete, and edit the materials of asset instances while keeping the path-traced result synchronized.

## Changes

- Add `WebGPUPathTracer.updateTransforms()` for lightweight transform-only updates.
- Complete resource cleanup in `WebGPUPathTracer.dispose()`, including BVH data, texture atlases, and environment/background caches.
- Add a new `dynamicScene` WebGPU example featuring:
  - model asset instancing with shared geometry and textures;
  - translate, rotate, and scale controls;
  - object deletion;
  - interactive editing of common physical material properties;

Transform and material changes are coalesced to at most one update per animation frame. 

## Controls

- Click Add/Delete to manage an instance.
- Click an object to select it.
- Press `T`, `R`, or `S` to switch between translate, rotate, and scale modes.