### PR TITLE
Fix sample UI updates

### DIFF
--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -133,6 +133,7 @@ async function init() {
 	// initialize scene
 	pathTracer.setScene( scene, camera );
 
+	loader.setPercentage( 1 );
 	loader.setCredits( CREDITS );
 
 	// gui

--- a/example/basic.js
+++ b/example/basic.js
@@ -97,6 +97,7 @@ async function init() {
 	// initialize the path tracer
 	pathTracer.setScene( scene, camera );
 
+	loader.setPercentage( 1 );
 	loader.setCredits( CREDITS );
 	loader.setDescription( DESCRIPTION );
 

--- a/example/depthOfField.js
+++ b/example/depthOfField.js
@@ -137,6 +137,7 @@ async function init() {
 	// update the scene
 	pathTracer.setScene( scene, camera );
 
+	loader.setPercentage( 1 );
 	loader.setCredits( CREDITS );
 	loader.setDescription( DESCRIPTION );
 	onParamsChange();

--- a/example/interior.js
+++ b/example/interior.js
@@ -115,6 +115,7 @@ async function init() {
 
 	pathTracer.setScene( scene, camera );
 
+	loader.setPercentage( 1 );
 	loader.setCredits( CREDITS );
 
 	onResize();

--- a/example/overlay.js
+++ b/example/overlay.js
@@ -53,7 +53,7 @@ async function init() {
 
 	// renderer
 	renderer = new WebGPURenderer( { antialias: true } );
-	renderer.init();
+	await renderer.init();
 	renderer.toneMapping = ACESFilmicToneMapping;
 	document.body.appendChild( renderer.domElement );
 
@@ -120,6 +120,7 @@ async function init() {
 	// initialize scene
 	pathTracer.setScene( scene, camera );
 
+	loader.setPercentage( 1 );
 	loader.setCredits( CREDITS );
 
 	// gui

--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -171,6 +171,7 @@ async function init() {
 
 	pathTracer.setScene( scene, camera );
 
+	loader.setPercentage( 1 );
 	loader.setCredits( CREDITS );
 	onParamsChange();
 	onResize();


### PR DESCRIPTION
### Current changes
- `overlay.js`: Added `await renderer.init()` to prevent uninitialized renderer errors.
- Updated the example UI via `setPercentage( 1 )` to correctly display the currently accumulated sample count.

### Remaining Examples
I have tested the remaining examples, such as `fog`, `materialBall`, `areaLight`, `materialDatabase`, and `spotLights`, are currently not working properly. 

They can be restored to a working state once the WebGPU path tracer supports the following features:
- Collecting scene lights and uploading their data to GPU buffers.
- `updateLights()` and dynamic light updates.
- Direct-light sampling and shadow rays.
- NEE / MIS for area, spot, point, and directional lights.
- IES profile sampling.
- Volumetric media traversal and scattering for fog materials.

### lkg Example
The `lkg` example has not been migrated to WebGPU yet. It currently depends on:
- The WebGL-based `QuiltPathTracingRenderer`.
- GLSL fullscreen and quilt-preview materials.
- The Looking Glass WebXR WebGL layer integration.

I believe migrating this will be quite complex.