### PR TITLE
WebGPUPathTracer: Add kernel for limiting ray dispatch

### DIFF
--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -5,8 +5,9 @@ import { RayIntersectionKernel } from './compute/wavefront/RayIntersectionKernel
 import { UpdateRayQueueParamsKernel } from './compute/wavefront/UpdateRayQueueParamsKernel.js';
 import { ZeroOutBufferKernel } from './compute/ZeroOutBufferKernel.js';
 import { ProcessHitsKernel } from './compute/wavefront/ProcessHitsKernel.js';
+import { QueueLengthToDispatchKernel } from './compute/wavefront/QueueLengthToDispatchKernel.js';
 import { EquirectHdrInfoUniform } from '../uniforms/EquirectHdrInfoUniform.js';
-import { queuedHitStruct, queuedRayStruct } from './compute/wavefront/structs.js';
+import { queuedHitStruct, queuedRayStruct, rayQueueStruct, hitQueueStruct } from './compute/wavefront/structs.js';
 import { PathTracerBackend } from './PathTracerBackend.js';
 
 // set the buffers to the max possible size supported by default (128MB)
@@ -47,6 +48,8 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 		this.rayIntersectionKernel = new RayIntersectionKernel( ).setWorkgroupSize( 64, 1, 1 );
 		this.updateRayQueueParamsKernel = new UpdateRayQueueParamsKernel().setWorkgroupSize( 1, 1, 1 );
 		this.hitProcessKernel = new ProcessHitsKernel( ).setWorkgroupSize( 64, 1, 1 );
+		this.rayDispatchConverter = new QueueLengthToDispatchKernel( rayQueueStruct ).setWorkgroupSize( 1, 1, 1 );
+		this.hitDispatchConverter = new QueueLengthToDispatchKernel( hitQueueStruct ).setWorkgroupSize( 1, 1, 1 );
 
 		// clear kernels
 		this.zeroDispatchKernel = new ZeroOutBufferKernel().setWorkgroupSize( 1, 1, 1 );
@@ -241,6 +244,8 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 			rayIntersectionKernel,
 			updateRayQueueParamsKernel,
 			hitProcessKernel,
+			rayDispatchConverter,
+			hitDispatchConverter,
 
 			lowResMode
 		} = this;
@@ -296,28 +301,29 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 
 				}
 
-				// Step 2: run intersections, add color for terminated rays, add material handling to a dedicated queue
-				// TODO: setting dispatch size to 10000 is causing failures / missed rays
-				const intersectDispatch = rayIntersectionKernel.getDispatchSize( RAYS_TO_PROCESS, 1, 1 );
+				// Step 2: run intersections over exactly the number of queued rays, add color for
+				// terminated rays, add material handling to a dedicated queue
+				rayDispatchConverter.queue = rayQueue;
+				renderer.compute( rayDispatchConverter.kernel, [ 1, 1, 1 ] );
+
 				rayIntersectionKernel.sampleCountTarget = sampleCountTarget;
 				rayIntersectionKernel.rayQueue = rayQueue;
 				rayIntersectionKernel.hitQueue = hitQueue;
-				renderer.compute( rayIntersectionKernel.kernel, intersectDispatch );
+				renderer.compute( rayIntersectionKernel.kernel, rayDispatchConverter.outputDispatch );
 
 				// mark the rays as consumed
-				const processed = intersectDispatch[ 0 ] * rayIntersectionKernel.workgroupSize[ 0 ];
-				updateRayQueueParamsKernel.processed = processed;
 				updateRayQueueParamsKernel.rayQueue = rayQueue;
 				renderer.compute( updateRayQueueParamsKernel.kernel, [ 1, 1, 1 ] );
 
-				// TODO: we should use an indirect dispatch here to only kick off the number of threads
-				// as needed to iterate over all the fields
-				// Step 3: attenuate ray color, scatter, run russian roulette
+				// Step 3: attenuate ray color, scatter, run russian roulette over exactly the queued hits
+				hitDispatchConverter.queue = hitQueue;
+				renderer.compute( hitDispatchConverter.kernel, [ 1, 1, 1 ] );
+
 				hitProcessKernel.sampleCountTarget = sampleCountTarget;
 				hitProcessKernel.bounces = bounces;
 				hitProcessKernel.rayQueue = rayQueue;
 				hitProcessKernel.hitQueue = hitQueue;
-				renderer.compute( hitProcessKernel.kernel, hitProcessKernel.getDispatchSize( processed, 1, 1 ) );
+				renderer.compute( hitProcessKernel.kernel, hitDispatchConverter.outputDispatch );
 				// Note: hit queue size ([2] and [3]) is reset at the top of the next iteration by PrimeRayGenerationDispatchKernel
 
 				// Step 4: connect to lights

--- a/src/webgpu/compute/wavefront/QueueLengthToDispatchKernel.js
+++ b/src/webgpu/compute/wavefront/QueueLengthToDispatchKernel.js
@@ -16,7 +16,9 @@ export class QueueLengthToDispatchKernel extends ComputeKernel {
 			fn compute() -> void {
 
 				let queueLength = ${ params.queue }.end - ${ params.queue }.start;
-				${ params.outputDispatch }[ 0 ] = ( queueLength + 63u ) / 64u;
+
+				// assumes the consuming kernel runs 64 threads per workgroup
+				${ params.outputDispatch }[ 0 ] = u32( ceil( f32( queueLength ) / 64.0 ) );
 				${ params.outputDispatch }[ 1 ] = 1u;
 				${ params.outputDispatch }[ 2 ] = 1u;
 

--- a/src/webgpu/compute/wavefront/QueueLengthToDispatchKernel.js
+++ b/src/webgpu/compute/wavefront/QueueLengthToDispatchKernel.js
@@ -1,0 +1,32 @@
+import { wgslTagFn } from 'three-mesh-bvh/webgpu';
+import { ComputeKernel } from '../ComputeKernel.js';
+import { storage } from 'three/tsl';
+import { IndirectStorageBufferAttribute, StorageBufferAttribute } from 'three/webgpu';
+
+export class QueueLengthToDispatchKernel extends ComputeKernel {
+
+	constructor( queueStruct ) {
+
+		const params = {
+			queue: storage( new StorageBufferAttribute( 1, 1 ), queueStruct ),
+			outputDispatch: storage( new IndirectStorageBufferAttribute( 3, 1 ), 'u32' ).setName( 'outputDispatch' ),
+		};
+
+		const fn = wgslTagFn/* wgsl */`
+			fn compute() -> void {
+
+				let queueLength = ${ params.queue }.end - ${ params.queue }.start;
+				${ params.outputDispatch }[ 0 ] = ( queueLength + 63u ) / 64u;
+				${ params.outputDispatch }[ 1 ] = 1u;
+				${ params.outputDispatch }[ 2 ] = 1u;
+
+			}
+		`;
+
+		super( fn( params ) );
+
+		this.defineUniformAccessors( params );
+
+	}
+
+}

--- a/src/webgpu/compute/wavefront/UpdateRayQueueParamsKernel.js
+++ b/src/webgpu/compute/wavefront/UpdateRayQueueParamsKernel.js
@@ -1,5 +1,5 @@
 import { StorageBufferAttribute } from 'three/webgpu';
-import { uniform, storage } from 'three/tsl';
+import { storage } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { rayQueueStruct } from './structs.js';
@@ -9,24 +9,17 @@ export class UpdateRayQueueParamsKernel extends ComputeKernel {
 	constructor() {
 
 		const params = {
-			processed: uniform( 0 ),
 			rayQueue: storage( new StorageBufferAttribute( 1, 1 ), rayQueueStruct ),
 		};
 
 		const fn = wgslTagFn/* wgsl */`
-			fn compute( processed: u32 ) -> void {
+			fn compute() -> void {
 
 				let rayQueue = &${ params.rayQueue };
-			    var queueSize = rayQueue.end - rayQueue.start;
-				if ( processed > queueSize ) {
 
-					rayQueue.start = rayQueue.end;
-
-				} else {
-
-					rayQueue.start = rayQueue.start + processed;
-
-				}
+				// the intersection kernel is dispatched indirectly over the exact queue length, so
+				// every queued ray has been consumed
+				rayQueue.start = rayQueue.end;
 
 			}
 		`;


### PR DESCRIPTION
Related to #770, #804

Migrate exact queue size dispatch from #770 to the main webgpu-pathtracer for more simply comparing architecture performance.