### PR TITLE
WebGPUPathTracer: Add Transmission Support

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -207,7 +207,6 @@ async function init() {
 	pathTracer = new WebGPUPathTracer( renderer );
 	pathTracer.tiles.set( params.tiles, params.tiles );
 	pathTracer.multipleImportanceSampling = params.multipleImportanceSampling;
-	pathTracer.transmissiveBounces = 10;
 	pathTracer.useMegakernel( params.useMegakernel );
 
 	// camera

--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -26,7 +26,7 @@ const params = {
 		metalness: 1,
 		ior: 1.495,
 		transmission: 0.0,
-		thinFilm: false,
+		thinWall: false,
 		attenuationColor: '#ffffff',
 		attenuationDistance: 0.5,
 		opacity: 1.0,
@@ -168,7 +168,7 @@ async function init() {
 	matFolder1.add( params.materialProperties, 'metalness', 0, 1 ).onChange( onParamsChange );
 	matFolder1.add( params.materialProperties, 'opacity', 0, 1 ).onChange( onParamsChange );
 	matFolder1.add( params.materialProperties, 'transmission', 0, 1 ).onChange( onParamsChange );
-	matFolder1.add( params.materialProperties, 'thinFilm', 0, 1 ).onChange( onParamsChange );
+	matFolder1.add( params.materialProperties, 'thinWall', 0, 1 ).onChange( onParamsChange );
 	matFolder1.add( params.materialProperties, 'attenuationDistance', 0.05, 2.0 ).onChange( onParamsChange );
 	matFolder1.addColor( params.materialProperties, 'attenuationColor' ).onChange( onParamsChange );
 	matFolder1.add( params.materialProperties, 'ior', 0.9, 3.0 ).onChange( onParamsChange );
@@ -209,7 +209,7 @@ function onParamsChange() {
 	material.metalness = materialProperties.metalness;
 	material.roughness = materialProperties.roughness;
 	material.transmission = materialProperties.transmission;
-	material.attenuationDistance = materialProperties.thinFilm ? Infinity : materialProperties.attenuationDistance;
+	material.attenuationDistance = materialProperties.thinWall ? Infinity : materialProperties.attenuationDistance;
 	material.attenuationColor.set( materialProperties.attenuationColor );
 	material.ior = materialProperties.ior;
 	material.opacity = materialProperties.opacity;

--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -47,7 +47,6 @@ const params = {
 	multipleImportanceSampling: true,
 	bounces: 5,
 	renderScale: 1 / window.devicePixelRatio,
-	transmissiveBounces: 20,
 	filterGlossyFactor: 0.5,
 	tiles: 3,
 };
@@ -159,7 +158,6 @@ async function init() {
 	} );
 	ptFolder.add( params, 'filterGlossyFactor', 0, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'bounces', 1, 30, 1 ).onChange( onParamsChange );
-	ptFolder.add( params, 'transmissiveBounces', 0, 40, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );
 
 	const matFolder1 = gui.addFolder( 'Material' );
@@ -227,7 +225,6 @@ function onParamsChange() {
 	material.transparent = material.opacity < 1;
 	material.flatShading = materialProperties.flatShading;
 
-	pathTracer.transmissiveBounces = params.transmissiveBounces;
 	pathTracer.multipleImportanceSampling = params.multipleImportanceSampling;
 	pathTracer.filterGlossyFactor = params.filterGlossyFactor;
 	pathTracer.bounces = params.bounces;

--- a/example/viewerTest.js
+++ b/example/viewerTest.js
@@ -35,7 +35,6 @@ const params = {
 
 	enable: true,
 	bounces: 10,
-	transmissiveBounces: 10,
 	pause: false,
 	multipleImportanceSampling: true,
 	acesToneMapping: true,
@@ -256,7 +255,6 @@ function onParamsChange() {
 
 	pathTracer.multipleImportanceSampling = params.multipleImportanceSampling;
 	pathTracer.bounces = params.bounces;
-	pathTracer.transmissiveBounces = params.transmissiveBounces;
 	pathTracer.renderScale = params.scale;
 
 	const model = modelDatabase[ params.model ];
@@ -331,7 +329,6 @@ function buildGui() {
 
 	} );
 	pathTracingFolder.add( params, 'bounces', 1, 20, 1 ).onChange( onParamsChange );
-	pathTracingFolder.add( params, 'transmissiveBounces', 1, 20, 1 ).onChange( onParamsChange );
 
 	pathTracingFolder.add( params, 'iterationsPerFrame', 1, 30, 1 );
 

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -95,6 +95,13 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 
 	}
 
+	setTransmissiveBackground( value ) {
+
+		this.kernel.transmissiveBackground = value;
+		this.reset();
+
+	}
+
 	setTiles( tiles ) {
 
 		this.tiles.copy( tiles );

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -147,6 +147,13 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 
 	}
 
+	setTransmissiveBackground( value ) {
+
+		this.rayIntersectionKernel.transmissiveBackground = value;
+		this.reset();
+
+	}
+
 	setTiles( tiles ) {
 
 		this.tiles.copy( tiles );

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -17,7 +17,7 @@ const RAYS_TO_PROCESS = 250000;
 
 // Both queues use the same element count so the hit queue can never overflow - every intersected
 // ray produces at most one hit, so hits are bounded by the ray queue capacity.
-const MAX_QUEUE_COUNT = RAYS_TO_PROCESS * 2;
+const MAX_QUEUE_COUNT = RAYS_TO_PROCESS * 5;
 
 export class WaveFrontPathTracer extends PathTracerBackend {
 

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -208,7 +208,6 @@ export class WebGPUPathTracer {
 		// WebGLPathTracer compatibility stubs (see getters above)
 		// TOOD: implement these correctly
 		this.multipleImportanceSampling = true;
-		this.transmissiveBounces = 5;
 		this.filterGlossyFactor = 0;
 
 		this.random = null;

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -138,8 +138,12 @@ export class WebGPUPathTracer {
 
 	set transmissiveBackground( v ) {
 
-		this._transmissiveBackground = v;
-		this._pathTracer.setTransmissiveBackground( v );
+		if ( this._transmissiveBackground !== v ) {
+
+			this._transmissiveBackground = v;
+			this._pathTracer.setTransmissiveBackground( v );
+
+		}
 
 	}
 

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -12,6 +12,7 @@ import { PathtracerBVHComputeData } from './nodes/PathtracerBVHComputeData.js';
 import { AtlasDebugMaterial } from './materials/debug/AtlasDebugMaterial.js';
 import { setCommonAttributes } from '../core/utils/GeometryPreparationUtils.js';
 import { GltfCompliantMaterial } from './materials/GltfCompliantMaterial.js';
+import { TRANSMISSIVE_BACKGROUND_OVERLAY } from './constants.js';
 
 const _resolution = new Vector2();
 const _color = new Color();
@@ -129,6 +130,19 @@ export class WebGPUPathTracer {
 
 	}
 
+	get transmissiveBackground() {
+
+		return this._transmissiveBackground;
+
+	}
+
+	set transmissiveBackground( v ) {
+
+		this._transmissiveBackground = v;
+		this._pathTracer.setTransmissiveBackground( v );
+
+	}
+
 	// --- WebGLPathTracer compatibility stubs ---
 	// These mirror the WebGLPathTracer API surface so existing examples run unchanged.
 	// They are currently no-ops on the WebGPU path tracer until the corresponding
@@ -168,6 +182,7 @@ export class WebGPUPathTracer {
 		this._pathTracer.setBVHData( this._bvhData );
 		this._pathTracer.setMaterial( this.material );
 		this._pathTracer.setRandom( this.random );
+		this._pathTracer.setTransmissiveBackground( this._transmissiveBackground );
 		this.setCamera( this.camera );
 		this.updateEnvironment();
 
@@ -213,6 +228,7 @@ export class WebGPUPathTracer {
 		this.random = null;
 		this.material = new GltfCompliantMaterial();
 		this._pathTracer = new WaveFrontPathTracer( renderer );
+		this.transmissiveBackground = TRANSMISSIVE_BACKGROUND_OVERLAY;
 
 		// default camera ray generation ( perspective / orthographic ), assigned onto each bvh compute
 		// data's fns so the kernels can proxy it. The uniform is the inverse view-projection

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -217,37 +217,47 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						} else {
 
-							// camera rays show the background directly while rays that have only passed
-							// through transmissive surfaces handle it based on the transmissive background
-							// mode: ENVIRONMENT displays the environment through the glass, TRANSPARENT
-							// lets a transparent background composite through by the average transmitted
-							// throughput, and OVERLAY does both so the glass keeps a tint matching the
-							// rest of the model.
+							// hit the background
+							// support multiple transparent background blending techniques
 							let bg = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, ray.direction, rng );
 							if ( bounce == 0u ) {
 
+								// sample the background directly if this is the primary ray
 								resultColor = vec4f( bg.a * bg.rgb, bg.a );
 
 							} else {
 
+								// transmissive ray handling
 								let env = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, ray.direction, rng );
-								var light = mix( env.rgb, bg.rgb, bg.a );
-								var transparency = ( 1.0 - bg.a ) * saturate( dot( throughputColor, vec3f( 1.0 / 3.0 ) ) );
+								let avg = saturate( dot( throughputColor, vec3f( 1.0 / 3.0 ) ) );
+								let transparency = ( 1.0 - bg.a ) * avg;
+
 								if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
-									light = env.rgb;
-									transparency = 0.0;
+									// display the env map through transmissive surfaces
+									resultColor = vec4f(
+										resultColor.rgb + env.rgb * throughputColor,
+										1.0,
+									);
 
 								} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
 
-									light = bg.a * bg.rgb;
+									// fade the background by the throughput color average
+									resultColor = vec4f(
+										resultColor.rgb + bg.a * bg.rgb * throughputColor,
+										1.0 - transparency,
+									);
+
+								} else {
+
+									// fade the background by the throughput color average, mixing in env lighting
+									var light = mix( env.rgb, bg.rgb, bg.a );
+									resultColor = vec4f(
+										resultColor.rgb + light * throughputColor,
+										1.0 - transparency,
+									);
 
 								}
-
-								resultColor = vec4f(
-									resultColor.rgb + light * throughputColor,
-									1.0 - transparency,
-								);
 
 							}
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -5,6 +5,8 @@ import { rngInit, rngNextBounce, rand1, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_E
 import { sampleEnvironmentFn, weightedAlphaBlendFn, luminanceFn } from '../nodes/sampling.wgsl.js';
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
+import { transmissionAttenuationFunc } from '../nodes/material.wgsl.js';
+import { SCATTER_RECORD_FLAG_TRANSMISSIVE } from '../nodes/structs.wgsl.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
 
@@ -119,6 +121,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				var resultColor = vec4f( 0, 0, 0, 1 );
 				var throughputColor = vec3f( 1.0 );
+				var isFullyTransmissive = true;
 
 				for ( var bounce = 0u; bounce < bounces; bounce ++ ) {
 
@@ -138,6 +141,13 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						let surface = ${ getSurfaceRecordFn }( material, vertexData, hitResult.side, hitResult.normal );
 
+						// attenuate the light transmitted through the volume when exiting a backface
+						if ( hitResult.side < 0.0 ) {
+
+							throughputColor *= ${ transmissionAttenuationFunc }( hitResult.dist, material.attenuationColor, material.attenuationDistance );
+
+						}
+
 						resultColor += vec4f( throughputColor * surface.emission, 0.0 );
 
 						let scatterRec = ${ bsdfSampleFn }( - ray.direction, surface );
@@ -147,6 +157,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 							break;
 
 						}
+
+						isFullyTransmissive = isFullyTransmissive && ( ( scatterRec.flags & ${ SCATTER_RECORD_FLAG_TRANSMISSIVE }u ) > 0 );
 
 						// russian roulette early out
 						if ( bounce >= 3u ) {
@@ -183,12 +195,14 @@ export class PathTracerMegaKernel extends ComputeKernel {
 					} else {
 
 						let rng = ${ rand2 }( ${ RNG_INDEX_ENVIRONMENT_SAMPLE } );
-						if ( bounce > 0u ) {
+						if ( bounce > 0u && ! isFullyTransmissive ) {
 
 							resultColor += ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, ray.direction, rng ) * vec4f( throughputColor, 0.0 );
 
 						} else {
 
+							// camera rays and rays that have only passed through transmissive surfaces
+							// show the background so it appears through glass
 							resultColor = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, ray.direction, rng );
 
 						}

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -7,7 +7,7 @@ import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
 import { transmissionAttenuationFunc } from '../nodes/material.wgsl.js';
 import { SCATTER_RECORD_FLAG_TRANSMISSIVE } from '../nodes/structs.wgsl.js';
-import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../constants.js';
+import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_OVERLAY, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../constants.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
 
@@ -39,7 +39,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			backgroundIntensity: uniform( 1 ),
 			backgroundBlurriness: uniform( 0 ),
 
-			transmissiveBackground: uniform( 1 ),
+			transmissiveBackground: uniform( TRANSMISSIVE_BACKGROUND_OVERLAY ),
 
 			textures: texture( new DataTexture() ),
 			textureSampler: sampler( new DataTexture() ),

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -7,6 +7,7 @@ import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
 import { transmissionAttenuationFunc } from '../nodes/material.wgsl.js';
 import { SCATTER_RECORD_FLAG_TRANSMISSIVE } from '../nodes/structs.wgsl.js';
+import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../constants.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
 
@@ -36,6 +37,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			backgroundRotation: uniform( new Matrix3() ),
 			backgroundIntensity: uniform( 1 ),
 			backgroundBlurriness: uniform( 0 ),
+
+			transmissiveBackground: uniform( 1 ),
 
 			textures: texture( new DataTexture() ),
 			textureSampler: sampler( new DataTexture() ),
@@ -77,6 +80,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				backgroundRotation: mat3x3f,
 				backgroundIntensity: f32,
 				backgroundBlurriness: f32,
+
+				transmissiveBackground: u32,
 
 			) -> void {
 
@@ -201,9 +206,39 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						} else {
 
-							// camera rays and rays that have only passed through transmissive surfaces
-							// show the background so it appears through glass
-							resultColor = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, ray.direction, rng );
+							// camera rays show the background directly while rays that have only passed
+							// through transmissive surfaces handle it based on the transmissive background
+							// mode: ENVIRONMENT displays the environment through the glass, TRANSPARENT
+							// lets a transparent background composite through by the average transmitted
+							// throughput, and OVERLAY does both so the glass keeps a tint matching the
+							// rest of the model.
+							let bg = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, ray.direction, rng );
+							if ( bounce == 0u ) {
+
+								resultColor = vec4f( bg.a * bg.rgb, bg.a );
+
+							} else {
+
+								let env = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, ray.direction, rng );
+								var light = mix( env.rgb, bg.rgb, bg.a );
+								var transparency = ( 1.0 - bg.a ) * dot( throughputColor, vec3f( 1.0 / 3.0 ) );
+								if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
+
+									light = env.rgb;
+									transparency = 0.0;
+
+								} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
+
+									light = bg.a * bg.rgb;
+
+								}
+
+								resultColor = vec4f(
+									resultColor.rgb + light * throughputColor,
+									1.0 - transparency,
+								);
+
+							}
 
 						}
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -154,17 +154,17 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						let blurRoughness = sqrt( clamp( 1.0 - filterGlossy * minPdf, 0.0, 1.0 ) ) * 0.5;
 
 						let surface = ${ getSurfaceRecordFn }( material, vertexData, hitResult.side, hitResult.normal, view, blurRoughness );
+						let scatterRec = ${ bsdfSampleFn }( view, surface );
 
 						// attenuate the light transmitted through the volume when exiting a backface
-						if ( hitResult.side < 0.0 ) {
+						if ( hitResult.side < 0.0 && material.transmission > 0.0 ) {
 
 							throughputColor *= ${ transmissionAttenuationFunc }( hitResult.dist, material.attenuationColor, material.attenuationDistance );
 
 						}
 
+						// emission
 						resultColor += vec4f( throughputColor * surface.emission, 0.0 );
-
-						let scatterRec = ${ bsdfSampleFn }( view, surface );
 
 						if ( ${ isTerminatingScatterFunc }( scatterRec ) ) {
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -145,6 +145,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						let view = - ray.direction;
 						var vertexData = ${ sampleTrianglePointFn }( hitResult.barycoord, hitResult.indices.xyz );
 						vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
+						vertexData.tangent = vec4f( ( object.matrixWorld * vec4f( vertexData.tangent.xyz, 0.0 ) ).xyz, vertexData.tangent.w );
 						vertexData.position = object.matrixWorld * vertexData.position;
 
 						// blur glossy surfaces after low-probability bounces to suppress fireflies,

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -6,7 +6,6 @@ import { sampleEnvironmentFn, weightedAlphaBlendFn, luminanceFn } from '../nodes
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
 import { transmissionAttenuationFunc } from '../nodes/material.wgsl.js';
-import { SCATTER_RECORD_FLAG_TRANSMISSIVE } from '../nodes/structs.wgsl.js';
 import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_OVERLAY, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../constants.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
@@ -172,7 +171,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						}
 
-						isFullyTransmissive = isFullyTransmissive && ( ( scatterRec.flags & ${ SCATTER_RECORD_FLAG_TRANSMISSIVE }u ) > 0 );
+						isFullyTransmissive = isFullyTransmissive && scatterRec.isTransmissive;
 
 						// track the smallest pdf seen along the path for the glossy filter
 						minPdf = min( minPdf, scatterRec.pdf );

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -221,7 +221,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 								let env = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, ray.direction, rng );
 								var light = mix( env.rgb, bg.rgb, bg.a );
-								var transparency = ( 1.0 - bg.a ) * dot( throughputColor, vec3f( 1.0 / 3.0 ) );
+								var transparency = ( 1.0 - bg.a ) * saturate( dot( throughputColor, vec3f( 1.0 / 3.0 ) ) );
 								if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
 									light = env.rgb;

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -90,18 +90,18 @@ export class ProcessHitsKernel extends ComputeKernel {
 				let blurRoughness = sqrt( clamp( 1.0 - filterGlossy * input.minPdf, 0.0, 1.0 ) ) * 0.5;
 
 				let surface = ${ getSurfaceRecordFn }( material, vertexData, input.side, input.normal, input.view, blurRoughness );
+				let scatterRec = ${ bsdfSampleFn }( input.view, surface );
 
 				var throughputColor = input.throughputColor;
 
 				// attenuate the light transmitted through the volume when exiting a backface
-				if ( input.side < 0.0 ) {
+				if ( input.side < 0.0 && material.transmission > 0.0 ) {
 
 					throughputColor *= ${ transmissionAttenuationFunc }( input.dist, material.attenuationColor, material.attenuationDistance );
 
 				}
 
-				let scatterRec = ${ bsdfSampleFn }( input.view, surface );
-
+				// emission
 				let resultColor = input.resultColor + vec4f( throughputColor * surface.emission, 0.0 );
 
 				var isTerminated = input.currentBounce >= bounces || ${ isTerminatingScatterFunc }( scatterRec );

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -81,6 +81,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 				let barycoord = vec3( input.barycoord, 1.0 - input.barycoord.x - input.barycoord.y );
 				var vertexData = ${ sampleTrianglePointFn }( barycoord, input.indices.xyz );
 				vertexData.normal = normalize( transpose( object.inverseMatrixWorld ) * vertexData.normal );
+				vertexData.tangent = vec4f( ( object.matrixWorld * vec4f( vertexData.tangent.xyz, 0.0 ) ).xyz, vertexData.tangent.w );
 				vertexData.position = object.matrixWorld * vertexData.position;
 
 				// blur glossy surfaces after low-probability bounces to suppress fireflies,

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -1,11 +1,13 @@
 import { StorageBufferAttribute, StorageTexture, DataTexture } from 'three/webgpu';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { uniform, storage, textureStore, globalId, texture, sampler } from 'three/tsl';
-import { rayQueueAtomicStruct, hitQueueStruct } from './structs.js';
+import { rayQueueAtomicStruct, hitQueueStruct, RAY_FLAG_FULLY_TRANSMISSIVE } from './structs.js';
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { weightedAlphaBlendFn, luminanceFn } from '../../nodes/sampling.wgsl.js';
 import { isTerminatingScatterFunc } from '../../nodes/utils.wgsl.js';
 import { rngInit, rand1, RNG_INDEX_RUSSIAN_ROULETTE } from '../../nodes/random.wgsl.js';
+import { transmissionAttenuationFunc } from '../../nodes/material.wgsl.js';
+import { SCATTER_RECORD_FLAG_TRANSMISSIVE } from '../../nodes/structs.wgsl.js';
 
 export class ProcessHitsKernel extends ComputeKernel {
 
@@ -82,11 +84,19 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 				let surface = ${ getSurfaceRecordFn }( material, vertexData, input.side, input.normal );
 
+				var throughputColor = input.throughputColor;
+
+				// attenuate the light transmitted through the volume when exiting a backface
+				if ( input.side < 0.0 ) {
+
+					throughputColor *= ${ transmissionAttenuationFunc }( input.dist, material.attenuationColor, material.attenuationDistance );
+
+				}
+
 				let scatterRec = ${ bsdfSampleFn }( input.view, surface );
 
-				let resultColor = input.resultColor + vec4f( input.throughputColor * surface.emission, 0.0 );
+				let resultColor = input.resultColor + vec4f( throughputColor * surface.emission, 0.0 );
 
-				var throughputColor = input.throughputColor;
 				var isTerminated = input.currentBounce >= bounces || ${ isTerminatingScatterFunc }( scatterRec );
 
 				// russian roulette early out
@@ -131,6 +141,11 @@ export class ProcessHitsKernel extends ComputeKernel {
 					rayQueue.elements[ index ].currentBounce = input.currentBounce + 1;
 					rayQueue.elements[ index ].resultColor = resultColor;
 					rayQueue.elements[ index ].seed = input.seed;
+					rayQueue.elements[ index ].flags = select(
+						input.flags & ~${ RAY_FLAG_FULLY_TRANSMISSIVE }u,
+						input.flags,
+						( scatterRec.flags & ${ SCATTER_RECORD_FLAG_TRANSMISSIVE }u ) > 0
+					);
 
 				}
 

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -1,13 +1,12 @@
 import { StorageBufferAttribute, StorageTexture, DataTexture } from 'three/webgpu';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { uniform, storage, textureStore, globalId, texture, sampler } from 'three/tsl';
-import { rayQueueAtomicStruct, hitQueueStruct, RAY_FLAG_FULLY_TRANSMISSIVE } from './structs.js';
+import { rayQueueAtomicStruct, hitQueueStruct } from './structs.js';
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { weightedAlphaBlendFn, luminanceFn } from '../../nodes/sampling.wgsl.js';
 import { isTerminatingScatterFunc } from '../../nodes/utils.wgsl.js';
 import { rngInit, rand1, RNG_INDEX_RUSSIAN_ROULETTE } from '../../nodes/random.wgsl.js';
 import { transmissionAttenuationFunc } from '../../nodes/material.wgsl.js';
-import { SCATTER_RECORD_FLAG_TRANSMISSIVE } from '../../nodes/structs.wgsl.js';
 
 export class ProcessHitsKernel extends ComputeKernel {
 
@@ -148,11 +147,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 					rayQueue.elements[ index ].currentBounce = input.currentBounce + 1;
 					rayQueue.elements[ index ].resultColor = resultColor;
 					rayQueue.elements[ index ].seed = input.seed;
-					rayQueue.elements[ index ].flags = select(
-						input.flags & ~${ RAY_FLAG_FULLY_TRANSMISSIVE }u,
-						input.flags,
-						( scatterRec.flags & ${ SCATTER_RECORD_FLAG_TRANSMISSIVE }u ) > 0
-					);
+					rayQueue.elements[ index ].transmissiveRay = select( 0u, input.transmissiveRay, scatterRec.isTransmissive );
 					rayQueue.elements[ index ].minPdf = min( scatterRec.pdf, input.minPdf );
 
 				}

--- a/src/webgpu/compute/wavefront/RayGenerationKernel.js
+++ b/src/webgpu/compute/wavefront/RayGenerationKernel.js
@@ -3,7 +3,7 @@ import { IndirectStorageBufferAttribute, StorageBufferAttribute, StorageTexture 
 import { uniform, storage, globalId, textureStore } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { rngInit, rand2, RNG_INDEX_RAY_JITTER } from '../../nodes/random.wgsl.js';
-import { rayQueueAtomicStruct } from './structs.js';
+import { rayQueueAtomicStruct, RAY_FLAG_FULLY_TRANSMISSIVE } from './structs.js';
 import { proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 
 export class RayGenerationKernel extends ComputeKernel {
@@ -87,6 +87,7 @@ export class RayGenerationKernel extends ComputeKernel {
 				rayQueue.elements[ index ].currentBounce = 0;
 				rayQueue.elements[ index ].resultColor = vec4f( 0.0, 0.0, 0.0, 1.0 );
 				rayQueue.elements[ index ].seed = seed + samples;
+				rayQueue.elements[ index ].flags = ${ RAY_FLAG_FULLY_TRANSMISSIVE }u;
 
 				// write the active params
 				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( ACTIVE_FLAG | samples ) );

--- a/src/webgpu/compute/wavefront/RayGenerationKernel.js
+++ b/src/webgpu/compute/wavefront/RayGenerationKernel.js
@@ -3,7 +3,7 @@ import { IndirectStorageBufferAttribute, StorageBufferAttribute, StorageTexture 
 import { uniform, storage, globalId, textureStore } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { rngInit, rand2, RNG_INDEX_RAY_JITTER } from '../../nodes/random.wgsl.js';
-import { rayQueueAtomicStruct, RAY_FLAG_FULLY_TRANSMISSIVE } from './structs.js';
+import { rayQueueAtomicStruct } from './structs.js';
 import { proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 
 export class RayGenerationKernel extends ComputeKernel {
@@ -87,7 +87,7 @@ export class RayGenerationKernel extends ComputeKernel {
 				rayQueue.elements[ index ].currentBounce = 0;
 				rayQueue.elements[ index ].resultColor = vec4f( 0.0, 0.0, 0.0, 1.0 );
 				rayQueue.elements[ index ].seed = seed + samples;
-				rayQueue.elements[ index ].flags = ${ RAY_FLAG_FULLY_TRANSMISSIVE }u;
+				rayQueue.elements[ index ].transmissiveRay = 1u;
 				rayQueue.elements[ index ].minPdf = 1.0;
 
 				// write the active params

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -5,6 +5,7 @@ import { rngInit, rand2, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../../nodes/random
 import { rayQueueStruct, hitQueueAtomicStruct, RAY_FLAG_FULLY_TRANSMISSIVE } from './structs.js';
 import { proxy, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
+import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../../constants.js';
 
 export class RayIntersectionKernel extends ComputeKernel {
 
@@ -33,6 +34,8 @@ export class RayIntersectionKernel extends ComputeKernel {
 			backgroundIntensity: uniform( 1 ),
 			backgroundBlurriness: uniform( 0 ),
 
+			transmissiveBackground: uniform( 1 ),
+
 			globalId: globalId,
 		};
 
@@ -53,6 +56,8 @@ export class RayIntersectionKernel extends ComputeKernel {
 				backgroundRotation: mat3x3f,
 				backgroundIntensity: f32,
 				backgroundBlurriness: f32,
+
+				transmissiveBackground: u32,
 
 				globalId: vec3u
 			) -> void {
@@ -119,9 +124,39 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 					} else {
 
-						// camera rays and rays that have only passed through transmissive surfaces
-						// show the background so it appears through glass
-						resultColor = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, input.direction, rng );
+						// camera rays show the background directly while rays that have only passed
+						// through transmissive surfaces handle it based on the transmissive background
+						// mode: ENVIRONMENT displays the environment through the glass, TRANSPARENT
+						// lets a transparent background composite through by the average transmitted
+						// throughput, and OVERLAY does both so the glass keeps a tint matching the
+						// rest of the model.
+						let bg = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, input.direction, rng );
+						if ( input.currentBounce == 0u ) {
+
+							resultColor = vec4f( bg.a * bg.rgb, bg.a );
+
+						} else {
+
+							let env = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, input.direction, rng );
+							var light = mix( env.rgb, bg.rgb, bg.a );
+							var transparency = ( 1.0 - bg.a ) * dot( input.throughputColor, vec3f( 1.0 / 3.0 ) );
+							if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
+
+								light = env.rgb;
+								transparency = 0.0;
+
+							} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
+
+								light = bg.a * bg.rgb;
+
+							}
+
+							resultColor = vec4f(
+								resultColor.rgb + light * input.throughputColor,
+								1.0 - transparency,
+							);
+
+						}
 
 					}
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -125,37 +125,47 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 					} else {
 
-						// camera rays show the background directly while rays that have only passed
-						// through transmissive surfaces handle it based on the transmissive background
-						// mode: ENVIRONMENT displays the environment through the glass, TRANSPARENT
-						// lets a transparent background composite through by the average transmitted
-						// throughput, and OVERLAY does both so the glass keeps a tint matching the
-						// rest of the model.
+						// hit the background
+						// support multiple transparent background blending techniques
 						let bg = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, input.direction, rng );
 						if ( input.currentBounce == 0u ) {
 
+							// sample the background directly if this is the primary ray
 							resultColor = vec4f( bg.a * bg.rgb, bg.a );
 
 						} else {
 
+							// transmissive ray handling
 							let env = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, input.direction, rng );
-							var light = mix( env.rgb, bg.rgb, bg.a );
-							var transparency = ( 1.0 - bg.a ) * saturate( dot( input.throughputColor, vec3f( 1.0 / 3.0 ) ) );
+							let avg = saturate( dot( input.throughputColor, vec3f( 1.0 / 3.0 ) ) );
+							let transparency = ( 1.0 - bg.a ) * avg;
+
 							if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
-								light = env.rgb;
-								transparency = 0.0;
+								// display the env map through transmissive surfaces
+								resultColor = vec4f(
+									resultColor.rgb + env.rgb * input.throughputColor,
+									1.0,
+								);
 
 							} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
 
-								light = bg.a * bg.rgb;
+								// fade the background by the throughput color average
+								resultColor = vec4f(
+									resultColor.rgb + bg.a * bg.rgb * input.throughputColor,
+									1.0 - transparency,
+								);
+
+							} else {
+
+								// fade the background by the throughput color average, mixing in env lighting
+								var light = mix( env.rgb, bg.rgb, bg.a );
+								resultColor = vec4f(
+									resultColor.rgb + light * input.throughputColor,
+									1.0 - transparency,
+								);
 
 							}
-
-							resultColor = vec4f(
-								resultColor.rgb + light * input.throughputColor,
-								1.0 - transparency,
-							);
 
 						}
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -139,7 +139,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 							let env = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, input.direction, rng );
 							var light = mix( env.rgb, bg.rgb, bg.a );
-							var transparency = ( 1.0 - bg.a ) * dot( input.throughputColor, vec3f( 1.0 / 3.0 ) );
+							var transparency = ( 1.0 - bg.a ) * saturate( dot( input.throughputColor, vec3f( 1.0 / 3.0 ) ) );
 							if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
 								light = env.rgb;

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -2,7 +2,7 @@ import { DataTexture, Matrix3, StorageBufferAttribute, StorageTexture } from 'th
 import { ComputeKernel } from '../ComputeKernel.js';
 import { uniform, texture, sampler, storage, textureStore, globalId } from 'three/tsl';
 import { rngInit, rand2, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../../nodes/random.wgsl.js';
-import { rayQueueStruct, hitQueueAtomicStruct, RAY_FLAG_FULLY_TRANSMISSIVE } from './structs.js';
+import { rayQueueStruct, hitQueueAtomicStruct } from './structs.js';
 import { proxy, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
 import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_OVERLAY, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../../constants.js';
@@ -112,14 +112,14 @@ export class RayIntersectionKernel extends ComputeKernel {
 					hitQueue.elements[ index ].resultColor = input.resultColor;
 					hitQueue.elements[ index ].seed = input.seed;
 					hitQueue.elements[ index ].dist = hitResult.dist;
-					hitQueue.elements[ index ].flags = input.flags;
+					hitQueue.elements[ index ].transmissiveRay = input.transmissiveRay;
 					hitQueue.elements[ index ].minPdf = input.minPdf;
 
 				} else {
 
 					let rng = ${ rand2 }( ${ RNG_INDEX_ENVIRONMENT_SAMPLE } );
 					var resultColor = input.resultColor;
-					if ( input.currentBounce > 0u && ( input.flags & ${ RAY_FLAG_FULLY_TRANSMISSIVE }u ) == 0u ) {
+					if ( input.currentBounce > 0u && input.transmissiveRay == 0u ) {
 
 						resultColor += ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, input.direction, rng ) * vec4f( input.throughputColor, 0.0 );
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -5,7 +5,7 @@ import { rngInit, rand2, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../../nodes/random
 import { rayQueueStruct, hitQueueAtomicStruct, RAY_FLAG_FULLY_TRANSMISSIVE } from './structs.js';
 import { proxy, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
-import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../../constants.js';
+import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_OVERLAY, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../../constants.js';
 
 export class RayIntersectionKernel extends ComputeKernel {
 
@@ -34,7 +34,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 			backgroundIntensity: uniform( 1 ),
 			backgroundBlurriness: uniform( 0 ),
 
-			transmissiveBackground: uniform( 1 ),
+			transmissiveBackground: uniform( TRANSMISSIVE_BACKGROUND_OVERLAY ),
 
 			globalId: globalId,
 		};

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -2,7 +2,7 @@ import { DataTexture, Matrix3, StorageBufferAttribute, StorageTexture } from 'th
 import { ComputeKernel } from '../ComputeKernel.js';
 import { uniform, texture, sampler, storage, textureStore, globalId } from 'three/tsl';
 import { rngInit, rand2, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../../nodes/random.wgsl.js';
-import { rayQueueStruct, hitQueueAtomicStruct } from './structs.js';
+import { rayQueueStruct, hitQueueAtomicStruct, RAY_FLAG_FULLY_TRANSMISSIVE } from './structs.js';
 import { proxy, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
 
@@ -106,17 +106,21 @@ export class RayIntersectionKernel extends ComputeKernel {
 					hitQueue.elements[ index ].currentBounce = input.currentBounce;
 					hitQueue.elements[ index ].resultColor = input.resultColor;
 					hitQueue.elements[ index ].seed = input.seed;
+					hitQueue.elements[ index ].dist = hitResult.dist;
+					hitQueue.elements[ index ].flags = input.flags;
 
 				} else {
 
 					let rng = ${ rand2 }( ${ RNG_INDEX_ENVIRONMENT_SAMPLE } );
 					var resultColor = input.resultColor;
-					if ( input.currentBounce > 0u ) {
+					if ( input.currentBounce > 0u && ( input.flags & ${ RAY_FLAG_FULLY_TRANSMISSIVE }u ) == 0u ) {
 
 						resultColor += ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, input.direction, rng ) * vec4f( input.throughputColor, 0.0 );
 
 					} else {
 
+						// camera rays and rays that have only passed through transmissive surfaces
+						// show the background so it appears through glass
 						resultColor = ${ sampleEnvironmentFn }( background, backgroundSampler, backgroundInfo, input.direction, rng );
 
 					}

--- a/src/webgpu/compute/wavefront/structs.js
+++ b/src/webgpu/compute/wavefront/structs.js
@@ -26,9 +26,6 @@ class DependentStructTypeNode extends StructTypeNode {
 
 }
 
-// set while a ray has only passed through transmissive surfaces so misses show the background
-export const RAY_FLAG_FULLY_TRANSMISSIVE = 1 << 0;
-
 export const queuedRayStruct = new StructTypeNode( {
 
 	origin: 'vec3f',
@@ -41,7 +38,7 @@ export const queuedRayStruct = new StructTypeNode( {
 	currentBounce: 'uint',
 
 	pixel: 'vec2u',
-	flags: 'uint',
+	transmissiveRay: 'uint',
 	minPdf: 'float',
 
 	resultColor: 'vec4f',
@@ -67,7 +64,7 @@ export const queuedHitStruct = new StructTypeNode( {
 	side: 'float',
 
 	dist: 'float',
-	flags: 'uint',
+	transmissiveRay: 'uint',
 	minPdf: 'float',
 	_alignment0: 'uint',
 

--- a/src/webgpu/compute/wavefront/structs.js
+++ b/src/webgpu/compute/wavefront/structs.js
@@ -26,6 +26,9 @@ class DependentStructTypeNode extends StructTypeNode {
 
 }
 
+// set while a ray has only passed through transmissive surfaces so misses show the background
+export const RAY_FLAG_FULLY_TRANSMISSIVE = 1 << 0;
+
 export const queuedRayStruct = new StructTypeNode( {
 
 	origin: 'vec3f',
@@ -38,6 +41,8 @@ export const queuedRayStruct = new StructTypeNode( {
 	currentBounce: 'uint',
 
 	pixel: 'vec2u',
+	flags: 'uint',
+	_alignment1: 'uint',
 
 	resultColor: 'vec4f',
 
@@ -60,6 +65,11 @@ export const queuedHitStruct = new StructTypeNode( {
 
 	normal: 'vec3f',
 	side: 'float',
+
+	dist: 'float',
+	flags: 'uint',
+	_alignment0: 'uint',
+	_alignment1: 'uint',
 
 	resultColor: 'vec4f',
 

--- a/src/webgpu/constants.js
+++ b/src/webgpu/constants.js
@@ -1,0 +1,9 @@
+// How rays that have only passed through transmissive surfaces treat the background on a miss.
+// ENVIRONMENT displays the environment map through the glass and keeps the pixel opaque. OVERLAY
+// and TRANSPARENT reduce the pixel alpha by the average transmitted throughput so a transparent
+// background composites through the glass, with OVERLAY also adding transmitted environment light
+// so the glass keeps a tint matching the rest of the model. OVERLAY and TRANSPARENT only differ
+// from each other when the background is transparent.
+export const TRANSMISSIVE_BACKGROUND_ENVIRONMENT = 0;
+export const TRANSMISSIVE_BACKGROUND_OVERLAY = 1;
+export const TRANSMISSIVE_BACKGROUND_TRANSPARENT = 2;

--- a/src/webgpu/constants.js
+++ b/src/webgpu/constants.js
@@ -1,9 +1,10 @@
-// How rays that have only passed through transmissive surfaces treat the background on a miss.
-// ENVIRONMENT displays the environment map through the glass and keeps the pixel opaque. OVERLAY
-// and TRANSPARENT reduce the pixel alpha by the average transmitted throughput so a transparent
-// background composites through the glass, with OVERLAY also adding transmitted environment light
-// so the glass keeps a tint matching the rest of the model. OVERLAY and TRANSPARENT only differ
-// from each other when the background is transparent.
+// How rays that have only passed through transmissive surfaces treat the background on a miss
+
+// Sample the env map
 export const TRANSMISSIVE_BACKGROUND_ENVIRONMENT = 0;
+
+// Set the opacity based on transmitted light intensity with env lighting tint
 export const TRANSMISSIVE_BACKGROUND_OVERLAY = 1;
+
+// Attenuate light based on transmitted
 export const TRANSMISSIVE_BACKGROUND_TRANSPARENT = 2;

--- a/src/webgpu/index.js
+++ b/src/webgpu/index.js
@@ -1,5 +1,6 @@
 export * from './WebGPUPathTracer.js';
 export * from './BlurredEnvMapGenerator.js';
+export * from './constants.js';
 
 export * as RANDOM_PCG from './nodes/rand/pcg.wgsl.js';
 export * as RANDOM_SOBOL from './nodes/rand/sobol.wgsl.js';

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -109,7 +109,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
 				let reflection = ${ this.diffuseBrdf }( NdotV, NdotL, ctx.VdotH, surf );
 				let diffuse = ( 1.0 - surf.transmission ) * reflection;
-				let dielectricBase = ${ this.fresnelMix }( ctx.VdotH, surf.specularColor, surf.ior, surf.specularIntensity, diffuse, specular );
+				let dielectricBase = ${ this.fresnelMix }( ctx.VdotH, surf.specularColor, surf.ior, surf.eta, surf.specularIntensity, diffuse, specular );
 
 				let dielectric = ${ this.iridescentDielectricLayer }(
 					dielectricBase, diffuse, specular, ctx.VdotH, /* outsideIor */ 1.0,
@@ -210,18 +210,16 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					wi = refract( - wo, wh, surf.eta );
 					isTransmissive = true;
 
-					// Total internal reflection case
-					// TODO: handle better
-					if ( wi.x == 0.0 && wi.y == 0.0 && wi.z == 0.0 ) {
+					if ( all( wi == vec3f( 0.0 ) ) ) {
 
-						return result;
+						// total internal reflection - refract returns a zero vector, so bounce the
+						// ray off the inside of the surface instead of terminating it
+						wi = - normalize( reflect( wo, wh ) );
 
-					}
+					} else if ( surf.thinFilm ) {
 
-					// thin film surfaces refract the ray back out of the flat backside so the
-					// direction continues straight through the shell
-					if ( surf.thinFilm ) {
-
+						// thin film surfaces refract the ray back out of the flat backside so the
+						// direction continues straight through the shell
 						wi = - refract( normalize( - wi ), - vec3f( 0.0, 0.0, 1.0 ), 1.0 / surf.eta );
 
 					}

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -2,7 +2,8 @@ import { texture, textureStore, globalId, float, vec2 } from 'three/tsl';
 import { StorageTexture, RedFormat, LinearFilter, TextureLoader, HalfFloatType } from 'three/webgpu';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { PathtracingMaterial } from './PathtracingMaterial.js';
-import { specularBrdfFunc, specularBtdfFunc, diffuseBrdfFunc, fresnelMixFunc, conductorFresnelFunc, albedoIntegralMetallic, fresnelCoatFunc, iridescentDielectricLayerFunc, iridescentConductorLayerFunc } from '../nodes/material.wgsl.js';
+import { specularBrdfFunc, specularBtdfFunc, diffuseBrdfFunc, fresnelMixFunc, conductorFresnelFunc, albedoIntegralMetallic, fresnelCoatFunc, iridescentDielectricLayerFunc, iridescentConductorLayerFunc, thinWallTransmissionRoughnessFunc } from '../nodes/material.wgsl.js';
+import { dielectricFresnelFunc } from '../nodes/utils.wgsl.js';
 import { sheenColorFunc, sheenAlbedoScalingFunc } from '../nodes/sheen.wgsl.js';
 import { diffuseDirectionFunc, getLobeWeightsFunc } from '../nodes/sampling.wgsl.js';
 import { ggxDirectionFunc, ggxReflectionAdjustedPDFFunc, ggxRefractionAdjustedPDFFunc } from '../nodes/ggx.wgsl.js';
@@ -101,7 +102,21 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				// gated to the upper hemisphere, matching the WebGL implementation
 				if ( NdotL < 0.0 ) {
 
-					let refraction = ${ this.specularBtdf }( ctx.V, ctx.L, ctx.H, alpha, surf.eta );
+					var refraction: vec3f;
+					if ( surf.thinWall ) {
+
+						// evaluate the flipped reflection
+						let wiMirror = vec3f( ctx.L.xy, - ctx.L.z );
+						let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
+						let F = ${ dielectricFresnelFunc }( saturate( ctx.VdotH ), surf.eta );
+						refraction = ( 1.0 - F ) * ${ this.specularBrdf }( ctx.V, wiMirror, ctx.H, thinWallAlpha );
+
+					} else {
+
+						refraction = ${ this.specularBtdf }( ctx.V, ctx.L, ctx.H, alpha, surf.eta );
+
+					}
+
 					return ( 1.0 - surf.metalness ) * surf.transmission * refraction * surf.color;
 
 				}
@@ -206,21 +221,28 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				} else if ( r <= cdf.w ) { // transmission / refraction
 
-					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
-					wi = refract( - wo, wh, surf.eta );
 					isTransmissive = true;
 
-					if ( all( wi == vec3f( 0.0 ) ) ) {
+					if ( surf.thinWall ) {
 
-						// total internal reflection - refract returns a zero vector, so bounce the
-						// ray off the inside of the surface instead of terminating it
+						// model the double refraction as a single reflection flipped through the surface
+						let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
+						wh = ${ ggxDirectionFunc }( wo, thinWallAlpha, directionUV );
 						wi = - normalize( reflect( wo, wh ) );
+						wi = vec3f( wi.xy, - wi.z );
 
-					} else if ( surf.thinFilm ) {
+					} else {
 
-						// thin film surfaces refract the ray back out of the flat backside so the
-						// direction continues straight through the shell
-						wi = - refract( normalize( - wi ), - vec3f( 0.0, 0.0, 1.0 ), 1.0 / surf.eta );
+						wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
+						wi = refract( - wo, wh, surf.eta );
+
+						if ( all( wi == vec3f( 0.0 ) ) ) {
+
+							// total internal reflection - refract returns a zero vector, so bounce the
+							// ray off the inside of the surface instead of terminating it
+							wi = - normalize( reflect( wo, wh ) );
+
+						}
 
 					}
 
@@ -260,7 +282,17 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				if ( weights.transmission > 0.0 && wi.z < 0.0 ) {
 
-					result.pdf += weights.transmission * ${ ggxRefractionAdjustedPDFFunc }( wo, wi, wh, alpha, surf.eta );
+					if ( surf.thinWall ) {
+
+						// the flipped reflection shares the reflection pdf
+						let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
+						result.pdf += weights.transmission * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, thinWallAlpha );
+
+					} else {
+
+						result.pdf += weights.transmission * ${ ggxRefractionAdjustedPDFFunc }( wo, wi, wh, alpha, surf.eta );
+
+					}
 
 				}
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -2,11 +2,11 @@ import { texture, textureStore, globalId, float, vec2 } from 'three/tsl';
 import { StorageTexture, RedFormat, LinearFilter, TextureLoader, HalfFloatType } from 'three/webgpu';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { PathtracingMaterial } from './PathtracingMaterial.js';
-import { specularBrdfFunc, diffuseBrdfFunc, fresnelMixFunc, conductorFresnelFunc, albedoIntegralMetallic, fresnelCoatFunc, iridescentDielectricLayerFunc, iridescentConductorLayerFunc } from '../nodes/material.wgsl.js';
+import { specularBrdfFunc, specularBtdfFunc, diffuseBrdfFunc, fresnelMixFunc, conductorFresnelFunc, albedoIntegralMetallic, fresnelCoatFunc, iridescentDielectricLayerFunc, iridescentConductorLayerFunc } from '../nodes/material.wgsl.js';
 import { sheenColorFunc, sheenAlbedoScalingFunc } from '../nodes/sheen.wgsl.js';
 import { diffuseDirectionFunc, getLobeWeightsFunc } from '../nodes/sampling.wgsl.js';
-import { ggxDirectionFunc, ggxReflectionAdjustedPDFFunc } from '../nodes/ggx.wgsl.js';
-import { bxdfContextStruct, scatterRecordStruct, surfaceRecordStruct } from '../nodes/structs.wgsl.js';
+import { ggxDirectionFunc, ggxReflectionAdjustedPDFFunc, ggxRefractionAdjustedPDFFunc } from '../nodes/ggx.wgsl.js';
+import { bxdfContextStruct, scatterRecordStruct, surfaceRecordStruct, SCATTER_RECORD_FLAG_TRANSMISSIVE } from '../nodes/structs.wgsl.js';
 import { rand1, rand2, RNG_INDEX_SCATTER_DIRECTION, RNG_INDEX_SCATTER_TYPE } from '../nodes/random.wgsl.js';
 import { ComputeKernel } from '../compute/ComputeKernel.js';
 
@@ -24,6 +24,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 		const {
 			specularBrdf = specularBrdfFunc,
+			specularBtdf = specularBtdfFunc,
 			diffuseBrdf = diffuseBrdfFunc,
 			fresnelMix = fresnelMixFunc,
 			conductorFresnel = conductorFresnelFunc,
@@ -52,6 +53,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 		const turquinNode = texture( this.turquinTexture, vec2( 0.0 ) ).setName( 'turquinTexture' );
 
 		this.specularBrdf = specularBrdf;
+		this.specularBtdf = specularBtdf;
 		this.diffuseBrdf = diffuseBrdf;
 		this.fresnelMix = fresnelMix;
 		this.conductorFresnel = conductorFresnel( turquinNode );
@@ -95,8 +97,18 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let NdotVc = ctx.Vc.z;
 				let NdotL = ctx.L.z;
 
+				// transmitted directions only gather the refracted lobe — the reflection lobes are
+				// gated to the upper hemisphere, matching the WebGL implementation
+				if ( NdotL < 0.0 ) {
+
+					let refraction = ${ this.specularBtdf }( ctx.V, ctx.L, ctx.H, alpha, surf.eta );
+					return ( 1.0 - surf.metalness ) * surf.transmission * refraction * surf.color;
+
+				}
+
 				let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
-				let diffuse = ${ this.diffuseBrdf }( NdotV, NdotL, ctx.VdotH, surf );
+				let reflection = ${ this.diffuseBrdf }( NdotV, NdotL, ctx.VdotH, surf );
+				let diffuse = ( 1.0 - surf.transmission ) * reflection;
 				let dielectricBase = ${ this.fresnelMix }( ctx.VdotH, surf.specularColor, surf.ior, surf.specularIntensity, diffuse, specular );
 
 				let dielectric = ${ this.iridescentDielectricLayer }(
@@ -151,32 +163,22 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let wo = normalize( invBasis * worldWo );
 				let woClearcoat = normalize( invClearcoatBasis * worldWo );
 
-				// TODO: handle such intersections better;
-				// Sometimes .z < 0.0 on a pretty round surface e.g. sphere
-				// Disabling this condition leads to more fireflies on ClearCoatCarPaint example
-				// This could also be fixed by offsetting rays by 1e-1
-				// Also, this will be an invalid condition when transmission is implemented
-				if ( wo.z < 0.0 || woClearcoat.z < 0.0 ) {
-
-					return result;
-
-				}
-
-				let weights = ${ getLobeWeightsFunc }( wo, woClearcoat, vec3( 0, 0, 1 ), ${ CLEARCOAT_IOR }, surf );
+				let weights = ${ getLobeWeightsFunc }( wo, wo, woClearcoat, vec3( 0, 0, 1 ), ${ CLEARCOAT_IOR }, surf );
 
 				var cdf: vec4f;
 				cdf.x = weights.diffuse;
 				cdf.y = weights.specular + cdf.x;
 				cdf.z = weights.clearcoat + cdf.y;
-				cdf.w = 0; // weights.transmission + cdf.z;
+				cdf.w = weights.transmission + cdf.z;
 
-				let r = ${ rand1 }( ${ RNG_INDEX_SCATTER_TYPE } ) * cdf.z;
+				let r = ${ rand1 }( ${ RNG_INDEX_SCATTER_TYPE } ) * cdf.w;
 
 				let directionUV = ${ rand2 }( ${ RNG_INDEX_SCATTER_DIRECTION } );
 				var wi: vec3f;
 				var wiClearcoat: vec3f;
 				var wh: vec3f;
 				var whClearcoat: vec3f;
+				var isTransmissive = false;
 
 				if ( r <= cdf.x ) { // diffuse
 
@@ -204,7 +206,28 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				} else if ( r <= cdf.w ) { // transmission / refraction
 
-					// NOT IMPLEMENTED
+					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
+					wi = refract( - wo, wh, surf.eta );
+					isTransmissive = true;
+
+					// Total internal reflection case
+					// TODO: handle better
+					if ( wi.x == 0.0 && wi.y == 0.0 && wi.z == 0.0 ) {
+
+						return result;
+
+					}
+
+					// thin film surfaces refract the ray back out of the flat backside so the
+					// direction continues straight through the shell
+					if ( surf.thinFilm ) {
+
+						wi = - refract( normalize( - wi ), - vec3f( 0.0, 0.0, 1.0 ), 1.0 / surf.eta );
+
+					}
+
+					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
+					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
 
 				}
 
@@ -237,9 +260,21 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				}
 
+				if ( weights.transmission > 0.0 && wi.z < 0.0 ) {
+
+					result.pdf += weights.transmission * ${ ggxRefractionAdjustedPDFFunc }( wo, wi, wh, alpha, surf.eta );
+
+				}
+
 				result.color = ${ bsdfEvalFunc }( ctx, surf );
-				result.color *= max( 0.0, wi.z );
+				result.color *= select( max( 0.0, wi.z ), abs( wi.z ), isTransmissive );
 				result.direction = normalize( normalBasis * wi );
+
+				if ( isTransmissive ) {
+
+					result.flags = result.flags | ${ SCATTER_RECORD_FLAG_TRANSMISSIVE }u;
+
+				}
 
 				return result;
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -301,16 +301,14 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				result.direction = normalize( normalBasis * wi );
 				result.isTransmissive = isTransmissive;
 
-				if ( ! isTransmissive ) {
+				// Flip the scattered ray through the surface if it lands on the wrong side of the
+				// geometry due to the shading normal - reflected rays must leave above the surface
+				// and transmitted rays below it
+				let scatterNormal = surf.faceNormal * select( 1.0, - 1.0, isTransmissive );
+				let geomDotDir = dot( result.direction, scatterNormal );
+				if ( geomDotDir < 0.0 ) {
 
-					// Flip the reflected vector if it was scattered below the geometry normal with glossy
-					// reflections. Transmitted rays intentionally pass below the surface and are skipped.
-					let geomDotDir = dot( result.direction, surf.faceNormal );
-					if ( geomDotDir < 0.0 ) {
-
-						result.direction = normalize( result.direction - 2.0 * geomDotDir * surf.faceNormal );
-
-					}
+					result.direction = normalize( result.direction - 2.0 * geomDotDir * scatterNormal );
 
 				}
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -6,7 +6,7 @@ import { specularBrdfFunc, specularBtdfFunc, diffuseBrdfFunc, fresnelMixFunc, co
 import { sheenColorFunc, sheenAlbedoScalingFunc } from '../nodes/sheen.wgsl.js';
 import { diffuseDirectionFunc, getLobeWeightsFunc } from '../nodes/sampling.wgsl.js';
 import { ggxDirectionFunc, ggxReflectionAdjustedPDFFunc, ggxRefractionAdjustedPDFFunc } from '../nodes/ggx.wgsl.js';
-import { bxdfContextStruct, scatterRecordStruct, surfaceRecordStruct, SCATTER_RECORD_FLAG_TRANSMISSIVE } from '../nodes/structs.wgsl.js';
+import { bxdfContextStruct, scatterRecordStruct, surfaceRecordStruct } from '../nodes/structs.wgsl.js';
 import { rand1, rand2, RNG_INDEX_SCATTER_DIRECTION, RNG_INDEX_SCATTER_TYPE } from '../nodes/random.wgsl.js';
 import { ComputeKernel } from '../compute/ComputeKernel.js';
 
@@ -267,12 +267,9 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				result.color = ${ bsdfEvalFunc }( ctx, surf );
 				result.color *= select( max( 0.0, wi.z ), abs( wi.z ), isTransmissive );
 				result.direction = normalize( normalBasis * wi );
+				result.isTransmissive = isTransmissive;
 
-				if ( isTransmissive ) {
-
-					result.flags = result.flags | ${ SCATTER_RECORD_FLAG_TRANSMISSIVE }u;
-
-				} else {
+				if ( ! isTransmissive ) {
 
 					// Flip the reflected vector if it was scattered below the geometry normal with glossy
 					// reflections. Transmitted rays intentionally pass below the surface and are skipped.

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -296,8 +296,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				}
 
-				result.color = ${ bsdfEvalFunc }( ctx, surf );
-				result.color *= select( max( 0.0, wi.z ), abs( wi.z ), isTransmissive );
+				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isTransmissive );
 				result.direction = normalize( normalBasis * wi );
 				result.isTransmissive = isTransmissive;
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -102,6 +102,10 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				// gated to the upper hemisphere, matching the WebGL implementation
 				if ( NdotL < 0.0 ) {
 
+					// TODO: transmitted light also crosses the thin film so it should be weighted by
+					// the film-aware fresnel complement (1 - filmF) rather than the plain dielectric
+					// fresnel, tinting transmission with the film's complementary color. Deferred until
+					// the material is generalized into a layer stack that owns the fresnel per interface.
 					var refraction: vec3f;
 					if ( surf.thinWall ) {
 
@@ -126,16 +130,21 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let diffuse = ( 1.0 - surf.transmission ) * reflection;
 				let dielectricBase = ${ this.fresnelMix }( ctx.VdotH, surf.specularColor, surf.ior, surf.eta, surf.specularIntensity, diffuse, specular );
 
+				// the media on either side of the film - air outside and the volume interior
+				// as the base on front faces, swapped on back faces so TIR can take effect
+				let outsideIor = select( surf.ior, 1.0, surf.frontFace );
+				let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
+
 				let dielectric = ${ this.iridescentDielectricLayer }(
-					dielectricBase, diffuse, specular, ctx.VdotH, /* outsideIor */ 1.0,
-					surf.ior, surf.iridescenceIor, surf.iridescenceThickness, surf.iridescence
+					dielectricBase, diffuse, specular, ctx.VdotH, outsideIor,
+					filmBaseIor, surf.iridescenceIor, surf.iridescenceThickness, surf.iridescence
 				);
 
 				// TODO: this only handles non-anisotropic surfaces
 				let metallicBase = ${ this.conductorFresnel }( NdotV, ctx.VdotH, surf.color, specular, alpha.y );
 
 				let metallic = ${ this.iridescentConductorLayer }(
-					metallicBase, specular, surf.color, ctx.VdotH, /* outsideIor */ 1.0,
+					metallicBase, specular, surf.color, ctx.VdotH, outsideIor,
 					surf.iridescenceIor, surf.iridescenceThickness, surf.iridescence
 				);
 

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -756,9 +756,9 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 			floatArray[ index ++ ] = getField( m, 'specularIntensity', 1.0 );
 			intArray[ index ++ ] = getTexture( m, 'specularIntensityMap' );
 
-			// isThinFilm
-			const isThinFilm = getField( m, 'thickness', 0.0 ) === 0.0 && getField( m, 'attenuationDistance', Infinity ) === Infinity;
-			intArray[ index ++ ] = Number( isThinFilm );
+			// isThinWall
+			const isThinWall = getField( m, 'thickness', 0.0 ) === 0.0 && getField( m, 'attenuationDistance', Infinity ) === Infinity;
+			intArray[ index ++ ] = Number( isThinWall );
 			index ++;
 
 			// attenuation - offset 44
@@ -785,7 +785,7 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 			floatArray[ index ++ ] = m.alphaTest;
 
 			// side & matte - offset 52
-			if ( ! isThinFilm && m.transmission > 0.0 ) {
+			if ( ! isThinWall && m.transmission > 0.0 ) {
 
 				floatArray[ index ++ ] = 0;
 

--- a/src/webgpu/nodes/ggx.wgsl.js
+++ b/src/webgpu/nodes/ggx.wgsl.js
@@ -169,3 +169,21 @@ export const ggxReflectionAdjustedPDFFunc = wgslFn( /* wgsl */ `
 
 	}
 `, [ ggxDistributionFunc, ggxShadowMaskG1Func ] );
+
+// ggxPDF, divided by the Jacobian of refraction operation
+// See equation (3) from [2] for pdf and (17) from [0] for Jacobian
+export const ggxRefractionAdjustedPDFFunc = wgslFn( /* wgsl */ `
+
+	fn ggxRefractionAdjustedPDF( V: vec3f, L: vec3f, H: vec3f, alpha: vec2f, eta: f32 ) -> f32 {
+
+		let NdotV = max( V.z, MIN_INCIDENT_COS );
+		let HdotV = dot( V, H );
+		let HdotL = dot( L, H );
+		let D = ggxDistribution( H, alpha );
+		let G1 = ggxShadowMaskG1( V, alpha );
+
+		let denom = eta * HdotV + HdotL;
+		return D * G1 * abs( HdotV ) * abs( HdotL ) / ( NdotV * denom * denom );
+
+	}
+`, [ ggxDistributionFunc, ggxShadowMaskG1Func ] );

--- a/src/webgpu/nodes/ggx.wgsl.js
+++ b/src/webgpu/nodes/ggx.wgsl.js
@@ -81,7 +81,8 @@ export const ggxLambdaFunc = wgslFn( /* wgsl */ `
 		let alphaT = alpha.x;
 		let alphaB = alpha.y;
 
-		let NdotV = max( V.z, MIN_INCIDENT_COS );
+		// abs v.z to support transmitted rays
+		let NdotV = max( abs( V.z ), MIN_INCIDENT_COS );
 		let cos2 = NdotV * NdotV;
 		let t = ( alphaT * alphaT * V.x * V.x + alphaB * alphaB * V.y * V.y ) / cos2;
 		let numerator = - 1.0 + sqrt( 1.0 + t );

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -142,10 +142,11 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 		blurRoughness: f32,
 	) -> SurfaceRecord {
 
-		var normal = faceNormal;
+		// "faceNormal" is provided on the hit side so flip it back to the geometric side
+		var normal = faceNormal * side;
 		if ( material.flatShading == 0 ) {
 
-			normal = normalize( vertexData.normal.xyz ) * side;
+			normal = normalize( vertexData.normal.xyz );
 
 		}
 
@@ -171,6 +172,8 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 			}
 
 		}
+
+		normal *= side;
 
 		normal = ensureValidViewNormal( normal, faceNormal, view );
 
@@ -268,6 +271,8 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 			}
 
 		}
+
+		clearcoatNormal *= side;
 
 		clearcoatNormal = ensureValidViewNormal( clearcoatNormal, faceNormal, view );
 

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -522,7 +522,7 @@ export const specularBtdfFunc = wgslFn( /* wgsl */`
 		// separable G2 product, no height correlation
 		let denom = eta * HdotV + HdotL;
 		let Vis = G1_i * G1_o * abs( HdotV ) * abs( HdotL ) /
-							( abs( NdotV ) * abs( NdotL ) * denom * denom );
+			( abs( NdotV ) * abs( NdotL ) * denom * denom );
 
 		let F = dielectricFresnel( abs( HdotV ), eta );
 
@@ -569,8 +569,7 @@ export const fresnelMixFunc = wgslFn( /* wgsl */ `
 		var f0 = iorToF0( ior ) * f0Color;
 		f0 = min( f0, vec3f( 1.0 ) );
 
-		// reflect all light on total internal reflection, matching the WebGL
-		// evaluateFresnel function
+		// reflect all light on total internal reflection, matching the WebGL evaluateFresnel function
 		var fr = vec3f( 1.0 );
 		if ( ! totalInternalReflection( abs( VdotH ), eta ) ) {
 

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -8,12 +8,14 @@ import {
 	iorToF0GeneralFunc,
 	fresnel0ToIorFunc,
 	iorToF0GeneralVecFunc,
+	dielectricFresnelFunc,
 } from './utils.wgsl.js';
 import {
 	ggxSmithVisibilityFunc,
 	ggxDistributionFunc,
 	ggxDirectionFunc,
 	ggxReflectionAdjustedPDFFunc,
+	ggxShadowMaskG1Func,
 } from './ggx.wgsl.js';
 import { constants, surfaceRecordStruct } from './structs.wgsl.js';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
@@ -379,6 +381,51 @@ export const specularBrdfFunc = wgslFn( /* wgsl */ `
 	}
 
 `, [ ggxSmithVisibilityFunc, ggxDistributionFunc ] );
+
+export const specularBtdfFunc = wgslFn( /* wgsl */`
+
+	fn specularBtdf( V: vec3f, L: vec3f, H: vec3f, alpha: vec2f, eta: f32 ) -> vec3f {
+
+		let NdotV = V.z;
+		let NdotL = L.z;
+		let HdotV = dot( V, H );
+		let HdotL = dot( L, H );
+
+		// Heaviside function for G term
+		if ( NdotV * HdotV < 0.0 || NdotL * HdotL < 0.0 || HdotV * HdotL > 0.0 ) {
+
+			return vec3f( 0.0 );
+
+		}
+
+		let G1_i = ggxShadowMaskG1( V, alpha );
+		let G1_o = ggxShadowMaskG1( L, alpha );
+
+		// separable G2 product, no height correlation
+		let denom = eta * HdotV + HdotL;
+		let Vis = G1_i * G1_o * abs( HdotV ) * abs( HdotL ) /
+							( abs( NdotV ) * abs( NdotL ) * denom * denom );
+
+		let F = dielectricFresnel( abs( HdotV ), eta );
+
+		let D = ggxDistribution( H, alpha );
+
+		return vec3f( ( 1 - F ) * D * Vis );
+
+	}
+
+`, [ ggxShadowMaskG1Func, ggxDistributionFunc, dielectricFresnelFunc ] );
+
+// https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_volume/README.md#attenuation
+export const transmissionAttenuationFunc = wgslFn( /* wgsl */ `
+
+	fn transmissionAttenuation( dist: f32, attColor: vec3f, attDist: f32 ) -> vec3f {
+
+		return pow( attColor, vec3f( dist / attDist ) );
+
+	}
+
+` );
 
 // Dielectric layer fresnel operator that supports custom f0 color, specular weight.
 // Based on the specular color specification:

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -386,7 +386,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 
 		surf.ior = material.ior;
 		surf.transmission = transmission;
-		surf.thinFilm = material.thinFilm == 1;
+		surf.thinWall = material.thinWall == 1;
 		surf.attenuationColor = material.attenuationColor;
 		surf.attenuationDistance = material.attenuationDistance;
 
@@ -412,7 +412,7 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 		// frontFace is used to determine transmissive properties and PDF. If no transmission is used
 		// then we can just always assume this is a front face.
 		surf.frontFace = side == 1.0 || transmission == 0.0;
-		if ( material.thinFilm == 1 || surf.frontFace ) {
+		if ( material.thinWall == 1 || surf.frontFace ) {
 
 			surf.eta = 1.0 / material.ior;
 
@@ -533,6 +533,20 @@ export const specularBtdfFunc = wgslFn( /* wgsl */`
 	}
 
 `, [ ggxShadowMaskG1Func, ggxDistributionFunc, dielectricFresnelFunc ] );
+
+// Effective roughness for thin walled transmission, from page 40 (note the slides' 3.7 is a typo for 3.4) -
+// referenced from Blender Cycles:
+// https://blog.selfshadow.com/publications/s2017-shading-course/imageworks/s2017_pbs_imageworks_slides_v2.pdf
+export const thinWallTransmissionRoughnessFunc = wgslFn( /* wgsl */ `
+
+	fn thinWallTransmissionRoughness( alpha: f32, eta: f32 ) -> f32 {
+
+		let t = 3.4 * ( eta - 1.0 ) * ( eta - 0.5 ) * ( eta - 0.5 ) / ( eta * eta * eta );
+		return saturate( alpha * sqrt( max( t, 0.0 ) ) );
+
+	}
+
+` );
 
 // https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_volume/README.md#attenuation
 export const transmissionAttenuationFunc = wgslFn( /* wgsl */ `

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -10,6 +10,7 @@ import {
 	iorToF0GeneralVecFunc,
 	dielectricFresnelFunc,
 	totalInternalReflectionFunc,
+	totalInternalReflectionVecFunc,
 } from './utils.wgsl.js';
 import {
 	ggxSmithVisibilityFunc,
@@ -647,9 +648,13 @@ export const iridescentFresnelFunc = wgslFn( /* wgsl */ `
 		let phi21 = PI - phi12;
 
 		// Second interface: iridescent thin film -> base material
-		let baseIor = fresnel0ToIor( baseF0 + 0.0001 ); // guard against 1.0
+		let baseIor = fresnel0ToIor( clamp( baseF0, vec3( 0.0 ), vec3( 0.9999 ) ) ); // guard against 1.0
 		let R1 = iorToF0GeneralVec( baseIor, vec3( iridescenceIor ) );
-		let R23 = schlickFresnelVec( cosTheta2, R1, vec3( 1.0 ) );
+		var R23 = schlickFresnelVec( cosTheta2, R1, vec3( 1.0 ) );
+
+		// Handle total internal reflection at the film -> base interface
+		// NOTE: Added separately from the original implementation. Is this correct?
+		R23 = select( R23, vec3( 1.0 ), totalInternalReflectionVec( cosTheta2, vec3( iridescenceIor ) / baseIor ) );
 		let phi23 = select( vec3( 0.0 ), vec3( PI ), baseIor < vec3( iridescenceIor ) );
 
 		// Phase shift
@@ -680,7 +685,7 @@ export const iridescentFresnelFunc = wgslFn( /* wgsl */ `
 
 	}
 
-`, [ iorToF0GeneralFunc, iorToF0GeneralVecFunc, schlickFresnelFunc, fresnel0ToIorFunc, evalSensitivityFunc ] );
+`, [ iorToF0GeneralFunc, iorToF0GeneralVecFunc, schlickFresnelFunc, fresnel0ToIorFunc, evalSensitivityFunc, totalInternalReflectionVecFunc ] );
 
 const rgbMixFunc = wgslFn( /* wgsl */ `
 

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -9,6 +9,7 @@ import {
 	fresnel0ToIorFunc,
 	iorToF0GeneralVecFunc,
 	dielectricFresnelFunc,
+	totalInternalReflectionFunc,
 } from './utils.wgsl.js';
 import {
 	ggxSmithVisibilityFunc,
@@ -432,19 +433,27 @@ export const transmissionAttenuationFunc = wgslFn( /* wgsl */ `
 // https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular
 export const fresnelMixFunc = wgslFn( /* wgsl */ `
 
-	fn fresnelMix( VdotH: f32, f0Color: vec3f, ior: f32, weight: f32, base: vec3f, layer: vec3f ) -> vec3f {
+	fn fresnelMix( VdotH: f32, f0Color: vec3f, ior: f32, eta: f32, weight: f32, base: vec3f, layer: vec3f ) -> vec3f {
 
 		var f0 = iorToF0( ior ) * f0Color;
 		f0 = min( f0, vec3f( 1.0 ) );
 
-		let fr = schlickFresnelVec( abs( VdotH ), f0, vec3f( 1.0 ) );
+		// reflect all light on total internal reflection, matching the WebGL
+		// evaluateFresnel function
+		var fr = vec3f( 1.0 );
+		if ( ! totalInternalReflection( abs( VdotH ), eta ) ) {
+
+			fr = schlickFresnelVec( abs( VdotH ), f0, vec3f( 1.0 ) );
+
+		}
+
 		let maxFr = max( max( fr.r, fr.g ), fr.b );
 
 		return ( 1.0 - weight * maxFr ) * base + weight * fr * layer;
 
 	}
 
-`, [ schlickFresnelVecFunc, iorToF0Func ] );
+`, [ schlickFresnelVecFunc, iorToF0Func, totalInternalReflectionFunc ] );
 
 const XYZ_TO_REC709 = mat3(
 	3.2404542, - 0.9692660, 0.0556434,

--- a/src/webgpu/nodes/sampling.wgsl.js
+++ b/src/webgpu/nodes/sampling.wgsl.js
@@ -42,24 +42,24 @@ export const diffuseDirectionFunc = wgslFn( /* wgsl */ `
 
 export const getLobeWeightsFunc = wgslFn( /* wgsl */ `
 
-	fn getLobeWeights(wo: vec3f, wi: vec3f, woClearcoat: vec3f, wh: vec3f, clearcoatIor: f32, surf: SurfaceRecord) -> LobeWeights {
+	fn getLobeWeights( wo: vec3f, wi: vec3f, woClearcoat: vec3f, wh: vec3f, clearcoatIor: f32, surf: SurfaceRecord ) -> LobeWeights {
 
 		var weights: LobeWeights;
-		var weightLeft = 1.0;
+		var remaining = 1.0;
 
 		let clearcoatF0 = iorToF0( clearcoatIor );
 		let clearcoatFresnel = schlickFresnel( saturate( woClearcoat.z ), clearcoatF0 );
 		weights.clearcoat = surf.clearcoat * clearcoatFresnel;
-		weightLeft -= weights.clearcoat;
+		remaining -= weights.clearcoat;
 
 		let fEstimate = disneyFresnel( wo, wi, wh, surf.f0, surf.eta, surf.metalness );
-		weights.specular = weightLeft * ( surf.metalness + ( 1.0 - surf.metalness ) * fEstimate );
-		weightLeft -= weights.specular;
+		weights.specular = remaining * ( surf.metalness + ( 1.0 - surf.metalness ) * fEstimate );
+		remaining -= weights.specular;
 
-		weights.transmission = weightLeft * select( 0.0, surf.transmission, surf.transmission > 0.1 );
-		weightLeft -= weights.transmission;
+		weights.transmission = remaining * surf.transmission;
+		remaining -= weights.transmission;
 
-		weights.diffuse = weightLeft;
+		weights.diffuse = remaining;
 
 		return weights;
 

--- a/src/webgpu/nodes/sampling.wgsl.js
+++ b/src/webgpu/nodes/sampling.wgsl.js
@@ -1,6 +1,6 @@
 import { wgslFn } from 'three/tsl';
 import { environmentInfoStruct, constants, lobeWeightsStruct } from './structs.wgsl.js';
-import { evaluateFresnelFunc, iorToF0Func, schlickFresnelFunc } from './utils.wgsl.js';
+import { disneyFresnelFunc, iorToF0Func, schlickFresnelFunc } from './utils.wgsl.js';
 
 /*
 wi     : incident vector or light vector (pointing toward the light)
@@ -42,39 +42,30 @@ export const diffuseDirectionFunc = wgslFn( /* wgsl */ `
 
 export const getLobeWeightsFunc = wgslFn( /* wgsl */ `
 
-	fn getLobeWeights(wo: vec3f, woClearcoat: vec3f, wh: vec3f, clearcoatIor: f32, surf: SurfaceRecord) -> LobeWeights {
-
-		// TODO: experiment with this; I don't see any usage of normal?
-		let metalness = surf.metalness;
-		let transmission = surf.transmission;
-		let HdotL = dot( wh, wo );
-		let fEstimate = evaluateFresnel( HdotL, surf.eta, vec3f( surf.f0 ), vec3f( 1.0 ) ).x;
-
-		let transSpecularProb = mix( max( 0.25, fEstimate ), 1.0, metalness );
-		let diffSpecularProb = 0.5 + 0.5 * metalness;
+	fn getLobeWeights(wo: vec3f, wi: vec3f, woClearcoat: vec3f, wh: vec3f, clearcoatIor: f32, surf: SurfaceRecord) -> LobeWeights {
 
 		var weights: LobeWeights;
-		weights.diffuse = ( 1.0 - transmission ) * ( 1.0 - diffSpecularProb );
-		weights.specular = transmission * transSpecularProb + ( 1.0 - transmission ) * diffSpecularProb;
+		var weightLeft = 1.0;
 
 		let clearcoatF0 = iorToF0( clearcoatIor );
 		let clearcoatFresnel = schlickFresnel( saturate( woClearcoat.z ), clearcoatF0 );
 		weights.clearcoat = surf.clearcoat * clearcoatFresnel;
+		weightLeft -= weights.clearcoat;
 
-		weights.transmission = transmission * ( 1.0 - transSpecularProb );
+		let fEstimate = disneyFresnel( wo, wi, wh, surf.f0, surf.eta, surf.metalness );
+		weights.specular = weightLeft * ( surf.metalness + ( 1.0 - surf.metalness ) * fEstimate );
+		weightLeft -= weights.specular;
 
-		let totalWeight = weights.diffuse + weights.specular;
-		if ( totalWeight > 0 ) {
-			weights.diffuse = ( weights.diffuse / totalWeight ) * ( 1 - weights.clearcoat );
-			weights.specular = ( weights.specular / totalWeight ) * ( 1 - weights.clearcoat );
-		}
-		// weights.transmission /= totalWeight;
+		weights.transmission = weightLeft * select( 0.0, surf.transmission, surf.transmission > 0.1 );
+		weightLeft -= weights.transmission;
+
+		weights.diffuse = weightLeft;
 
 		return weights;
 
 	}
 
-`, [ schlickFresnelFunc, iorToF0Func, evaluateFresnelFunc, lobeWeightsStruct, constants ] );
+`, [ disneyFresnelFunc, schlickFresnelFunc, iorToF0Func, lobeWeightsStruct, constants ] );
 
 const equirectDirectionToUvFn = wgslFn( /* wgsl */`
 

--- a/src/webgpu/nodes/structs.wgsl.js
+++ b/src/webgpu/nodes/structs.wgsl.js
@@ -76,7 +76,7 @@ export const materialStruct = new StructTypeNode( {
 	// offset 40 floats
 	specularIntensity: 'float',
 	specularIntensityMap: 'int',
-	thinFilm: 'int', // actually a boolean
+	thinWall: 'int', // actually a boolean
 
 	// offset 44 floats
 	attenuationColor: 'vec3',
@@ -176,7 +176,7 @@ export const surfaceRecordStruct = new StructTypeNode( {
 	// transmission
 	ior: 'f32',
 	transmission: 'f32',
-	thinFilm: 'bool',
+	thinWall: 'bool',
 	attenuationColor: 'vec3f',
 	attenuationDistance: ' f32',
 

--- a/src/webgpu/nodes/structs.wgsl.js
+++ b/src/webgpu/nodes/structs.wgsl.js
@@ -11,9 +11,11 @@ export const constants = wgsl( /* wgsl */ `
 
 ` );
 
+export const SCATTER_RECORD_FLAG_TRANSMISSIVE = 1 << 0;
+
 export const scatterRecordStruct = new StructTypeNode( {
 	color: 'vec3f',
-	specularPdf: 'float',
+	flags: 'uint',
 	direction: 'vec3f',
 	pdf: 'float',
 }, 'ScatterRecord' );

--- a/src/webgpu/nodes/structs.wgsl.js
+++ b/src/webgpu/nodes/structs.wgsl.js
@@ -11,11 +11,9 @@ export const constants = wgsl( /* wgsl */ `
 
 ` );
 
-export const SCATTER_RECORD_FLAG_TRANSMISSIVE = 1 << 0;
-
 export const scatterRecordStruct = new StructTypeNode( {
 	color: 'vec3f',
-	flags: 'uint',
+	isTransmissive: 'bool',
 	direction: 'vec3f',
 	pdf: 'float',
 }, 'ScatterRecord' );

--- a/src/webgpu/nodes/utils.wgsl.js
+++ b/src/webgpu/nodes/utils.wgsl.js
@@ -119,6 +119,17 @@ export const totalInternalReflectionFunc = wgslFn( /* wgsl */ `
 
 ` );
 
+export const totalInternalReflectionVecFunc = wgslFn( /* wgsl */ `
+
+	fn totalInternalReflectionVec( cosTheta: f32, eta: vec3f ) -> vec3<bool> {
+
+		let sinTheta = sqrt( 1.0 - cosTheta * cosTheta );
+		return eta * sinTheta > vec3f( 1.0 );
+
+	}
+
+` );
+
 export const evaluateFresnelFunc = wgslFn( /* wgsl */ `
 
 	fn evaluateFresnel( cosine: f32, eta: f32, f0: vec3f, f90: vec3f ) -> vec3f {

--- a/src/webgpu/nodes/utils.wgsl.js
+++ b/src/webgpu/nodes/utils.wgsl.js
@@ -134,6 +134,54 @@ export const evaluateFresnelFunc = wgslFn( /* wgsl */ `
 
 `, [ totalInternalReflectionFunc ] );
 
+export const dielectricFresnelFunc = wgslFn( /* wgsl */ `
+
+	fn dielectricFresnel( cosThetaI: f32, eta: f32 ) -> f32 {
+
+		// https://schuttejoe.github.io/post/disneybsdf/
+		let ni = eta;
+		let nt = 1.0;
+
+		// Check for total internal reflection
+		let sinThetaISq = 1.0 - cosThetaI * cosThetaI;
+		let sinThetaTSq = eta * eta * sinThetaISq;
+		if ( sinThetaTSq >= 1.0 ) {
+
+			return 1.0;
+
+		}
+
+		let sinThetaT = sqrt( sinThetaTSq );
+		let cosThetaT = sqrt( max( 0.0, 1.0 - sinThetaT * sinThetaT ) );
+		let rParallel = ( ( nt * cosThetaI ) - ( ni * cosThetaT ) ) / ( ( nt * cosThetaI ) + ( ni * cosThetaT ) );
+		let rPerpendicular = ( ( ni * cosThetaI ) - ( nt * cosThetaT ) ) / ( ( ni * cosThetaI ) + ( nt * cosThetaT ) );
+		return ( rParallel * rParallel + rPerpendicular * rPerpendicular ) / 2.0;
+
+	}
+
+` );
+
+export const disneyFresnelFunc = wgslFn( /* wgsl */ `
+
+	fn disneyFresnel( wo: vec3f, wi: vec3f, wh: vec3f, f0: f32, eta: f32, metalness: f32 ) -> f32 {
+
+		let dotHV = dot( wo, wh );
+		if ( totalInternalReflection( dotHV, eta ) ) {
+
+			return 1.0;
+
+		}
+
+		let dotHL = dot( wi, wh );
+		let dielectricF = dielectricFresnel( abs( dotHV ), eta );
+		let metallicF = schlickFresnel( dotHL, f0 );
+
+		return mix( dielectricF, metallicF, metalness );
+
+	}
+
+`, [ totalInternalReflectionFunc, dielectricFresnelFunc, schlickFresnelFunc ] );
+
 export const isTerminatingScatterFunc = wgslFn( /* wgsl */ `
 
 	fn isTerminatingScatter( scatterRec: ScatterRecord ) -> bool {


### PR DESCRIPTION
Related to #770, #777

- Adds support for transmission and thin film transmission
- Removes "transmissiveBounces"
- Adds three options for transparent background handling with transmissive objects - display env map, overlay env map with average color used to drive alpha (so there's some color overlaid), and just transparent.
- Add support for thin film, mirroring Blender's method
- Rename "thinFilm" to "thinWall", matching blenders vocabulary

**TODO**
- Clean up
- Review


<img height="300" alt="image" src="https://github.com/user-attachments/assets/f3991182-6c07-4820-a51e-295514bd232b" /> 
<img height="300" alt="image" src="https://github.com/user-attachments/assets/c4a9e417-69cf-4c4a-ac79-a95078b9186a" />
<img height="300" alt="image" src="https://github.com/user-attachments/assets/9c763a07-106d-4864-9f28-e3c1b1645c57" />


And the new transmissive background handling options:

| Env Map | Overlay | Transparent | WebGLPathTracer Approach |
|---|---|---|---|
| <img width="1274" height="1154" alt="image" src="https://github.com/user-attachments/assets/6dc745e4-d489-4778-8df8-7319175453f1" /> | <img width="1274" height="1154" alt="image" src="https://github.com/user-attachments/assets/17ab08e9-7d87-4095-9b8c-4af5889666e0" /> | <img width="1274" height="1154" alt="image" src="https://github.com/user-attachments/assets/fd845051-e3e3-466a-8f69-f88f41480c12" /> | <img width="1274" height="1154" alt="image" src="https://github.com/user-attachments/assets/c857f19f-024a-4deb-b9fd-8c3e9b8bd505" /> |



