### PR TITLE
WebGPUPathTracer: Add support for filter glossy, based on blender-cycles

### DIFF
--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -40,7 +40,7 @@ const params = {
 	// path tracer settings
 	bounces: 5,
 	renderScale: 1 / window.devicePixelRatio,
-	filterGlossyFactor: 0.5,
+	filterGlossyFactor: 1,
 	tiles: 1,
 	multipleImportanceSampling: true,
 
@@ -144,7 +144,7 @@ async function init() {
 		pathTracer.tiles.set( value, value );
 
 	} );
-	ptFolder.add( params, 'filterGlossyFactor', 0, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'filterGlossyFactor', 0, 10 ).onChange( onParamsChange );
 	ptFolder.add( params, 'bounces', 1, 15, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'multipleImportanceSampling' ).onChange( onParamsChange );

--- a/example/index.js
+++ b/example/index.js
@@ -111,7 +111,7 @@ const params = {
 	enable: true,
 	useMegakernel: false,
 	bounces: 5,
-	filterGlossyFactor: 0.5,
+	filterGlossyFactor: 1,
 	pause: false,
 	debugBounds: false,
 	displayTLAS: true,
@@ -433,7 +433,7 @@ function buildGui() {
 
 	} );
 	pathTracingFolder.add( params, 'bounces', 1, 20, 1 ).onChange( onParamsChange );
-	pathTracingFolder.add( params, 'filterGlossyFactor', 0, 1 ).onChange( onParamsChange );
+	pathTracingFolder.add( params, 'filterGlossyFactor', 0, 10 ).onChange( onParamsChange );
 	pathTracingFolder.add( params, 'renderScale', 0.1, 1.0, 0.01 ).onChange( () => {
 
 		onParamsChange();

--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -48,7 +48,7 @@ const params = {
 	bounces: 5,
 	renderScale: 1 / window.devicePixelRatio,
 	transmissiveBounces: 20,
-	filterGlossyFactor: 0.5,
+	filterGlossyFactor: 1,
 	tiles: 3,
 };
 
@@ -157,7 +157,7 @@ async function init() {
 		pathTracer.tiles.set( value, value );
 
 	} );
-	ptFolder.add( params, 'filterGlossyFactor', 0, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'filterGlossyFactor', 0, 10 ).onChange( onParamsChange );
 	ptFolder.add( params, 'bounces', 1, 30, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'transmissiveBounces', 0, 40, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );

--- a/example/overlay.js
+++ b/example/overlay.js
@@ -34,7 +34,7 @@ const params = {
 	// path tracer settings
 	bounces: 5,
 	renderScale: 1 / window.devicePixelRatio,
-	filterGlossyFactor: 0.5,
+	filterGlossyFactor: 1,
 	tiles: 1,
 	multipleImportanceSampling: true,
 
@@ -131,7 +131,7 @@ async function init() {
 		pathTracer.tiles.set( value, value );
 
 	} );
-	ptFolder.add( params, 'filterGlossyFactor', 0, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'filterGlossyFactor', 0, 10 ).onChange( onParamsChange );
 	ptFolder.add( params, 'bounces', 1, 15, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'multipleImportanceSampling' ).onChange( onParamsChange );

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -1,5 +1,6 @@
 import { Matrix4, Vector2 } from 'three/webgpu';
 import { PathTracerMegaKernel } from './compute/PathTracerMegaKernel.js';
+import { FILTER_GLOSSY_DISABLED } from './nodes/material.wgsl.js';
 import { EquirectHdrInfoUniform } from '../uniforms/EquirectHdrInfoUniform.js';
 import { PathTracerBackend } from './PathTracerBackend.js';
 
@@ -45,6 +46,14 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 
 		this.kernel.material = material.getData();
 		this.kernel.needsUpdate = true;
+		this.reset();
+
+	}
+
+	setFilterGlossy( value ) {
+
+		// the kernel takes the inverted threshold, mirroring Cycles
+		this.kernel.filterGlossy = value === 0 ? FILTER_GLOSSY_DISABLED : 1 / value;
 		this.reset();
 
 	}

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -54,6 +54,10 @@ export class PathTracerBackend {
 
 	}
 
+	setFilterGlossy( value ) {
+
+	}
+
 	setEnvironment(
 		envMap,
 		envMapIntensity,

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -6,6 +6,7 @@ import { UpdateRayQueueParamsKernel } from './compute/wavefront/UpdateRayQueuePa
 import { ZeroOutBufferKernel } from './compute/ZeroOutBufferKernel.js';
 import { ProcessHitsKernel } from './compute/wavefront/ProcessHitsKernel.js';
 import { EquirectHdrInfoUniform } from '../uniforms/EquirectHdrInfoUniform.js';
+import { FILTER_GLOSSY_DISABLED } from './nodes/material.wgsl.js';
 import { queuedHitStruct, queuedRayStruct } from './compute/wavefront/structs.js';
 import { PathTracerBackend } from './PathTracerBackend.js';
 
@@ -97,6 +98,14 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 
 		this.hitProcessKernel.material = material.getData();
 		this.hitProcessKernel.needsUpdate = true;
+		this.reset();
+
+	}
+
+	setFilterGlossy( value ) {
+
+		// the kernel takes the inverted threshold, mirroring Cycles
+		this.hitProcessKernel.filterGlossy = value === 0 ? FILTER_GLOSSY_DISABLED : 1 / value;
 		this.reset();
 
 	}

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -129,6 +129,19 @@ export class WebGPUPathTracer {
 
 	}
 
+	get filterGlossyFactor() {
+
+		return this._filterGlossyFactor;
+
+	}
+
+	set filterGlossyFactor( v ) {
+
+		this._filterGlossyFactor = v;
+		this._pathTracer?.setFilterGlossy( v );
+
+	}
+
 	// --- WebGLPathTracer compatibility stubs ---
 	// These mirror the WebGLPathTracer API surface so existing examples run unchanged.
 	// They are currently no-ops on the WebGPU path tracer until the corresponding
@@ -168,6 +181,7 @@ export class WebGPUPathTracer {
 		this._pathTracer.setBVHData( this._bvhData );
 		this._pathTracer.setMaterial( this.material );
 		this._pathTracer.setRandom( this.random );
+		this._pathTracer.setFilterGlossy( this._filterGlossyFactor );
 		this.setCamera( this.camera );
 		this.updateEnvironment();
 
@@ -205,11 +219,12 @@ export class WebGPUPathTracer {
 		this.stableNoise = false;
 		this.pause = false;
 
+		this.filterGlossyFactor = 1;
+
 		// WebGLPathTracer compatibility stubs (see getters above)
 		// TOOD: implement these correctly
 		this.multipleImportanceSampling = true;
 		this.transmissiveBounces = 5;
-		this.filterGlossyFactor = 0;
 
 		this.random = null;
 		this.material = new GltfCompliantMaterial();

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -137,8 +137,12 @@ export class WebGPUPathTracer {
 
 	set filterGlossyFactor( v ) {
 
-		this._filterGlossyFactor = v;
-		this._pathTracer.setFilterGlossy( v );
+		if ( this._filterGlossyFactor !== v ) {
+
+			this._filterGlossyFactor = v;
+			this._pathTracer.setFilterGlossy( v );
+
+		}
 
 	}
 

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -138,7 +138,7 @@ export class WebGPUPathTracer {
 	set filterGlossyFactor( v ) {
 
 		this._filterGlossyFactor = v;
-		this._pathTracer?.setFilterGlossy( v );
+		this._pathTracer.setFilterGlossy( v );
 
 	}
 
@@ -206,6 +206,8 @@ export class WebGPUPathTracer {
 		this._lowResTarget.type = FloatType;
 		this._lowResTarget.generateMipmaps = false;
 
+		this._pathTracer = new WaveFrontPathTracer( renderer );
+
 		// options
 		this.minSamples = 1;
 		this.renderDelay = 500;
@@ -228,7 +230,6 @@ export class WebGPUPathTracer {
 
 		this.random = null;
 		this.material = new GltfCompliantMaterial();
-		this._pathTracer = new WaveFrontPathTracer( renderer );
 
 		// default camera ray generation ( perspective / orthographic ), assigned onto each bvh compute
 		// data's fns so the kernels can proxy it. The uniform is the inverse view-projection

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -22,6 +22,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			tileSize: uniform( new Vector2() ),
 			seed: uniform( 0 ),
 			bounces: uniform( 5 ),
+			filterGlossy: uniform( 1 ),
 
 			// environment
 			envMap: texture( new DataTexture() ),
@@ -63,6 +64,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				// settings
 				seed: u32,
 				bounces: u32,
+				filterGlossy: f32,
 
 				// environment
 				envMap: texture_2d<f32>,
@@ -119,6 +121,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				var resultColor = vec4f( 0, 0, 0, 1 );
 				var throughputColor = vec3f( 1.0 );
+				var minPdf = 1.0;
 
 				for ( var bounce = 0u; bounce < bounces; bounce ++ ) {
 
@@ -136,7 +139,9 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 						vertexData.position = object.matrixWorld * vertexData.position;
 
-						let surface = ${ getSurfaceRecordFn }( material, vertexData, hitResult.side, hitResult.normal );
+						let blurRoughness = sqrt( clamp( 1.0 - filterGlossy * minPdf, 0.0, 1.0 ) ) * 0.5;
+
+						let surface = ${ getSurfaceRecordFn }( material, vertexData, hitResult.side, hitResult.normal, blurRoughness );
 
 						resultColor += vec4f( throughputColor * surface.emission, 0.0 );
 
@@ -147,6 +152,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 							break;
 
 						}
+
+						minPdf = min( minPdf, scatterRec.pdf );
 
 						// russian roulette early out
 						if ( bounce >= 3u ) {

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -140,6 +140,9 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 						vertexData.position = object.matrixWorld * vertexData.position;
 
+						// blur glossy surfaces after low-probability bounces to suppress fireflies,
+						// from the Cycles "filter glossy" approach in integrator/surface_shader.h
+						// The smallest pdf seen along the path for the glossy filter is tracked below
 						let blurRoughness = sqrt( clamp( 1.0 - filterGlossy * minPdf, 0.0, 1.0 ) ) * 0.5;
 
 						let surface = ${ getSurfaceRecordFn }( material, vertexData, hitResult.side, hitResult.normal, view, blurRoughness );

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -82,6 +82,9 @@ export class ProcessHitsKernel extends ComputeKernel {
 				vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 				vertexData.position = object.matrixWorld * vertexData.position;
 
+				// blur glossy surfaces after low-probability bounces to suppress fireflies,
+				// from the Cycles "filter glossy" approach in integrator/surface_shader.h
+				// The smallest pdf seen along the path for the glossy filter is tracked below
 				let blurRoughness = sqrt( clamp( 1.0 - filterGlossy * input.minPdf, 0.0, 1.0 ) ) * 0.5;
 
 				let surface = ${ getSurfaceRecordFn }( material, vertexData, input.side, input.normal, input.view, blurRoughness );

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -22,6 +22,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 			// settings
 			smoothNormals: uniform( 1 ),
 			bounces: uniform( 1 ),
+			filterGlossy: uniform( 1 ),
 
 			// rays
 			rayQueue: storage( new StorageBufferAttribute( 1, 1 ), rayQueueAtomicStruct ),
@@ -43,6 +44,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 				// settings
 				smoothNormals: u32,
 				bounces: u32,
+				filterGlossy: f32,
 
 				globalId: vec3u
 			) -> void {
@@ -80,7 +82,9 @@ export class ProcessHitsKernel extends ComputeKernel {
 				vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
 				vertexData.position = object.matrixWorld * vertexData.position;
 
-				let surface = ${ getSurfaceRecordFn }( material, vertexData, input.side, input.normal );
+				let blurRoughness = sqrt( clamp( 1.0 - filterGlossy * input.minPdf, 0.0, 1.0 ) ) * 0.5;
+
+				let surface = ${ getSurfaceRecordFn }( material, vertexData, input.side, input.normal, blurRoughness );
 
 				let scatterRec = ${ bsdfSampleFn }( input.view, surface );
 
@@ -131,6 +135,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 					rayQueue.elements[ index ].currentBounce = input.currentBounce + 1;
 					rayQueue.elements[ index ].resultColor = resultColor;
 					rayQueue.elements[ index ].seed = input.seed;
+					rayQueue.elements[ index ].minPdf = min( scatterRec.pdf, input.minPdf );
 
 				}
 

--- a/src/webgpu/compute/wavefront/RayGenerationKernel.js
+++ b/src/webgpu/compute/wavefront/RayGenerationKernel.js
@@ -87,6 +87,7 @@ export class RayGenerationKernel extends ComputeKernel {
 				rayQueue.elements[ index ].currentBounce = 0;
 				rayQueue.elements[ index ].resultColor = vec4f( 0.0, 0.0, 0.0, 1.0 );
 				rayQueue.elements[ index ].seed = seed + samples;
+				rayQueue.elements[ index ].minPdf = 1.0;
 
 				// write the active params
 				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( ACTIVE_FLAG | samples ) );

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -106,6 +106,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 					hitQueue.elements[ index ].currentBounce = input.currentBounce;
 					hitQueue.elements[ index ].resultColor = input.resultColor;
 					hitQueue.elements[ index ].seed = input.seed;
+					hitQueue.elements[ index ].minPdf = input.minPdf;
 
 				} else {
 

--- a/src/webgpu/compute/wavefront/structs.js
+++ b/src/webgpu/compute/wavefront/structs.js
@@ -38,6 +38,8 @@ export const queuedRayStruct = new StructTypeNode( {
 	currentBounce: 'uint',
 
 	pixel: 'vec2u',
+	minPdf: 'float',
+	_alignment1: 'uint',
 
 	resultColor: 'vec4f',
 
@@ -60,6 +62,11 @@ export const queuedHitStruct = new StructTypeNode( {
 
 	normal: 'vec3f',
 	side: 'float',
+
+	minPdf: 'float',
+	_alignment0: 'uint',
+	_alignment1: 'uint',
+	_alignment2: 'uint',
 
 	resultColor: 'vec4f',
 

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -19,6 +19,10 @@ import { constants, surfaceRecordStruct } from './structs.wgsl.js';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
 
 // Builds getSurfaceRecord using the given per-instance sampleTexel and uv channel lookup
+// Sentinel for a disabled glossy filter ( FLT_MAX, mirroring Cycles ): the blur term
+// clamps to zero for any path pdf when the inverted filter value is this large.
+export const FILTER_GLOSSY_DISABLED = 3.402823466e38;
+
 export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) => wgslFn( /* wgsl */ `
 
 	fn getSurfaceRecord(
@@ -26,6 +30,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 		vertexData: bvh_GeometryStruct,
 		side: f32,
 		faceNormal: vec3f,
+		blurRoughness: f32,
 	) -> SurfaceRecord {
 
 		var normal = faceNormal * side;
@@ -286,9 +291,10 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 		surf.sheen = material.sheen;
 		surf.sheenColor = sheenColor;
 
-		surf.roughness = clamp( roughness, MIN_ROUGHNESS, 1.0 );
-		surf.clearcoatRoughness = clamp( clearcoatRoughness, MIN_ROUGHNESS, 1.0 );
-		surf.sheenRoughness = clamp( sheenRoughness, MIN_ROUGHNESS, 1.0 );
+		let minRoughness = max( MIN_ROUGHNESS, blurRoughness );
+		surf.roughness = clamp( roughness, minRoughness, 1.0 );
+		surf.clearcoatRoughness = clamp( clearcoatRoughness, minRoughness, 1.0 );
+		surf.sheenRoughness = clamp( sheenRoughness, minRoughness, 1.0 );
 		surf.anisotropy = saturate( anisotropyStrength );
 
 		// frontFace is used to determine transmissive properties and PDF. If no transmission is used


### PR DESCRIPTION
Related to #770, #777, #804

Add support for filter glossy factor, based on the blender cycles approach (also followed in #770). The field is exposed the same as in blender. Also adjusts the demos to default the factor to 1.0, mirroring the class & blender, and adjusts the input ranges for the UI.