### PR TITLE
WebGPUPathTracer: Add ray early-out optimizations

### DIFF
--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -148,6 +148,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						}
 
+						// russian roulette early out
 						if ( bounce >= 3u ) {
 
 							let rrThroughput = throughputColor * scatterRec.color / scatterRec.pdf;
@@ -166,6 +167,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						throughputColor *= scatterRec.color;
 						throughputColor /= scatterRec.pdf;
 
+						// exit if our throughput is 0.0
 						if ( all( throughputColor == vec3f( 0.0 ) ) ) {
 
 							break;

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -1,8 +1,8 @@
 import { DataTexture, Matrix3, Vector2, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from './ComputeKernel.js';
 import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
-import { rngInit, rngNextBounce, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../nodes/random.wgsl.js';
-import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
+import { rngInit, rngNextBounce, rand1, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_ENVIRONMENT_SAMPLE, RNG_INDEX_RUSSIAN_ROULETTE } from '../nodes/random.wgsl.js';
+import { sampleEnvironmentFn, weightedAlphaBlendFn, luminanceFn } from '../nodes/sampling.wgsl.js';
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
 
@@ -148,8 +148,29 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						}
 
+						if ( bounce >= 3u ) {
+
+							let rrThroughput = throughputColor * scatterRec.color / scatterRec.pdf;
+							let rrProb = sqrt( saturate( ${ luminanceFn }( rrThroughput ) / max( ${ luminanceFn }( throughputColor ), 1e-4 ) ) );
+							if ( ${ rand1 }( ${ RNG_INDEX_RUSSIAN_ROULETTE } ) > rrProb ) {
+
+								break;
+
+							}
+
+							// perform sample clamping here to avoid bright pixels
+							throughputColor *= min( 1.0 / rrProb, 20.0 );
+
+						}
+
 						throughputColor *= scatterRec.color;
 						throughputColor /= scatterRec.pdf;
+
+						if ( all( throughputColor == vec3f( 0.0 ) ) ) {
+
+							break;
+
+						}
 
 						// TODO: Investigate offsetting this position to not self-intersect multiple times
 						// Adding + scatterRec.direction * 1e-1 seems to fix almost all the fireflies

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -87,22 +87,27 @@ export class ProcessHitsKernel extends ComputeKernel {
 				let resultColor = input.resultColor + vec4f( input.throughputColor * surface.emission, 0.0 );
 
 				var throughputColor = input.throughputColor;
-				var isTerminated = all( throughputColor == vec3f( 0.0 ) ) || input.currentBounce >= bounces || ${ isTerminatingScatterFunc }( scatterRec );
+				var isTerminated = input.currentBounce >= bounces || ${ isTerminatingScatterFunc }( scatterRec );
 
+				// russian roulette early out
 				if ( ! isTerminated && input.currentBounce >= 3u ) {
 
 					let rrThroughput = throughputColor * scatterRec.color / scatterRec.pdf;
 					let rrProb = sqrt( saturate( ${ luminanceFn }( rrThroughput ) / max( ${ luminanceFn }( throughputColor ), 1e-4 ) ) );
-					if ( ${ rand1 }( ${ RNG_INDEX_RUSSIAN_ROULETTE } ) > rrProb ) {
+					isTerminated = ${ rand1 }( ${ RNG_INDEX_RUSSIAN_ROULETTE } ) > rrProb;
 
-						isTerminated = true;
+					// perform sample clamping here to avoid bright pixels
+					throughputColor *= min( 1.0 / rrProb, 20.0 );
 
-					} else {
+				}
 
-						// perform sample clamping here to avoid bright pixels
-						throughputColor *= min( 1.0 / rrProb, 20.0 );
+				if ( ! isTerminated ) {
 
-					}
+					// only divide by the pdf if this ray is valid
+					throughputColor *= scatterRec.color / scatterRec.pdf;
+
+					// exit if our throughput is 0.0
+					isTerminated = all( throughputColor == vec3f( 0.0 ) );
 
 				}
 
@@ -122,7 +127,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 					rayQueue.elements[ index ].origin = vertexData.position.xyz;
 					rayQueue.elements[ index ].direction = scatterRec.direction;
 					rayQueue.elements[ index ].pixel = indexUV;
-					rayQueue.elements[ index ].throughputColor = throughputColor * scatterRec.color / scatterRec.pdf;
+					rayQueue.elements[ index ].throughputColor = throughputColor;
 					rayQueue.elements[ index ].currentBounce = input.currentBounce + 1;
 					rayQueue.elements[ index ].resultColor = resultColor;
 					rayQueue.elements[ index ].seed = input.seed;

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -3,9 +3,9 @@ import { ComputeKernel } from '../ComputeKernel.js';
 import { uniform, storage, textureStore, globalId, texture, sampler } from 'three/tsl';
 import { rayQueueAtomicStruct, hitQueueStruct } from './structs.js';
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
-import { weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
+import { weightedAlphaBlendFn, luminanceFn } from '../../nodes/sampling.wgsl.js';
 import { isTerminatingScatterFunc } from '../../nodes/utils.wgsl.js';
-import { rngInit } from '../../nodes/random.wgsl.js';
+import { rngInit, rand1, RNG_INDEX_RUSSIAN_ROULETTE } from '../../nodes/random.wgsl.js';
 
 export class ProcessHitsKernel extends ComputeKernel {
 
@@ -86,7 +86,25 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 				let resultColor = input.resultColor + vec4f( input.throughputColor * surface.emission, 0.0 );
 
-				let isTerminated = input.currentBounce >= bounces || ${ isTerminatingScatterFunc }( scatterRec );
+				var throughputColor = input.throughputColor;
+				var isTerminated = all( throughputColor == vec3f( 0.0 ) ) || input.currentBounce >= bounces || ${ isTerminatingScatterFunc }( scatterRec );
+
+				if ( ! isTerminated && input.currentBounce >= 3u ) {
+
+					let rrThroughput = throughputColor * scatterRec.color / scatterRec.pdf;
+					let rrProb = sqrt( saturate( ${ luminanceFn }( rrThroughput ) / max( ${ luminanceFn }( throughputColor ), 1e-4 ) ) );
+					if ( ${ rand1 }( ${ RNG_INDEX_RUSSIAN_ROULETTE } ) > rrProb ) {
+
+						isTerminated = true;
+
+					} else {
+
+						// perform sample clamping here to avoid bright pixels
+						throughputColor *= min( 1.0 / rrProb, 20.0 );
+
+					}
+
+				}
 
 				if ( isTerminated ) {
 
@@ -104,7 +122,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 					rayQueue.elements[ index ].origin = vertexData.position.xyz;
 					rayQueue.elements[ index ].direction = scatterRec.direction;
 					rayQueue.elements[ index ].pixel = indexUV;
-					rayQueue.elements[ index ].throughputColor = input.throughputColor * scatterRec.color / scatterRec.pdf;
+					rayQueue.elements[ index ].throughputColor = throughputColor * scatterRec.color / scatterRec.pdf;
 					rayQueue.elements[ index ].currentBounce = input.currentBounce + 1;
 					rayQueue.elements[ index ].resultColor = resultColor;
 					rayQueue.elements[ index ].seed = input.seed;

--- a/src/webgpu/nodes/random.wgsl.js
+++ b/src/webgpu/nodes/random.wgsl.js
@@ -4,6 +4,7 @@ export const RNG_INDEX_ENVIRONMENT_SAMPLE = 1;
 export const RNG_INDEX_SCATTER_TYPE = 2;
 export const RNG_INDEX_SCATTER_DIRECTION = 3;
 export const RNG_INDEX_APERTURE_SAMPLE = 4;
+export const RNG_INDEX_RUSSIAN_ROULETTE = 8;
 export const RNG_INDEX_ALPHA_TEST = 50;
 import { contextProxyFn } from 'three-mesh-bvh/webgpu';
 import * as sobol from './rand/sobol.wgsl.js';

--- a/src/webgpu/nodes/sampling.wgsl.js
+++ b/src/webgpu/nodes/sampling.wgsl.js
@@ -145,6 +145,16 @@ export const sampleEnvironmentFn = wgslFn( /* wgsl */ `
 
 `, [ sampleEquirectColorFn, sampleHemisphereFn, environmentInfoStruct ] );
 
+export const luminanceFn = wgslFn( /* wgsl */ `
+
+	fn luminance( color: vec3f ) -> f32 {
+
+		return dot( color, vec3f( 0.2126, 0.7152, 0.0722 ) );
+
+	}
+
+` );
+
 export const weightedAlphaBlendFn = wgslFn( /* wgsl */`
 
 	fn weightedAlphaBlend( prevColor: vec4f, newColor: vec4f, weight: f32 ) -> vec4f {


### PR DESCRIPTION
Related to #770 #777 

Backporting some features from #770 / #804 so it's easier to do compare architectures.

- Add support for russian roulette after three bounces
- Add a check for 0.0 throughput

