### PR TITLE
Support ArrayCamera and restore the LKG example

### DIFF
--- a/example/lkg.html
+++ b/example/lkg.html
@@ -58,7 +58,7 @@
 	<body>
 		<div id="loading">LOADING</div>
 		<div id="description">
-			Quilt rendering using WebXR to support hologram display on the <a href="https://lookingglassfactory.com/looking-glass-portrait">Looking Glass Portrait</a> display.
+			WebGPU quilt rendering for hologram display on the <a href="https://lookingglassfactory.com/looking-glass-portrait">Looking Glass Portrait</a> display.
 			<br/>
 			<br/>
 

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -101,7 +101,7 @@ const params = {
 
 	enable: true,
 	model: modelName in MODELS ? modelName : 'Voltron - Voltron',
-	renderScale: 0.25,
+	renderScale: 1,
 	tiles: 1,
 
 	samplesPerFrame: 1,
@@ -167,7 +167,7 @@ async function init() {
 	const adapter = await navigator.gpu?.requestAdapter();
 	const requiredLimits = getRequiredDeviceLimits( adapter );
 	// init renderer
-	renderer = new WebGPURenderer( { antialias: true, preserveDrawingBuffer: true, requiredLimits } );
+	renderer = new WebGPURenderer( { antialias: true, requiredLimits } );
 	await renderer.init();
 	renderer.toneMapping = ACESFilmicToneMapping;
 	document.body.appendChild( renderer.domElement );
@@ -348,11 +348,14 @@ async function animate() {
 
 	}
 
+	let pathTracingFrame = false;
 	if ( ! params.enable || interacting ) {
 
 		renderer.render( scene, camera );
 
 	} else {
+
+		pathTracingFrame = true;
 
 		// set path tracer variables
 		pathTracer.pause = params.pause;
@@ -386,7 +389,7 @@ async function animate() {
 	distEl.innerText = `Distance: ${ camera.position.length().toFixed( 2 ) }`;
 
 	const queue = renderer.backend?.device?.queue;
-	if ( queue?.onSubmittedWorkDone ) {
+	if ( pathTracingFrame && queue?.onSubmittedWorkDone ) {
 
 		// Keep CPU-side progress in step with completed GPU work.
 		await queue.onSubmittedWorkDone();
@@ -426,7 +429,6 @@ function onLkgParamsChange() {
 	const { renderScale } = params;
 
 	lkgParams = getLkgParams( params.numViews );
-	const previousCameraCount = quiltCamera.cameras.length;
 	updateQuiltCamera();
 
 	const width = Math.max( 1, Math.floor( renderScale * lkgParams.quiltWidth ) );
@@ -435,20 +437,11 @@ function onLkgParamsChange() {
 	previewQuad.material.quiltMap = pathTracer.target;
 	previewQuad.material.quiltDimensions.set( lkgParams.quiltTilesX, lkgParams.quiltTilesY );
 
-	if ( previousCameraCount !== quiltCamera.cameras.length ) {
-
-		pathTracer.setCamera( quiltCamera );
-
-	} else {
-
-		pathTracer.updateCamera();
-
-	}
+	pathTracer.updateCamera();
 
 }
 
-// Rebuild the off-axis cameras and their quilt viewports. Extra cells in the
-// final row repeat the last view so every output pixel belongs to a camera.
+// Rebuild the off-axis cameras and their quilt viewports.
 function updateQuiltCamera() {
 
 	const {
@@ -461,7 +454,6 @@ function updateQuiltCamera() {
 	const { renderScale, viewCone, viewerDistance } = params;
 	const width = Math.max( 1, Math.floor( renderScale * quiltWidth ) );
 	const height = Math.max( 1, Math.floor( renderScale * quiltHeight ) );
-	const cameraCount = quiltTilesX * quiltTilesY;
 
 	const displayHalfHeight = DISPLAY_HEIGHT * 0.5;
 	const displayHalfWidth = DISPLAY_WIDTH * 0.5;
@@ -472,7 +464,7 @@ function updateQuiltCamera() {
 	camera.updateProjectionMatrix();
 	camera.updateMatrixWorld();
 
-	while ( quiltCamera.cameras.length < cameraCount ) {
+	while ( quiltCamera.cameras.length < numViews ) {
 
 		const subCamera = new PerspectiveCamera();
 		subCamera.coordinateSystem = WebGPUCoordinateSystem;
@@ -481,11 +473,10 @@ function updateQuiltCamera() {
 
 	}
 
-	quiltCamera.cameras.length = cameraCount;
-	for ( let i = 0; i < cameraCount; i ++ ) {
+	quiltCamera.cameras.length = numViews;
+	for ( let i = 0; i < numViews; i ++ ) {
 
-		const viewIndex = Math.min( i, numViews - 1 );
-		const viewAlpha = numViews === 1 ? 0.5 : viewIndex / ( numViews - 1 );
+		const viewAlpha = numViews === 1 ? 0.5 : i / ( numViews - 1 );
 		const offset = MathUtils.lerp( - halfViewWidth, halfViewWidth, viewAlpha );
 		const subCamera = quiltCamera.cameras[ i ];
 

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -123,6 +123,8 @@ const params = {
 let loadingEl, samplesEl, distEl;
 let renderer, camera, quiltCamera;
 let pathTracer, previewQuad, controls, scene;
+let interacting = false;
+let cameraChanged = false;
 const _translation = new Matrix4();
 const _size = new Vector2();
 
@@ -198,10 +200,15 @@ async function init() {
 
 	// init controls
 	controls = new OrbitControls( camera, renderer.domElement );
-	controls.addEventListener( 'change', () => {
+	controls.addEventListener( 'start', () => {
 
-		updateQuiltCamera();
-		pathTracer.updateCamera();
+		interacting = true;
+
+	} );
+	controls.addEventListener( 'end', () => {
+
+		interacting = false;
+		cameraChanged = true;
 
 	} );
 
@@ -333,7 +340,15 @@ async function init() {
 
 async function animate() {
 
-	if ( ! params.enable ) {
+	if ( cameraChanged && ! interacting ) {
+
+		updateQuiltCamera();
+		pathTracer.updateCamera();
+		cameraChanged = false;
+
+	}
+
+	if ( ! params.enable || interacting ) {
 
 		renderer.render( scene, camera );
 

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -70,21 +70,14 @@ const MATERIALS_URL = 'https://raw.githubusercontent.com/gkjohnson/ldraw-parts-l
 const PARTS_PATH = 'https://raw.githubusercontent.com/gkjohnson/ldraw-parts-library/master/complete/ldraw/';
 const MODELS = {
 	'X-Wing': 'https://raw.githubusercontent.com/mrdoob/three.js/r150/examples/models/ldraw/officialLibrary/models/7140-1-X-wingFighter.mpd_Packed.mpd',
-	'UCS AT-ST': 'https://raw.githubusercontent.com/mrdoob/three.js/r150/examples/models/ldraw/officialLibrary/models/10174-1-ImperialAT-ST-UCS.mpd_Packed.mpd',
-	'Death Star': 'https://raw.githubusercontent.com/gkjohnson/ldraw-parts-library/master/models/10143-1 - Death Star II.mpd',
 	'Lunar Vehicle': 'https://raw.githubusercontent.com/mrdoob/three.js/r150/examples/models/ldraw/officialLibrary/models/1621-1-LunarMPVVehicle.mpd_Packed.mpd',
 };
 
 [
 	'6814-1 - Ice Tunnelator.mpd',
-	'6861-2 - Super Model Building Instruction.mpd',
-	'75060 - Slave I.mpd',
 	'6983-1 - Ice Station Odyssey.mpd',
 	'6835-1 - Saucer Scout.mpd',
-	'21311 - Voltron - Voltron.mpd',
-	'21303 - WALLE.mpd',
 	'1180-1 - Space Port Moon Buggy.mpd',
-	'10179-1 - Millennium Falcon - UCS.mpd',
 	'6232-1 - Skeleton Crew.mpd',
 	'6235 - Buried Treasure.mpd',
 ].forEach( name => {
@@ -100,9 +93,9 @@ const modelName = decodeURI( window.location.hash.replace( /^#/, '' ) );
 const params = {
 
 	enable: true,
-	model: modelName in MODELS ? modelName : 'Voltron - Voltron',
+	model: modelName in MODELS ? modelName : 'X-Wing',
 	renderScale: 1,
-	tiles: 1,
+	tiles: 3,
 
 	samplesPerFrame: 1,
 	bounces: 5,
@@ -131,30 +124,6 @@ const _size = new Vector2();
 // initialize lkg parameters
 let lkgParams = getLkgParams( params.numViews );
 
-const DEVICE_LIMITS_REQUESTED = [
-	'maxBufferSize',
-	'maxStorageBufferBindingSize',
-];
-function getRequiredDeviceLimits( adapter ) {
-
-	const limits = {};
-
-	for ( const limit of DEVICE_LIMITS_REQUESTED ) {
-
-		const value = adapter.limits[ limit ];
-
-		if ( typeof value === 'number' && Number.isFinite( value ) ) {
-
-			limits[ limit ] = value;
-
-		}
-
-	}
-
-	return limits;
-
-}
-
 init();
 
 async function init() {
@@ -164,10 +133,8 @@ async function init() {
 	loadingEl = document.getElementById( 'loading' );
 	samplesEl = document.getElementById( 'samples' );
 
-	const adapter = await navigator.gpu?.requestAdapter();
-	const requiredLimits = getRequiredDeviceLimits( adapter );
 	// init renderer
-	renderer = new WebGPURenderer( { antialias: true, requiredLimits } );
+	renderer = new WebGPURenderer( { antialias: true } );
 	await renderer.init();
 	renderer.toneMapping = ACESFilmicToneMapping;
 	document.body.appendChild( renderer.domElement );
@@ -183,8 +150,6 @@ async function init() {
 	// initialize the path tracer. The quilt has its own fixed resolution, independent
 	// of the preview canvas, so automatic and low-resolution resizing must be disabled.
 	pathTracer = new WebGPUPathTracer( renderer );
-	// Avoid the large fixed ray queues used by the wavefront backend.
-	pathTracer.useMegakernel( true );
 	pathTracer.synchronizeRenderSize = false;
 	pathTracer.dynamicLowRes = false;
 	pathTracer.tiles.set( params.tiles, params.tiles );
@@ -456,9 +421,7 @@ function updateQuiltCamera() {
 	const height = Math.max( 1, Math.floor( renderScale * quiltHeight ) );
 
 	const displayHalfHeight = DISPLAY_HEIGHT * 0.5;
-	const displayHalfWidth = DISPLAY_WIDTH * 0.5;
 	const halfViewWidth = Math.tan( viewCone * MathUtils.DEG2RAD * 0.5 ) * viewerDistance;
-	const nearScale = camera.near / viewerDistance;
 
 	camera.fov = 2 * Math.atan( displayHalfHeight / viewerDistance ) * MathUtils.RAD2DEG;
 	camera.updateProjectionMatrix();
@@ -486,16 +449,10 @@ function updateQuiltCamera() {
 
 		subCamera.near = camera.near;
 		subCamera.far = camera.far;
-		subCamera.projectionMatrix.makePerspective(
-			nearScale * ( - displayHalfWidth - offset ),
-			nearScale * ( displayHalfWidth - offset ),
-			nearScale * displayHalfHeight,
-			nearScale * - displayHalfHeight,
-			camera.near,
-			camera.far,
-			WebGPUCoordinateSystem,
-		);
-		subCamera.projectionMatrixInverse.copy( subCamera.projectionMatrix ).invert();
+		subCamera.fov = camera.fov;
+		subCamera.aspect = DISPLAY_WIDTH / DISPLAY_HEIGHT;
+		subCamera.filmOffset = - offset * subCamera.getFilmWidth() / viewerDistance;
+		subCamera.updateProjectionMatrix();
 
 		const tileX = i % quiltTilesX;
 		const tileY = Math.floor( i / quiltTilesX );
@@ -579,7 +536,7 @@ function buildGui() {
 
 	} );
 	ptFolder.add( params, 'samplesPerFrame', 1, 10, 1 );
-	ptFolder.add( params, 'tiles', 1, 3, 1 ).onChange( v => {
+	ptFolder.add( params, 'tiles', 3, 6, 1 ).onChange( v => {
 
 		pathTracer.tiles.setScalar( v );
 

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -27,7 +27,6 @@ import { LDrawUtils } from 'three/examples/jsm/utils/LDrawUtils.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import { generateRadialFloorTexture } from './utils/generateRadialFloorTexture.js';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { WebGPUPathTracer } from 'three-gpu-pathtracer/webgpu';
 import { QuiltPreviewNodeMaterial } from './materials/QuiltPreviewNodeMaterial.js';
 
@@ -115,9 +114,7 @@ const params = {
 
 let loadingEl, samplesEl, distEl;
 let renderer, camera, quiltCamera;
-let pathTracer, previewQuad, controls, scene;
-let interacting = false;
-let cameraChanged = false;
+let pathTracer, previewQuad, scene;
 const _translation = new Matrix4();
 const _size = new Vector2();
 
@@ -162,20 +159,6 @@ async function init() {
 		quiltDimensions: new Vector2(),
 		aspectRatio: DISPLAY_WIDTH / DISPLAY_HEIGHT,
 	} ) );
-
-	// init controls
-	controls = new OrbitControls( camera, renderer.domElement );
-	controls.addEventListener( 'start', () => {
-
-		interacting = true;
-
-	} );
-	controls.addEventListener( 'end', () => {
-
-		interacting = false;
-		cameraChanged = true;
-
-	} );
 
 	onResize();
 	onLkgParamsChange();
@@ -292,7 +275,7 @@ async function init() {
 
 		loadingEl.style.visibility = 'hidden';
 		renderer.domElement.style.visibility = 'visible';
-		requestAnimationFrame( animate );
+		renderer.setAnimationLoop( animate );
 
 	} catch ( err ) {
 
@@ -305,22 +288,11 @@ async function init() {
 
 async function animate() {
 
-	if ( cameraChanged && ! interacting ) {
-
-		updateQuiltCamera();
-		pathTracer.updateCamera();
-		cameraChanged = false;
-
-	}
-
-	let pathTracingFrame = false;
-	if ( ! params.enable || interacting ) {
+	if ( ! params.enable ) {
 
 		renderer.render( scene, camera );
 
 	} else {
-
-		pathTracingFrame = true;
 
 		// set path tracer variables
 		pathTracer.pause = params.pause;
@@ -354,14 +326,12 @@ async function animate() {
 	distEl.innerText = `Distance: ${ camera.position.length().toFixed( 2 ) }`;
 
 	const queue = renderer.backend?.device?.queue;
-	if ( pathTracingFrame && queue?.onSubmittedWorkDone ) {
+	if ( params.enable && queue?.onSubmittedWorkDone ) {
 
 		// Keep CPU-side progress in step with completed GPU work.
 		await queue.onSubmittedWorkDone();
 
 	}
-
-	requestAnimationFrame( animate );
 
 }
 

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -17,7 +17,6 @@ import {
 	Sphere,
 	Vector2,
 	Vector4,
-	WebGPUCoordinateSystem,
 	WebGPURenderer,
 } from 'three/webgpu';
 import { HDRLoader } from 'three/examples/jsm/loaders/HDRLoader.js';
@@ -29,32 +28,6 @@ import { generateRadialFloorTexture } from './utils/generateRadialFloorTexture.j
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { WebGPUPathTracer } from 'three-gpu-pathtracer/webgpu';
 import { QuiltPreviewNodeMaterial } from './materials/QuiltPreviewNodeMaterial.js';
-
-function normalizePackedFileNames( text ) {
-
-	// Match embedded MPD file names to LDrawLoader's normalized subobject paths.
-	return text.replace( /^0 FILE (.+)$/gm, ( _, name ) => {
-
-		name = name.replace( /\\/g, '/' );
-		name = name.startsWith( 's/' ) ? `parts/${ name }` : name.startsWith( '48/' ) ? `p/${ name }` : name;
-		return `0 FILE ${ name }`;
-
-	} );
-
-}
-
-class PackedLDrawLoader extends LDrawLoader {
-
-	constructor( manager ) {
-
-		super( manager );
-		const parseCache = this.partsCache.parseCache;
-		const parse = parseCache.parse.bind( parseCache );
-		parseCache.parse = ( text, fileName ) => parse( normalizePackedFileNames( text ), fileName );
-
-	}
-
-}
 
 // lkg display constants
 const LKG_WIDTH = 420;
@@ -185,7 +158,7 @@ async function init() {
 	try {
 
 		const envPromise = new HDRLoader().loadAsync( ENVMAP_URL );
-		const loader = new PackedLDrawLoader( manager );
+		const loader = new LDrawLoader( manager );
 		loader.setConditionalLineMaterial( LDrawConditionalLineMaterial );
 		await loader.preloadMaterials( MATERIALS_URL );
 		const result = await loader
@@ -287,7 +260,7 @@ async function init() {
 
 }
 
-async function animate() {
+function animate() {
 
 	if ( ! params.enable ) {
 
@@ -325,14 +298,6 @@ async function animate() {
 
 	samplesEl.innerText = `Samples: ${ Math.floor( pathTracer.samples ) }`;
 	distEl.innerText = `Distance: ${ camera.position.length().toFixed( 2 ) }`;
-
-	const queue = renderer.backend?.device?.queue;
-	if ( params.enable && queue?.onSubmittedWorkDone ) {
-
-		// Keep CPU-side progress in step with completed GPU work.
-		await queue.onSubmittedWorkDone();
-
-	}
 
 }
 
@@ -401,7 +366,6 @@ function updateQuiltCamera() {
 	while ( quiltCamera.cameras.length < numViews ) {
 
 		const subCamera = new PerspectiveCamera();
-		subCamera.coordinateSystem = WebGPUCoordinateSystem;
 		subCamera.viewport = new Vector4();
 		quiltCamera.cameras.push( subCamera );
 

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -142,6 +142,7 @@ async function init() {
 	const aspect = window.innerWidth / window.innerHeight;
 	camera = new PerspectiveCamera( 60, aspect, 0.025, 500 );
 	camera.position.set( 0.43, 0.06, - 0.2 ).normalize().multiplyScalar( 0.48 );
+	camera.lookAt( 0, 0, 0 );
 	quiltCamera = new ArrayCamera();
 
 	// initialize the path tracer. The quilt has its own fixed resolution, independent

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -1,37 +1,61 @@
 import {
 	ACESFilmicToneMapping,
+	ArrayCamera,
 	Box3,
-	LoadingManager,
-	Sphere,
 	DoubleSide,
-	Mesh,
-	MeshStandardMaterial,
-	PlaneGeometry,
-	Group,
-	MeshPhysicalMaterial,
-	WebGLRenderer,
-	Scene,
-	MeshBasicMaterial,
-	CustomBlending,
 	EquirectangularReflectionMapping,
+	Group,
+	LoadingManager,
 	MathUtils,
-	Vector4
-} from 'three';
+	Matrix4,
+	Mesh,
+	MeshPhysicalMaterial,
+	MeshStandardMaterial,
+	PerspectiveCamera,
+	PlaneGeometry,
+	Scene,
+	Sphere,
+	Vector2,
+	Vector4,
+	WebGPUCoordinateSystem,
+	WebGPURenderer,
+} from 'three/webgpu';
 import { HDRLoader } from 'three/examples/jsm/loaders/HDRLoader.js';
 import { LDrawLoader } from 'three/examples/jsm/loaders/LDrawLoader.js';
+import { LDrawConditionalLineMaterial } from 'three/examples/jsm/materials/LDrawConditionalLineNodeMaterial.js';
 import { LDrawUtils } from 'three/examples/jsm/utils/LDrawUtils.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import Stats from 'three/examples/jsm/libs/stats.module.js';
 import { generateRadialFloorTexture } from './utils/generateRadialFloorTexture.js';
-import { PathTracingSceneGenerator } from '../src/core/PathTracingSceneGenerator.js';
-import { PhysicalCamera } from 'three-gpu-pathtracer';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { QuiltPreviewMaterial } from './materials/QuiltPreviewMaterial.js';
-import { QuiltPathTracingRenderer } from '../src/core/QuiltPathTracingRenderer.js';
+import { WebGPUPathTracer } from 'three-gpu-pathtracer/webgpu';
+import { QuiltPreviewNodeMaterial } from './materials/QuiltPreviewNodeMaterial.js';
 
-import { LookingGlassWebXRPolyfill, LookingGlassConfig } from '@lookingglass/webxr';
-import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+function normalizePackedFileNames( text ) {
+
+	// Match embedded MPD file names to LDrawLoader's normalized subobject paths.
+	return text.replace( /^0 FILE (.+)$/gm, ( _, name ) => {
+
+		name = name.replace( /\\/g, '/' );
+		name = name.startsWith( 's/' ) ? `parts/${ name }` : name.startsWith( '48/' ) ? `p/${ name }` : name;
+		return `0 FILE ${ name }`;
+
+	} );
+
+}
+
+class PackedLDrawLoader extends LDrawLoader {
+
+	constructor( manager ) {
+
+		super( manager );
+		const parseCache = this.partsCache.parseCache;
+		const parse = parseCache.parse.bind( parseCache );
+		parseCache.parse = ( text, fileName ) => parse( normalizePackedFileNames( text ), fileName );
+
+	}
+
+}
 
 // lkg display constants
 const LKG_WIDTH = 420;
@@ -77,7 +101,7 @@ const params = {
 
 	enable: true,
 	model: modelName in MODELS ? modelName : 'Voltron - Voltron',
-	renderScale: 1,
+	renderScale: 0.25,
 	tiles: 1,
 
 	samplesPerFrame: 1,
@@ -92,23 +116,42 @@ const params = {
 	viewCone: 35,
 	viewerDistance: VIEWER_DISTANCE,
 
-	saveQuilt: () => {
-
-		saveQuilt();
-
-	},
+	saveQuilt,
 
 };
 
 let loadingEl, samplesEl, distEl;
-let gui, stats;
-let renderer, camera;
-let ptRenderer, fsQuad, previewQuad, controls, scene;
-let saveButton;
-const _viewport = new Vector4();
+let renderer, camera, quiltCamera;
+let pathTracer, previewQuad, controls, scene;
+const _translation = new Matrix4();
+const _size = new Vector2();
 
 // initialize lkg parameters
 let lkgParams = getLkgParams( params.numViews );
+
+const DEVICE_LIMITS_REQUESTED = [
+	'maxBufferSize',
+	'maxStorageBufferBindingSize',
+];
+function getRequiredDeviceLimits( adapter ) {
+
+	const limits = {};
+
+	for ( const limit of DEVICE_LIMITS_REQUESTED ) {
+
+		const value = adapter.limits[ limit ];
+
+		if ( typeof value === 'number' && Number.isFinite( value ) ) {
+
+			limits[ limit ] = value;
+
+		}
+
+	}
+
+	return limits;
+
+}
 
 init();
 
@@ -119,59 +162,53 @@ async function init() {
 	loadingEl = document.getElementById( 'loading' );
 	samplesEl = document.getElementById( 'samples' );
 
+	const adapter = await navigator.gpu?.requestAdapter();
+	const requiredLimits = getRequiredDeviceLimits( adapter );
 	// init renderer
-	renderer = new WebGLRenderer( { antialias: true } );
+	renderer = new WebGPURenderer( { antialias: true, preserveDrawingBuffer: true, requiredLimits } );
+	await renderer.init();
 	renderer.toneMapping = ACESFilmicToneMapping;
-	renderer.xr.enabled = true;
 	document.body.appendChild( renderer.domElement );
 
 	scene = new Scene();
 
 	// initialize the camera
 	const aspect = window.innerWidth / window.innerHeight;
-	camera = new PhysicalCamera( 60, aspect, 0.025, 500 );
+	camera = new PerspectiveCamera( 60, aspect, 0.025, 500 );
 	camera.position.set( 0.43, 0.06, - 0.2 ).normalize().multiplyScalar( 0.48 );
-	camera.bokehSize = 0;
+	quiltCamera = new ArrayCamera();
 
-	// initialize the quilt renderer
-	ptRenderer = new QuiltPathTracingRenderer( renderer );
-	ptRenderer.tiles.set( params.tiles, params.tiles );
-	ptRenderer.camera = camera;
-
-	camera.fov = ptRenderer.viewFoV * MathUtils.RAD2DEG;
-	camera.updateProjectionMatrix();
+	// initialize the path tracer. The quilt has its own fixed resolution, independent
+	// of the preview canvas, so automatic and low-resolution resizing must be disabled.
+	pathTracer = new WebGPUPathTracer( renderer );
+	// Avoid the large fixed ray queues used by the wavefront backend.
+	pathTracer.useMegakernel( true );
+	pathTracer.synchronizeRenderSize = false;
+	pathTracer.dynamicLowRes = false;
+	pathTracer.tiles.set( params.tiles, params.tiles );
+	pathTracer.bounces = params.bounces;
+	pathTracer.filterGlossyFactor = params.filterGlossyFactor;
 
 	// initialize quads
-	fsQuad = new FullScreenQuad( new MeshBasicMaterial( {
-		map: ptRenderer.target.texture,
-		blending: CustomBlending,
-	} ) );
-
-	previewQuad = new FullScreenQuad( new QuiltPreviewMaterial( {
-		quiltMap: ptRenderer.target.texture,
-		quiltDimensions: ptRenderer.quiltDimensions,
-		aspectRatio: ptRenderer.displayAspect,
+	previewQuad = new FullScreenQuad( new QuiltPreviewNodeMaterial( {
+		quiltMap: pathTracer.target,
+		quiltDimensions: new Vector2(),
+		aspectRatio: DISPLAY_WIDTH / DISPLAY_HEIGHT,
 	} ) );
 
 	// init controls
 	controls = new OrbitControls( camera, renderer.domElement );
 	controls.addEventListener( 'change', () => {
 
-		ptRenderer.reset();
+		updateQuiltCamera();
+		pathTracer.updateCamera();
 
 	} );
 
-	// load the environment map
-	new HDRLoader()
-		.load( ENVMAP_URL, texture => {
-
-			texture.mapping = EquirectangularReflectionMapping;
-			scene.environment = texture;
-			scene.background = texture;
-			ptRenderer.material.envMapInfo.updateFrom( texture );
-			ptRenderer.reset();
-
-		} );
+	onResize();
+	onLkgParamsChange();
+	buildGui();
+	window.addEventListener( 'resize', onResize );
 
 	// load the lego model
 	let failed = false;
@@ -189,230 +226,159 @@ async function init() {
 
 	};
 
-	// Load the lego model
-	let generator;
-	const loader = new LDrawLoader( manager );
-	await loader.preloadMaterials( MATERIALS_URL );
-	loader
-		.setPartsLibraryPath( PARTS_PATH )
-		.loadAsync( MODELS[ params.model ] )
-		.then( result => {
+	try {
 
-			// get a merged version of the model
-			const model = LDrawUtils.mergeObject( result );
-			model.rotation.set( Math.PI, 0, 0 );
+		const envPromise = new HDRLoader().loadAsync( ENVMAP_URL );
+		const loader = new PackedLDrawLoader( manager );
+		loader.setConditionalLineMaterial( LDrawConditionalLineMaterial );
+		await loader.preloadMaterials( MATERIALS_URL );
+		const result = await loader
+			.setPartsLibraryPath( PARTS_PATH )
+			.loadAsync( MODELS[ params.model ] );
 
-			// remove the non mesh components
-			const toRemove = [];
-			model.traverse( c => {
+		// get a merged version of the model
+		const model = LDrawUtils.mergeObject( result );
+		model.rotation.set( Math.PI, 0, 0 );
 
-				if ( c.isLineSegments ) {
+		// remove the non mesh components
+		const toRemove = [];
+		model.traverse( c => {
 
-					toRemove.push( c );
+			if ( c.isLineSegments ) {
 
-				}
-
-				if ( c.isMesh ) {
-
-					c.material.roughness *= 0.25;
-
-				}
-
-			} );
-
-			toRemove.forEach( c => {
-
-				c.parent.remove( c );
-
-			} );
-
-			// conver materials
-			convertOpacityToTransmission( model, 1.4 );
-
-			// generate the floor
-			const floorTex = generateRadialFloorTexture( 2048 );
-			const floorPlane = new Mesh(
-				new PlaneGeometry(),
-				new MeshStandardMaterial( {
-					map: floorTex,
-					transparent: true,
-					color: 0x111111,
-					roughness: 0.2,
-					metalness: 0.2,
-					side: DoubleSide,
-				} )
-			);
-			floorPlane.scale.setScalar( 5 );
-			floorPlane.rotation.x = - Math.PI / 2;
-
-			// center the model
-			const box = new Box3();
-			box.setFromObject( model );
-			model.position
-				.addScaledVector( box.min, - 0.5 )
-				.addScaledVector( box.max, - 0.5 );
-
-			const sphere = new Sphere();
-			box.getBoundingSphere( sphere );
-
-			const boxRadius2d = Math.sqrt( box.min.x ** 2 + box.min.z ** 2 );
-			const widthRadiusScale = 0.06 / Math.min( boxRadius2d, sphere.radius );
-			const heightRadiusScale = 0.14 / ( box.max.y - box.min.y );
-			const scaleRadius = Math.min( widthRadiusScale, heightRadiusScale );
-
-			// scale the model to 0.06 m so it fits within the LKG view volume
-			model.scale.setScalar( scaleRadius );
-			model.position.multiplyScalar( scaleRadius );
-			model.updateMatrixWorld();
-			box.setFromObject( model );
-
-			// generate the view group
-			const group = new Group();
-			floorPlane.position.y = box.min.y;
-			group.add( model, floorPlane );
-			group.updateMatrixWorld( true );
-
-			generator = new PathTracingSceneGenerator();
-			return generator.generate( group, { onProgress: v => {
-
-				const percent = Math.floor( 100 * v );
-				loadingEl.innerText = `Building BVH : ${ percent }%`;
-
-			} } );
-
-		} )
-		.then( result => {
-
-			scene.add( result.scene );
-
-			const { bvh, textures, materials, geometry } = result;
-			const material = ptRenderer.material;
-
-			material.bvh.updateFrom( bvh );
-			material.attributesArray.updateFrom(
-				geometry.attributes.normal,
-				geometry.attributes.tangent,
-				geometry.attributes.uv,
-				geometry.attributes.color,
-			);
-			material.materialIndexAttribute.updateFrom( geometry.attributes.materialIndex );
-			material.textures.setTextures( renderer, textures, 2048, 2048 );
-			material.materials.updateFrom( materials, textures );
-
-			generator.dispose();
-
-			loadingEl.style.visibility = 'hidden';
-			renderer.domElement.style.visibility = 'visible';
-			ptRenderer.reset();
-
-			// initialize LKG XR
-			new LookingGlassWebXRPolyfill();
-			document.body.append( VRButton.createButton( renderer ) );
-
-			// start render loop
-			renderer.setAnimationLoop( animate );
-
-		} )
-		.catch( err => {
-
-			failed = true;
-			loadingEl.innerText = 'Failed to load model. ' + err.message;
-
-		} );
-
-	stats = new Stats();
-	document.body.appendChild( stats.dom );
-
-	// initialize lkg config and xr button
-	LookingGlassConfig.tileHeight = LKG_HEIGHT;
-	LookingGlassConfig.numViews = params.numViews;
-	LookingGlassConfig.inlineView = 2;
-
-	onResize();
-	onLkgParamsChange();
-	buildGui();
-
-	window.addEventListener( 'resize', onResize );
-
-}
-
-function animate() {
-
-	// skip rendering if we still haven't loaded the env map
-	if ( ! scene.environment ) {
-
-		return;
-
-	}
-
-	// disable the xr component so three.js doesn't hijack the camera. But we need it enabled otherwise so
-	// we can start an xr session.
-	renderer.xr.enabled = false;
-	stats.update();
-
-	if ( ptRenderer.samples < 1.0 || ! params.enable ) {
-
-		renderer.render( scene, camera );
-
-	}
-
-	if ( params.enable ) {
-
-		// set path tracer variables
-		ptRenderer.material.filterGlossyFactor = params.filterGlossyFactor;
-		ptRenderer.material.bounces = params.bounces;
-		ptRenderer.material.physicalCamera.updateFrom( camera );
-		camera.updateMatrixWorld();
-
-		if ( ! params.pause || ptRenderer.samples < 1 ) {
-
-			for ( let i = 0, l = params.samplesPerFrame; i < l; i ++ ) {
-
-				ptRenderer.update();
+				toRemove.push( c );
 
 			}
 
-		}
+			if ( c.isMesh ) {
 
-		renderer.autoClear = false;
+				c.material.roughness *= 0.25;
 
-		if ( ptRenderer.samples > 1 && params.tiltingPreview && ! renderer.xr.isPresenting ) {
+			}
 
-			// render the animated tilting preview
-			const displayIndex = ( 0.5 + 0.5 * Math.sin( params.animationSpeed * window.performance.now() * 0.0025 ) ) * ptRenderer.viewCount;
-			previewQuad.material.displayIndex = Math.floor( displayIndex );
-			previewQuad.material.aspectRatio = ptRenderer.displayAspect * window.innerHeight / window.innerWidth;
-			previewQuad.material.heightScale = Math.min( LKG_HEIGHT / window.innerHeight, 1.0 );
-			previewQuad.render( renderer );
+		} );
 
-		} else if ( renderer.xr.isPresenting ) {
+		toRemove.forEach( c => {
 
-			// only display the first view if we haven't rendered the full number of views yet
-			LookingGlassConfig.numViews = ptRenderer.samples < 1.0 ? 1 : params.numViews;
+			c.parent.remove( c );
 
-			renderer.getViewport( _viewport );
-			renderer.setViewport( 0, 0, lkgParams.quiltWidth, lkgParams.quiltHeight );
-			fsQuad.render( renderer );
-			renderer.setViewport( _viewport );
+		} );
 
-		} else {
+		// convert materials
+		convertOpacityToTransmission( model, 1.4 );
 
-			// render the full quilt
-			fsQuad.render( renderer );
+		// generate the floor
+		const floorTex = generateRadialFloorTexture( 2048 );
+		const floorPlane = new Mesh(
+			new PlaneGeometry(),
+			new MeshStandardMaterial( {
+				map: floorTex,
+				transparent: true,
+				color: 0x111111,
+				roughness: 0.2,
+				metalness: 0.2,
+				side: DoubleSide,
+			} )
+		);
+		floorPlane.scale.setScalar( 5 );
+		floorPlane.rotation.x = - Math.PI / 2;
 
-		}
+		// center the model
+		const box = new Box3();
+		box.setFromObject( model );
+		model.position
+			.addScaledVector( box.min, - 0.5 )
+			.addScaledVector( box.max, - 0.5 );
 
-		renderer.autoClear = true;
+		const sphere = new Sphere();
+		box.getBoundingSphere( sphere );
+
+		const boxRadius2d = Math.sqrt( box.min.x ** 2 + box.min.z ** 2 );
+		const widthRadiusScale = 0.06 / Math.min( boxRadius2d, sphere.radius );
+		const heightRadiusScale = 0.14 / ( box.max.y - box.min.y );
+		const scaleRadius = Math.min( widthRadiusScale, heightRadiusScale );
+
+		// scale the model to 0.06 m so it fits within the LKG view volume
+		model.scale.setScalar( scaleRadius );
+		model.position.multiplyScalar( scaleRadius );
+		model.updateMatrixWorld();
+		box.setFromObject( model );
+
+		// generate the view group
+		const group = new Group();
+		floorPlane.position.y = box.min.y;
+		group.add( model, floorPlane );
+		scene.add( group );
+
+		loadingEl.innerText = 'Building scene';
+		const envTexture = await envPromise;
+		envTexture.mapping = EquirectangularReflectionMapping;
+		scene.environment = envTexture;
+		scene.background = envTexture;
+
+		pathTracer.setScene( scene, quiltCamera );
+
+		loadingEl.style.visibility = 'hidden';
+		renderer.domElement.style.visibility = 'visible';
+		requestAnimationFrame( animate );
+
+	} catch ( err ) {
+
+		failed = true;
+		loadingEl.innerText = 'Failed to load model. ' + err.message;
 
 	}
 
-	// toggle save button
-	saveButton.disable( renderer.xr.isPresenting );
+}
 
-	// re enable the xr manager
-	renderer.xr.enabled = true;
-	samplesEl.innerText = `Samples: ${ Math.floor( ptRenderer.samples ) }`;
+async function animate() {
+
+	if ( ! params.enable ) {
+
+		renderer.render( scene, camera );
+
+	} else {
+
+		// set path tracer variables
+		pathTracer.pause = params.pause;
+		const samplesPerFrame = params.pause ? 1 : params.samplesPerFrame;
+		for ( let i = 0; i < samplesPerFrame; i ++ ) {
+
+			pathTracer.renderSample();
+
+		}
+
+		if ( pathTracer.samples > 1 && params.tiltingPreview ) {
+
+			// render the animated tilting preview
+			const displayIndex = ( 0.5 + 0.5 * Math.sin( params.animationSpeed * window.performance.now() * 0.0025 ) ) * params.numViews;
+			previewQuad.material.displayIndex = Math.min( params.numViews - 1, Math.floor( displayIndex ) );
+			previewQuad.material.aspectRatio = DISPLAY_WIDTH / DISPLAY_HEIGHT * window.innerHeight / window.innerWidth;
+			previewQuad.material.heightScale = Math.min( LKG_HEIGHT / window.innerHeight, 1.0 );
+
+		} else {
+
+			previewQuad.material.displayIndex = - 1;
+
+		}
+
+		previewQuad.material.quiltMap = pathTracer.target;
+		previewQuad.render( renderer );
+
+	}
+
+	samplesEl.innerText = `Samples: ${ Math.floor( pathTracer.samples ) }`;
 	distEl.innerText = `Distance: ${ camera.position.length().toFixed( 2 ) }`;
+
+	const queue = renderer.backend?.device?.queue;
+	if ( queue?.onSubmittedWorkDone ) {
+
+		// Keep CPU-side progress in step with completed GPU work.
+		await queue.onSubmittedWorkDone();
+
+	}
+
+	requestAnimationFrame( animate );
 
 }
 
@@ -431,8 +397,6 @@ function getLkgParams( numViews ) {
 
 	return {
 		numViews,
-		numPixels,
-		bufferWidth,
 		quiltTilesX,
 		quiltTilesY,
 		quiltWidth,
@@ -444,16 +408,98 @@ function getLkgParams( numViews ) {
 // callback when a parameter impacting the LKG rendering changes
 function onLkgParamsChange() {
 
-	const { renderScale, viewCone, viewerDistance } = params;
+	const { renderScale } = params;
 
 	lkgParams = getLkgParams( params.numViews );
+	const previousCameraCount = quiltCamera.cameras.length;
+	updateQuiltCamera();
 
-	LookingGlassConfig.numViews = lkgParams.numViews;
-	ptRenderer.viewCount = lkgParams.numViews;
-	ptRenderer.viewCone = viewCone * MathUtils.DEG2RAD;
-	ptRenderer.setFromDisplayView( viewerDistance, DISPLAY_WIDTH, DISPLAY_HEIGHT );
-	ptRenderer.setSize( renderScale * lkgParams.quiltWidth, renderScale * lkgParams.quiltHeight );
-	ptRenderer.quiltDimensions.set( lkgParams.quiltTilesX, lkgParams.quiltTilesY );
+	const width = Math.max( 1, Math.floor( renderScale * lkgParams.quiltWidth ) );
+	const height = Math.max( 1, Math.floor( renderScale * lkgParams.quiltHeight ) );
+	pathTracer.setSize( width, height );
+	previewQuad.material.quiltMap = pathTracer.target;
+	previewQuad.material.quiltDimensions.set( lkgParams.quiltTilesX, lkgParams.quiltTilesY );
+
+	if ( previousCameraCount !== quiltCamera.cameras.length ) {
+
+		pathTracer.setCamera( quiltCamera );
+
+	} else {
+
+		pathTracer.updateCamera();
+
+	}
+
+}
+
+// Rebuild the off-axis cameras and their quilt viewports. Extra cells in the
+// final row repeat the last view so every output pixel belongs to a camera.
+function updateQuiltCamera() {
+
+	const {
+		numViews,
+		quiltTilesX,
+		quiltTilesY,
+		quiltWidth,
+		quiltHeight,
+	} = lkgParams;
+	const { renderScale, viewCone, viewerDistance } = params;
+	const width = Math.max( 1, Math.floor( renderScale * quiltWidth ) );
+	const height = Math.max( 1, Math.floor( renderScale * quiltHeight ) );
+	const cameraCount = quiltTilesX * quiltTilesY;
+
+	const displayHalfHeight = DISPLAY_HEIGHT * 0.5;
+	const displayHalfWidth = DISPLAY_WIDTH * 0.5;
+	const halfViewWidth = Math.tan( viewCone * MathUtils.DEG2RAD * 0.5 ) * viewerDistance;
+	const nearScale = camera.near / viewerDistance;
+
+	camera.fov = 2 * Math.atan( displayHalfHeight / viewerDistance ) * MathUtils.RAD2DEG;
+	camera.updateProjectionMatrix();
+	camera.updateMatrixWorld();
+
+	while ( quiltCamera.cameras.length < cameraCount ) {
+
+		const subCamera = new PerspectiveCamera();
+		subCamera.coordinateSystem = WebGPUCoordinateSystem;
+		subCamera.viewport = new Vector4();
+		quiltCamera.cameras.push( subCamera );
+
+	}
+
+	quiltCamera.cameras.length = cameraCount;
+	for ( let i = 0; i < cameraCount; i ++ ) {
+
+		const viewIndex = Math.min( i, numViews - 1 );
+		const viewAlpha = numViews === 1 ? 0.5 : viewIndex / ( numViews - 1 );
+		const offset = MathUtils.lerp( - halfViewWidth, halfViewWidth, viewAlpha );
+		const subCamera = quiltCamera.cameras[ i ];
+
+		_translation.makeTranslation( offset, 0, 0 );
+		subCamera.matrix.multiplyMatrices( camera.matrixWorld, _translation );
+		subCamera.matrix.decompose( subCamera.position, subCamera.quaternion, subCamera.scale );
+
+		subCamera.near = camera.near;
+		subCamera.far = camera.far;
+		subCamera.projectionMatrix.makePerspective(
+			nearScale * ( - displayHalfWidth - offset ),
+			nearScale * ( displayHalfWidth - offset ),
+			nearScale * displayHalfHeight,
+			nearScale * - displayHalfHeight,
+			camera.near,
+			camera.far,
+			WebGPUCoordinateSystem,
+		);
+		subCamera.projectionMatrixInverse.copy( subCamera.projectionMatrix ).invert();
+
+		const tileX = i % quiltTilesX;
+		const tileY = Math.floor( i / quiltTilesX );
+		const x0 = Math.floor( tileX * width / quiltTilesX );
+		const x1 = Math.floor( ( tileX + 1 ) * width / quiltTilesX );
+		const y0 = Math.floor( tileY * height / quiltTilesY );
+		const y1 = Math.floor( ( tileY + 1 ) * height / quiltTilesY );
+		subCamera.viewport.set( x0, y0, x1 - x0, y1 - y0 );
+
+	}
 
 }
 
@@ -465,8 +511,7 @@ function onResize() {
 	renderer.setSize( w, h );
 	renderer.setPixelRatio( window.devicePixelRatio );
 
-	const aspect = w / h;
-	camera.aspect = aspect;
+	camera.aspect = w / h;
 	camera.updateProjectionMatrix();
 
 }
@@ -474,16 +519,28 @@ function onResize() {
 // save the canvas
 function saveQuilt() {
 
-	renderer.setSize( ptRenderer.target.width, ptRenderer.target.height );
-	fsQuad.render( renderer );
+	const target = pathTracer.target;
+	renderer.getSize( _size );
+	const pixelRatio = renderer.getPixelRatio();
+	const displayIndex = previewQuad.material.displayIndex;
+
+	renderer.setPixelRatio( 1 );
+	renderer.setSize( target.width, target.height, false );
+	renderer.setViewport( 0, 0, target.width, target.height );
+	previewQuad.material.quiltMap = target;
+	previewQuad.material.displayIndex = - 1;
+	previewQuad.render( renderer );
 
 	const imageURL = renderer.domElement.toDataURL( 'image/png' );
 	const anchor = document.createElement( 'a' );
 	anchor.href = imageURL;
-	anchor.download = 'preview.png';
+	anchor.download = 'quilt.png';
 	anchor.click();
 	anchor.remove();
 
+	previewQuad.material.displayIndex = displayIndex;
+	renderer.setPixelRatio( pixelRatio );
+	renderer.setSize( _size.x, _size.y );
 	onResize();
 
 }
@@ -491,7 +548,7 @@ function saveQuilt() {
 // build the gui
 function buildGui() {
 
-	gui = new GUI();
+	const gui = new GUI();
 
 	gui.add( params, 'model', Object.keys( MODELS ) ).onChange( v => {
 
@@ -500,52 +557,32 @@ function buildGui() {
 
 	} );
 	gui.add( params, 'enable' );
-	gui.add( params, 'renderScale', 0.1, 1.0, 0.01 ).onChange( () => {
-
-		onLkgParamsChange();
-		ptRenderer.reset();
-
-	} );
-	saveButton = gui.add( params, 'saveQuilt' );
+	gui.add( params, 'renderScale', 0.1, 1.0, 0.01 ).onChange( onLkgParamsChange );
+	gui.add( params, 'saveQuilt' );
 
 	const ptFolder = gui.addFolder( 'Path Tracing' );
 	ptFolder.add( params, 'pause' );
 	ptFolder.add( params, 'bounces', 1, 20, 1 ).onChange( () => {
 
-		ptRenderer.reset();
+		pathTracer.bounces = params.bounces;
 
 	} );
 	ptFolder.add( params, 'filterGlossyFactor', 0, 1 ).onChange( () => {
 
-		ptRenderer.reset();
+		pathTracer.filterGlossyFactor = params.filterGlossyFactor;
 
 	} );
 	ptFolder.add( params, 'samplesPerFrame', 1, 10, 1 );
 	ptFolder.add( params, 'tiles', 1, 3, 1 ).onChange( v => {
 
-		ptRenderer.tiles.setScalar( v );
+		pathTracer.tiles.setScalar( v );
 
 	} );
 
 	const lkgFolder = gui.addFolder( 'Looking Glass Views' );
-	lkgFolder.add( params, 'numViews', 1, 100, 1 ).onChange( () => {
-
-		onLkgParamsChange();
-		ptRenderer.reset();
-
-	} );
-	lkgFolder.add( params, 'viewCone', 10, 70, 0.1 ).onChange( () => {
-
-		onLkgParamsChange();
-		ptRenderer.reset();
-
-	} );
-	lkgFolder.add( params, 'viewerDistance', 0.2, 2, 0.1 ).onChange( () => {
-
-		onLkgParamsChange();
-		ptRenderer.reset();
-
-	} );
+	lkgFolder.add( params, 'numViews', 1, 100, 1 ).onChange( onLkgParamsChange );
+	lkgFolder.add( params, 'viewCone', 10, 70, 0.1 ).onChange( onLkgParamsChange );
+	lkgFolder.add( params, 'viewerDistance', 0.2, 2, 0.1 ).onChange( onLkgParamsChange );
 
 	const quiltPreviewFolder = gui.addFolder( 'Preview' );
 	quiltPreviewFolder.add( params, 'tiltingPreview' );
@@ -566,27 +603,25 @@ function convertOpacityToTransmission( model, ior ) {
 				const newMaterial = new MeshPhysicalMaterial();
 				for ( const key in material ) {
 
-					if ( key in material ) {
+					const value = material[ key ];
+					const targetValue = newMaterial[ key ];
+					if ( value === null ) {
 
-						if ( material[ key ] === null ) {
+						continue;
 
-							continue;
+					}
 
-						}
+					if ( value.isTexture ) {
 
-						if ( material[ key ].isTexture ) {
+						newMaterial[ key ] = value;
 
-							newMaterial[ key ] = material[ key ];
+					} else if ( value.copy && targetValue?.constructor === value.constructor ) {
 
-						} else if ( material[ key ].copy && material[ key ].constructor === newMaterial[ key ].constructor ) {
+						targetValue.copy( value );
 
-							newMaterial[ key ].copy( material[ key ] );
+					} else if ( typeof value === 'number' ) {
 
-						} else if ( ( typeof material[ key ] ) === 'number' ) {
-
-							newMaterial[ key ] = material[ key ];
-
-						}
+						newMaterial[ key ] = value;
 
 					}
 

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -141,7 +141,7 @@ async function init() {
 	// initialize the camera
 	const aspect = window.innerWidth / window.innerHeight;
 	camera = new PerspectiveCamera( 60, aspect, 0.025, 500 );
-	camera.position.set( 0.43, 0.06, - 0.2 ).normalize().multiplyScalar( 0.48 );
+	camera.position.set( 0.43, 0.06, - 0.2 ).normalize().multiplyScalar( 0.5 );
 	camera.lookAt( 0, 0, 0 );
 	quiltCamera = new ArrayCamera();
 
@@ -194,7 +194,7 @@ async function init() {
 
 		// get a merged version of the model
 		const model = LDrawUtils.mergeObject( result );
-		model.rotation.set( Math.PI, 0, 0 );
+		model.rotation.set( Math.PI, - Math.PI / 2, 0 );
 
 		// remove the non mesh components
 		const toRemove = [];

--- a/example/materials/QuiltPreviewNodeMaterial.js
+++ b/example/materials/QuiltPreviewNodeMaterial.js
@@ -1,0 +1,146 @@
+import { MeshBasicNodeMaterial, StorageTexture } from 'three/webgpu';
+import { texture, uniform, uv, varying, vec4, wgslFn } from 'three/tsl';
+import { wgslTagFn } from 'three-mesh-bvh/webgpu';
+
+const sampleTexel = wgslFn( /* wgsl */`
+	fn sampleTexel( tex: texture_2d<f32>, coord: vec2f ) -> vec4f {
+
+		let size = vec2f( textureDimensions( tex, 0 ) );
+		let pxCoord = coord * size - 0.5;
+		let px = vec2i( floor( pxCoord ) );
+		let fr = fract( pxCoord );
+		let maxPx = vec2i( size ) - 1;
+
+		let s00 = textureLoad( tex, clamp( px, vec2i( 0 ), maxPx ), 0 );
+		let s10 = textureLoad( tex, clamp( px + vec2i( 1, 0 ), vec2i( 0 ), maxPx ), 0 );
+		let s01 = textureLoad( tex, clamp( px + vec2i( 0, 1 ), vec2i( 0 ), maxPx ), 0 );
+		let s11 = textureLoad( tex, clamp( px + vec2i( 1, 1 ), vec2i( 0 ), maxPx ), 0 );
+
+		return mix( mix( s00, s10, fr.x ), mix( s01, s11, fr.x ), fr.y );
+
+	}
+` );
+
+export class QuiltPreviewNodeMaterial extends MeshBasicNodeMaterial {
+
+	get quiltMap() {
+
+		return this._quiltMap.value;
+
+	}
+
+	set quiltMap( value ) {
+
+		this._quiltMap.value = value;
+
+	}
+
+	get quiltDimensions() {
+
+		return this._quiltDimensions.value;
+
+	}
+
+	set quiltDimensions( value ) {
+
+		this._quiltDimensions.value.copy( value );
+
+	}
+
+	get displayIndex() {
+
+		return this._displayIndex.value;
+
+	}
+
+	set displayIndex( value ) {
+
+		this._displayIndex.value = value;
+
+	}
+
+	get aspectRatio() {
+
+		return this._aspectRatio.value;
+
+	}
+
+	set aspectRatio( value ) {
+
+		this._aspectRatio.value = value;
+
+	}
+
+	get heightScale() {
+
+		return this._heightScale.value;
+
+	}
+
+	set heightScale( value ) {
+
+		this._heightScale.value = value;
+
+	}
+
+	constructor( parameters = {} ) {
+
+		super();
+
+		const quiltMap = texture( new StorageTexture() );
+		const quiltDimensions = uniform( parameters.quiltDimensions.clone() );
+		const displayIndex = uniform( - 1, 'int' );
+		const aspectRatio = uniform( 1 );
+		const heightScale = uniform( 1 );
+
+		this._quiltMap = quiltMap;
+		this._quiltDimensions = quiltDimensions;
+		this._displayIndex = displayIndex;
+		this._aspectRatio = aspectRatio;
+		this._heightScale = heightScale;
+
+		const getColor = wgslTagFn/* wgsl */`
+			fn getColor( uv: vec2f ) -> vec4f {
+
+				if ( ${ displayIndex } < 0 ) {
+
+					return ${ sampleTexel }( ${ quiltMap }, uv );
+
+				}
+
+				var tileUv = uv;
+				tileUv.x -= ( 1.0 - ${ aspectRatio } * ${ heightScale } ) * 0.5;
+				tileUv.x /= ${ aspectRatio };
+				tileUv.y -= ( 1.0 - ${ heightScale } ) * 0.5;
+				tileUv /= ${ heightScale };
+
+				if ( any( tileUv < vec2f( 0.0 ) ) || any( tileUv > vec2f( 1.0 ) ) ) {
+
+					return vec4f( 0.05, 0.05, 0.05, 1.0 );
+
+				}
+
+				let size = vec2f( textureDimensions( ${ quiltMap }, 0 ) );
+				let tileTexelHalfWidth = 0.5 * ${ quiltDimensions } / size;
+				tileUv = clamp( tileUv, tileTexelHalfWidth, 1.0 - tileTexelHalfWidth );
+
+				let columns = i32( ${ quiltDimensions }.x );
+				let tileIndex = vec2f(
+					f32( ${ displayIndex } % columns ),
+					f32( ${ displayIndex } / columns )
+				);
+				let quiltUv = ( tileIndex + tileUv ) / ${ quiltDimensions };
+				return ${ sampleTexel }( ${ quiltMap }, quiltUv );
+
+			}
+		`;
+
+		this.depthTest = false;
+		this.depthWrite = false;
+		this.colorNode = vec4( getColor( varying( uv() ) ) );
+
+		this.setValues( parameters );
+
+	}
+
+}

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -29,6 +29,13 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 	setBVHData( bvhData ) {
 
 		this.kernel.bvhData = bvhData;
+		this.rebuild();
+
+	}
+
+	rebuild() {
+
+		super.rebuild();
 		this.kernel.needsUpdate = true;
 		this.reset();
 

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -30,6 +30,7 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 
 		this.kernel.bvhData = bvhData;
 		this.rebuild();
+		this.reset();
 
 	}
 
@@ -37,7 +38,6 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 
 		super.rebuild();
 		this.kernel.needsUpdate = true;
-		this.reset();
 
 	}
 

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -30,7 +30,6 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 
 		this.kernel.bvhData = bvhData;
 		this.rebuild();
-		this.reset();
 
 	}
 
@@ -38,6 +37,7 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 
 		super.rebuild();
 		this.kernel.needsUpdate = true;
+		this.reset();
 
 	}
 

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -75,6 +75,13 @@ export class PathTracerBackend {
 
 	}
 
+	// Rebuild the render task after a shader-generating function changes.
+	rebuild() {
+
+		this._renderTask = null;
+
+	}
+
 	setSize( w, h ) {
 
 		w = Math.ceil( w );

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -75,7 +75,6 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 
 		this.hitProcessKernel.bvhData = bvhData;
 		this.rebuild();
-		this.reset();
 
 	}
 
@@ -85,6 +84,7 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 		this.enqueueRaysKernel.needsUpdate = true;
 		this.rayIntersectionKernel.needsUpdate = true;
 		this.hitProcessKernel.needsUpdate = true;
+		this.reset();
 
 	}
 

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -70,12 +70,19 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 	setBVHData( bvhData ) {
 
 		this.enqueueRaysKernel.bvhData = bvhData;
-		this.enqueueRaysKernel.needsUpdate = true;
 
 		this.rayIntersectionKernel.bvhData = bvhData;
-		this.rayIntersectionKernel.needsUpdate = true;
 
 		this.hitProcessKernel.bvhData = bvhData;
+		this.rebuild();
+
+	}
+
+	rebuild() {
+
+		super.rebuild();
+		this.enqueueRaysKernel.needsUpdate = true;
+		this.rayIntersectionKernel.needsUpdate = true;
 		this.hitProcessKernel.needsUpdate = true;
 
 		this.reset();

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -75,6 +75,7 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 
 		this.hitProcessKernel.bvhData = bvhData;
 		this.rebuild();
+		this.reset();
 
 	}
 
@@ -84,8 +85,6 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 		this.enqueueRaysKernel.needsUpdate = true;
 		this.rayIntersectionKernel.needsUpdate = true;
 		this.hitProcessKernel.needsUpdate = true;
-
-		this.reset();
 
 	}
 

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -182,6 +182,7 @@ export class WebGPUPathTracer {
 
 		this._pathTracer.dispose();
 		this._pathTracer = value ? new MegaKernelPathTracer( this._renderer ) : new WaveFrontPathTracer( this._renderer );
+		this._pathTracer.setBVHData( this._bvhData );
 		this._pathTracer.setMaterial( this.material );
 		this._pathTracer.setRandom( this.random );
 		this._pathTracer.setFilterGlossy( this._filterGlossyFactor );
@@ -307,6 +308,7 @@ export class WebGPUPathTracer {
 
 		this.scene = scene;
 		this._bvhData = bvhData;
+		this._pathTracer.setBVHData( bvhData );
 		this.setCamera( camera );
 		this.updateEnvironment();
 
@@ -361,15 +363,14 @@ export class WebGPUPathTracer {
 					}
 
 					invViewProjectionMatrix.value.multiplyMatrices( camera.matrixWorld, camera.projectionMatrixInverse );
+					return false;
 
 				},
 				fn: wgslTagFn/* wgsl */`
 					fn getCameraRay( uv: vec2f, resolution: vec2f, ray: ptr<function, ${ rayStruct }> ) -> bool {
 
 						let ndc = uv * 2.0 - vec2f( 1.0 );
-						let cameraRay = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrix } );
-						ray.origin = cameraRay.origin;
-						ray.direction = cameraRay.direction;
+						*ray = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrix } );
 						return true;
 
 					}
@@ -379,7 +380,6 @@ export class WebGPUPathTracer {
 		}
 
 		this._bvhData.fns.getCameraRay = this._cameraRayFnHandle.fn;
-		this._pathTracer.setBVHData( this._bvhData );
 		this.updateCamera();
 
 	}
@@ -403,12 +403,13 @@ export class WebGPUPathTracer {
 
 	updateCamera() {
 
-		const cameraRayFn = this._cameraRayFnHandle.fn;
-		this._cameraRayFnHandle.update();
-		if ( cameraRayFn !== this._cameraRayFnHandle.fn ) {
+		const { _bvhData, _cameraRayFnHandle, _pathTracer } = this;
+		const cameraRayFn = _bvhData.fns.getCameraRay;
+		const needsRebuild = _cameraRayFnHandle.update();
+		if ( cameraRayFn !== _cameraRayFnHandle.fn || needsRebuild ) {
 
-			this._bvhData.fns.getCameraRay = this._cameraRayFnHandle.fn;
-			this._pathTracer.setBVHData( this._bvhData );
+			_bvhData.fns.getCameraRay = _cameraRayFnHandle.fn;
+			_pathTracer.rebuild();
 
 		}
 

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -182,7 +182,6 @@ export class WebGPUPathTracer {
 
 		this._pathTracer.dispose();
 		this._pathTracer = value ? new MegaKernelPathTracer( this._renderer ) : new WaveFrontPathTracer( this._renderer );
-		this._pathTracer.setBVHData( this._bvhData );
 		this._pathTracer.setMaterial( this.material );
 		this._pathTracer.setRandom( this.random );
 		this._pathTracer.setFilterGlossy( this._filterGlossyFactor );
@@ -308,7 +307,6 @@ export class WebGPUPathTracer {
 
 		this.scene = scene;
 		this._bvhData = bvhData;
-		this._pathTracer.setBVHData( bvhData );
 		this.setCamera( camera );
 		this.updateEnvironment();
 
@@ -378,6 +376,7 @@ export class WebGPUPathTracer {
 		}
 
 		this._bvhData.fns.getCameraRay = this._cameraRayFnHandle.fn;
+		this._pathTracer.setBVHData( this._bvhData );
 		this.updateCamera();
 
 	}

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -364,10 +364,13 @@ export class WebGPUPathTracer {
 
 				},
 				fn: wgslTagFn/* wgsl */`
-					fn getCameraRay( uv: vec2f, resolution: vec2f ) -> ${ rayStruct } {
+					fn getCameraRay( uv: vec2f, resolution: vec2f, ray: ptr<function, ${ rayStruct }> ) -> bool {
 
 						let ndc = uv * 2.0 - vec2f( 1.0 );
-						return ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrix } );
+						let cameraRay = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrix } );
+						ray.origin = cameraRay.origin;
+						ray.direction = cameraRay.direction;
+						return true;
 
 					}
 				`,
@@ -400,7 +403,15 @@ export class WebGPUPathTracer {
 
 	updateCamera() {
 
+		const cameraRayFn = this._cameraRayFnHandle.fn;
 		this._cameraRayFnHandle.update();
+		if ( cameraRayFn !== this._cameraRayFnHandle.fn ) {
+
+			this._bvhData.fns.getCameraRay = this._cameraRayFnHandle.fn;
+			this._pathTracer.setBVHData( this._bvhData );
+
+		}
+
 		this.reset();
 
 	}

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -380,7 +380,9 @@ export class WebGPUPathTracer {
 		}
 
 		this._bvhData.fns.getCameraRay = this._cameraRayFnHandle.fn;
-		this.updateCamera();
+		this._cameraRayFnHandle.update();
+		this._pathTracer.rebuild();
+		this.reset();
 
 	}
 
@@ -403,10 +405,9 @@ export class WebGPUPathTracer {
 
 	updateCamera() {
 
-		const { _bvhData, _cameraRayFnHandle, _pathTracer } = this;
+		const { _cameraRayFnHandle, _pathTracer } = this;
 		if ( _cameraRayFnHandle.update() ) {
 
-			_bvhData.fns.getCameraRay = _cameraRayFnHandle.fn;
 			_pathTracer.rebuild();
 
 		}

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -404,9 +404,7 @@ export class WebGPUPathTracer {
 	updateCamera() {
 
 		const { _bvhData, _cameraRayFnHandle, _pathTracer } = this;
-		const cameraRayFn = _bvhData.fns.getCameraRay;
-		const needsRebuild = _cameraRayFnHandle.update();
-		if ( cameraRayFn !== _cameraRayFnHandle.fn || needsRebuild ) {
+		if ( _cameraRayFnHandle.update() ) {
 
 			_bvhData.fns.getCameraRay = _cameraRayFnHandle.fn;
 			_pathTracer.rebuild();

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -3,7 +3,7 @@ import { ComputeKernel } from './ComputeKernel.js';
 import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
 import { rngInit, rngNextBounce, rand1, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_ENVIRONMENT_SAMPLE, RNG_INDEX_RUSSIAN_ROULETTE } from '../nodes/random.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn, luminanceFn } from '../nodes/sampling.wgsl.js';
-import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
+import { proxy, proxyFn, rayStruct, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
@@ -116,7 +116,13 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 				// scene ray
 				let jitteredUv = uv + ${ rand2 }( ${ RNG_INDEX_RAY_JITTER } ) / vec2f( targetDimensions );
-				var ray = ${ getCameraRayFn }( jitteredUv, vec2f( targetDimensions ) );
+				var ray: ${ rayStruct };
+				if ( ! ${ getCameraRayFn }( jitteredUv, vec2f( targetDimensions ), &ray ) ) {
+
+					return;
+
+				}
+
 				ray.direction = normalize( ray.direction );
 
 				var resultColor = vec4f( 0, 0, 0, 1 );

--- a/src/webgpu/compute/wavefront/RayGenerationKernel.js
+++ b/src/webgpu/compute/wavefront/RayGenerationKernel.js
@@ -4,7 +4,7 @@ import { uniform, storage, globalId, textureStore } from 'three/tsl';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { rngInit, rand2, RNG_INDEX_RAY_JITTER } from '../../nodes/random.wgsl.js';
 import { rayQueueAtomicStruct } from './structs.js';
-import { proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
+import { proxyFn, rayStruct, wgslTagFn } from 'three-mesh-bvh/webgpu';
 
 export class RayGenerationKernel extends ComputeKernel {
 
@@ -70,14 +70,19 @@ export class RayGenerationKernel extends ComputeKernel {
 
 				}
 
-				// get the ray index
-				let queueCapacity = arrayLength( &rayQueue.elements );
-				let index = atomicAdd( &rayQueue.end, 1 ) % queueCapacity;
 				${ rngInit }( indexUV.xy, seed + samples, 0 );
 
 				// write the ray data
 				let jitteredUv = uv + ${ rand2 }( ${ RNG_INDEX_RAY_JITTER } ) / vec2f( targetDimensions );
-				var ray = ${ getCameraRayFn }( jitteredUv, vec2f( targetDimensions ) );
+				var ray: ${ rayStruct };
+				if ( ! ${ getCameraRayFn }( jitteredUv, vec2f( targetDimensions ), &ray ) ) {
+
+					return;
+
+				}
+
+				let queueCapacity = arrayLength( &rayQueue.elements );
+				let index = atomicAdd( &rayQueue.end, 1 ) % queueCapacity;
 				ray.direction = normalize( ray.direction );
 
 				rayQueue.elements[ index ].origin = ray.origin;

--- a/src/webgpu/index.js
+++ b/src/webgpu/index.js
@@ -8,3 +8,4 @@ export * as RANDOM_BLUE_DITHER from './nodes/rand/bluedither.wgsl.js';
 // extend the cameras to avoid adding WebGPU imports to the WebGLPathTracer
 import './shims/EquirectCameraShim.js';
 import './shims/PhysicalCameraShim.js';
+import './shims/ArrayCameraShim.js';

--- a/src/webgpu/shims/ArrayCameraShim.js
+++ b/src/webgpu/shims/ArrayCameraShim.js
@@ -1,0 +1,78 @@
+import { ArrayCamera, Matrix4, Vector4 } from 'three';
+import { uniformArray } from 'three/tsl';
+import { ndcToCameraRay, rayStruct, wgslTagFn } from 'three-mesh-bvh/webgpu';
+
+ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
+
+	const cameraCount = this.cameras.length;
+	if ( cameraCount === 0 ) {
+
+		throw new Error( 'ArrayCamera: At least one sub-camera is required.' );
+
+	}
+
+	const invViewProjectionMatrices = uniformArray(
+		Array.from( { length: cameraCount }, () => new Matrix4() ),
+		'mat4',
+	);
+	const viewports = uniformArray(
+		Array.from( { length: cameraCount }, () => new Vector4() ),
+		'vec4',
+	);
+
+	const fn = wgslTagFn/* wgsl */`
+		fn getCameraRay( uv: vec2f, resolution: vec2f ) -> ${ rayStruct } {
+
+			let pixel = uv * resolution;
+			var cameraUv = uv;
+			var cameraIndex = 0u;
+
+			for ( var i = 0u; i < ${ cameraCount }u; i ++ ) {
+
+				let viewport = ${ viewports }[ i ];
+				let viewportMax = viewport.xy + viewport.zw;
+				if ( all( pixel >= viewport.xy ) && all( pixel < viewportMax ) ) {
+
+					cameraIndex = i;
+					cameraUv = ( pixel - viewport.xy ) / viewport.zw;
+					break;
+
+				}
+
+			}
+
+			let ndc = cameraUv * 2.0 - vec2f( 1.0 );
+			return ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrices }[ cameraIndex ] );
+
+		}
+	`;
+
+	const update = () => {
+
+		if ( this.cameras.length !== cameraCount ) {
+
+			throw new Error( 'ArrayCamera: Call WebGPUPathTracer.setCamera() after changing the number of sub-cameras.' );
+
+		}
+
+		for ( let i = 0; i < cameraCount; i ++ ) {
+
+			const camera = this.cameras[ i ];
+			const viewport = camera.viewport;
+			if ( viewport === undefined || viewport.z <= 0 || viewport.w <= 0 ) {
+
+				throw new Error( 'ArrayCamera: Each sub-camera must define a non-empty viewport.' );
+
+			}
+
+			camera.updateMatrixWorld();
+			invViewProjectionMatrices.array[ i ].multiplyMatrices( camera.matrixWorld, camera.projectionMatrixInverse );
+			viewports.array[ i ].copy( viewport );
+
+		}
+
+	};
+
+	return { fn, update };
+
+};

--- a/src/webgpu/shims/ArrayCameraShim.js
+++ b/src/webgpu/shims/ArrayCameraShim.js
@@ -69,8 +69,6 @@ ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 
 	};
 
-	result.update();
-
 	return result;
 
 };

--- a/src/webgpu/shims/ArrayCameraShim.js
+++ b/src/webgpu/shims/ArrayCameraShim.js
@@ -65,9 +65,11 @@ ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 
 	result.update = () => {
 
+		let needsRebuild = false;
 		if ( this.cameras.length !== cameraCount ) {
 
 			rebuild();
+			needsRebuild = true;
 
 		}
 
@@ -83,6 +85,8 @@ ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 			viewports.array[ i ].copy( viewport );
 
 		}
+
+		return needsRebuild;
 
 	};
 

--- a/src/webgpu/shims/ArrayCameraShim.js
+++ b/src/webgpu/shims/ArrayCameraShim.js
@@ -1,4 +1,4 @@
-import { ArrayCamera, Matrix4, Vector4 } from 'three';
+import { ArrayCamera, Matrix4, Vector4, WebGPUCoordinateSystem } from 'three';
 import { uniformArray } from 'three/tsl';
 import { ndcToCameraRay, rayStruct, wgslTagFn } from 'three-mesh-bvh/webgpu';
 
@@ -76,7 +76,9 @@ ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 			const camera = this.cameras[ i ];
 			const viewport = camera.viewport;
 
+			camera.coordinateSystem = WebGPUCoordinateSystem;
 			camera.updateMatrixWorld();
+			camera.updateProjectionMatrix();
 			invViewProjectionMatrices.array[ i ].multiplyMatrices( camera.matrixWorld, camera.projectionMatrixInverse );
 			viewports.array[ i ].copy( viewport );
 

--- a/src/webgpu/shims/ArrayCameraShim.js
+++ b/src/webgpu/shims/ArrayCameraShim.js
@@ -1,86 +1,67 @@
 import { ArrayCamera, Matrix4, Vector4, WebGPUCoordinateSystem } from 'three';
-import { uniformArray } from 'three/tsl';
+import { uniformArray, int } from 'three/tsl';
 import { ndcToCameraRay, rayStruct, wgslTagFn } from 'three-mesh-bvh/webgpu';
 
 ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 
-	let cameraCount = 0;
-	let invViewProjectionMatrices;
-	let viewports;
 	const result = { fn: null, update: null };
 
-	const rebuild = () => {
+	const cameraCount = int( 0 );
+	const invViewProjectionMatrices = uniformArray( [], 'mat4' );
+	const viewports = uniformArray( [], 'vec4' );
 
-		cameraCount = this.cameras.length;
-		if ( cameraCount === 0 ) {
+	result.fn = wgslTagFn/* wgsl */`
+		fn getCameraRay( uv: vec2f, resolution: vec2f, ray: ptr<function, ${ rayStruct }> ) -> bool {
 
-			result.fn = wgslTagFn/* wgsl */`
-				fn getCameraRay( uv: vec2f, resolution: vec2f, ray: ptr<function, ${ rayStruct }> ) -> bool {
+			let pixel = uv * resolution;
 
-					return false;
+			for ( var i = 0u; i < ${ cameraCount }u; i ++ ) {
 
-				}
-			`;
-			return;
+				let viewport = ${ viewports }[ i ];
+				let viewportMax = viewport.xy + viewport.zw;
+				if ( all( pixel >= viewport.xy ) && all( pixel < viewportMax ) ) {
 
-		}
-
-		invViewProjectionMatrices = uniformArray(
-			Array.from( { length: cameraCount }, () => new Matrix4() ),
-			'mat4',
-		);
-		viewports = uniformArray(
-			Array.from( { length: cameraCount }, () => new Vector4() ),
-			'vec4',
-		);
-
-		result.fn = wgslTagFn/* wgsl */`
-			fn getCameraRay( uv: vec2f, resolution: vec2f, ray: ptr<function, ${ rayStruct }> ) -> bool {
-
-				let pixel = uv * resolution;
-
-				for ( var i = 0u; i < ${ cameraCount }u; i ++ ) {
-
-					let viewport = ${ viewports }[ i ];
-					let viewportMax = viewport.xy + viewport.zw;
-					if ( all( pixel >= viewport.xy ) && all( pixel < viewportMax ) ) {
-
-						let cameraUv = ( pixel - viewport.xy ) / viewport.zw;
-						let ndc = cameraUv * 2.0 - vec2f( 1.0 );
-						let cameraRay = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrices }[ i ] );
-						ray.origin = cameraRay.origin;
-						ray.direction = cameraRay.direction;
-						return true;
-
-					}
+					let cameraUv = ( pixel - viewport.xy ) / viewport.zw;
+					let ndc = cameraUv * 2.0 - vec2f( 1.0 );
+					let cameraRay = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrices }[ i ] );
+					ray.origin = cameraRay.origin;
+					ray.direction = cameraRay.direction;
+					return true;
 
 				}
-
-				return false;
 
 			}
-		`;
 
-	};
+			return false;
+
+		}
+	`;
 
 	result.update = () => {
 
-		let needsRebuild = false;
-		if ( this.cameras.length !== cameraCount ) {
+		const { cameras } = this;
+		const needsRebuild = cameraCount.node.value !== cameras.length;
+		cameraCount.node.value = cameras.length;
 
-			rebuild();
-			needsRebuild = true;
+		while ( viewports.array.length < cameras.length ) {
+
+			viewports.array.push( new Vector4() );
+			invViewProjectionMatrices.array.push( new Matrix4() );
 
 		}
 
-		for ( let i = 0; i < cameraCount; i ++ ) {
+		invViewProjectionMatrices.array.length = cameras.length;
+		viewports.array.length = cameras.length;
 
-			const camera = this.cameras[ i ];
+		for ( let i = 0; i < cameras.length; i ++ ) {
+
+			const camera = cameras[ i ];
 			const viewport = camera.viewport;
 
 			camera.coordinateSystem = WebGPUCoordinateSystem;
 			camera.updateMatrixWorld();
 			camera.updateProjectionMatrix();
+
 			invViewProjectionMatrices.array[ i ].multiplyMatrices( camera.matrixWorld, camera.projectionMatrixInverse );
 			viewports.array[ i ].copy( viewport );
 
@@ -90,7 +71,8 @@ ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 
 	};
 
-	rebuild();
+	result.update();
+
 	return result;
 
 };

--- a/src/webgpu/shims/ArrayCameraShim.js
+++ b/src/webgpu/shims/ArrayCameraShim.js
@@ -23,9 +23,7 @@ ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 
 					let cameraUv = ( pixel - viewport.xy ) / viewport.zw;
 					let ndc = cameraUv * 2.0 - vec2f( 1.0 );
-					let cameraRay = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrices }[ i ] );
-					ray.origin = cameraRay.origin;
-					ray.direction = cameraRay.direction;
+					*ray = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrices }[ i ] );
 					return true;
 
 				}

--- a/src/webgpu/shims/ArrayCameraShim.js
+++ b/src/webgpu/shims/ArrayCameraShim.js
@@ -4,54 +4,70 @@ import { ndcToCameraRay, rayStruct, wgslTagFn } from 'three-mesh-bvh/webgpu';
 
 ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 
-	const cameraCount = this.cameras.length;
-	if ( cameraCount === 0 ) {
+	let cameraCount = 0;
+	let invViewProjectionMatrices;
+	let viewports;
+	const result = { fn: null, update: null };
 
-		throw new Error( 'ArrayCamera: At least one sub-camera is required.' );
+	const rebuild = () => {
 
-	}
+		cameraCount = this.cameras.length;
+		if ( cameraCount === 0 ) {
 
-	const invViewProjectionMatrices = uniformArray(
-		Array.from( { length: cameraCount }, () => new Matrix4() ),
-		'mat4',
-	);
-	const viewports = uniformArray(
-		Array.from( { length: cameraCount }, () => new Vector4() ),
-		'vec4',
-	);
+			result.fn = wgslTagFn/* wgsl */`
+				fn getCameraRay( uv: vec2f, resolution: vec2f, ray: ptr<function, ${ rayStruct }> ) -> bool {
 
-	const fn = wgslTagFn/* wgsl */`
-		fn getCameraRay( uv: vec2f, resolution: vec2f ) -> ${ rayStruct } {
+					return false;
 
-			let pixel = uv * resolution;
-			var cameraUv = uv;
-			var cameraIndex = 0u;
+				}
+			`;
+			return;
 
-			for ( var i = 0u; i < ${ cameraCount }u; i ++ ) {
+		}
 
-				let viewport = ${ viewports }[ i ];
-				let viewportMax = viewport.xy + viewport.zw;
-				if ( all( pixel >= viewport.xy ) && all( pixel < viewportMax ) ) {
+		invViewProjectionMatrices = uniformArray(
+			Array.from( { length: cameraCount }, () => new Matrix4() ),
+			'mat4',
+		);
+		viewports = uniformArray(
+			Array.from( { length: cameraCount }, () => new Vector4() ),
+			'vec4',
+		);
 
-					cameraIndex = i;
-					cameraUv = ( pixel - viewport.xy ) / viewport.zw;
-					break;
+		result.fn = wgslTagFn/* wgsl */`
+			fn getCameraRay( uv: vec2f, resolution: vec2f, ray: ptr<function, ${ rayStruct }> ) -> bool {
+
+				let pixel = uv * resolution;
+
+				for ( var i = 0u; i < ${ cameraCount }u; i ++ ) {
+
+					let viewport = ${ viewports }[ i ];
+					let viewportMax = viewport.xy + viewport.zw;
+					if ( all( pixel >= viewport.xy ) && all( pixel < viewportMax ) ) {
+
+						let cameraUv = ( pixel - viewport.xy ) / viewport.zw;
+						let ndc = cameraUv * 2.0 - vec2f( 1.0 );
+						let cameraRay = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrices }[ i ] );
+						ray.origin = cameraRay.origin;
+						ray.direction = cameraRay.direction;
+						return true;
+
+					}
 
 				}
 
+				return false;
+
 			}
+		`;
 
-			let ndc = cameraUv * 2.0 - vec2f( 1.0 );
-			return ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrices }[ cameraIndex ] );
+	};
 
-		}
-	`;
-
-	const update = () => {
+	result.update = () => {
 
 		if ( this.cameras.length !== cameraCount ) {
 
-			throw new Error( 'ArrayCamera: Call WebGPUPathTracer.setCamera() after changing the number of sub-cameras.' );
+			rebuild();
 
 		}
 
@@ -59,11 +75,6 @@ ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 
 			const camera = this.cameras[ i ];
 			const viewport = camera.viewport;
-			if ( viewport === undefined || viewport.z <= 0 || viewport.w <= 0 ) {
-
-				throw new Error( 'ArrayCamera: Each sub-camera must define a non-empty viewport.' );
-
-			}
 
 			camera.updateMatrixWorld();
 			invViewProjectionMatrices.array[ i ].multiplyMatrices( camera.matrixWorld, camera.projectionMatrixInverse );
@@ -73,6 +84,7 @@ ArrayCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 
 	};
 
-	return { fn, update };
+	rebuild();
+	return result;
 
 };

--- a/src/webgpu/shims/EquirectCameraShim.js
+++ b/src/webgpu/shims/EquirectCameraShim.js
@@ -7,7 +7,7 @@ EquirectCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 
 	const cameraToWorld = uniform( new Matrix4() );
 	const fn = wgslTagFn/* wgsl */`
-		fn getCameraRay( uv: vec2f, resolution: vec2f ) -> ${ rayStruct } {
+		fn getCameraRay( uv: vec2f, resolution: vec2f, ray: ptr<function, ${ rayStruct }> ) -> bool {
 
 			// screen uv to spherical direction, matching three.js' equirect orientation
 			let theta = ( uv.x - 0.5 ) * 2.0 * ${ PI };
@@ -16,10 +16,9 @@ EquirectCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 			let direction = vec3f( sinPhi * cos( theta ), cos( phi ), sinPhi * sin( theta ) );
 
 			// equirect ignores the projection - orient by the camera world matrix and place the origin
-			var ray: ${ rayStruct };
 			ray.origin = ( ${ cameraToWorld } * vec4f( 0.0, 0.0, 0.0, 1.0 ) ).xyz;
 			ray.direction = ( ${ cameraToWorld } * vec4f( direction, 0.0 ) ).xyz;
-			return ray;
+			return true;
 
 		}
 	`;

--- a/src/webgpu/shims/EquirectCameraShim.js
+++ b/src/webgpu/shims/EquirectCameraShim.js
@@ -26,6 +26,7 @@ EquirectCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 	const update = () => {
 
 		cameraToWorld.value.copy( this.matrixWorld );
+		return false;
 
 	};
 

--- a/src/webgpu/shims/PhysicalCameraShim.js
+++ b/src/webgpu/shims/PhysicalCameraShim.js
@@ -92,7 +92,7 @@ PhysicalCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 	const anamorphicRatio = uniform( 1 );
 
 	const fn = wgslTagFn/* wgsl */`
-		fn getCameraRay( uv: vec2f, resolution: vec2f ) -> ${ rayStruct } {
+		fn getCameraRay( uv: vec2f, resolution: vec2f, rayOut: ptr<function, ${ rayStruct }> ) -> bool {
 
 			// base ray
 			let ndc = uv * 2.0 - vec2f( 1.0 );
@@ -118,7 +118,9 @@ PhysicalCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 			ray.origin += ( ${ cameraWorldMatrix } * vec4f( apertureSample, 0.0, 0.0 ) ).xyz;
 			ray.direction = focalPoint - ray.origin;
 
-			return ray;
+			rayOut.origin = ray.origin;
+			rayOut.direction = ray.direction;
+			return true;
 
 		}
 	`;

--- a/src/webgpu/shims/PhysicalCameraShim.js
+++ b/src/webgpu/shims/PhysicalCameraShim.js
@@ -92,11 +92,11 @@ PhysicalCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 	const anamorphicRatio = uniform( 1 );
 
 	const fn = wgslTagFn/* wgsl */`
-		fn getCameraRay( uv: vec2f, resolution: vec2f, rayOut: ptr<function, ${ rayStruct }> ) -> bool {
+		fn getCameraRay( uv: vec2f, resolution: vec2f, ray: ptr<function, ${ rayStruct }> ) -> bool {
 
 			// base ray
 			let ndc = uv * 2.0 - vec2f( 1.0 );
-			var ray = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrix } );
+			*ray = ${ ndcToCameraRay }( ndc, ${ invViewProjectionMatrix } );
 
 			// depth of field
 			// measure focus distance along the optical axis so the focal surface is a flat
@@ -118,8 +118,6 @@ PhysicalCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 			ray.origin += ( ${ cameraWorldMatrix } * vec4f( apertureSample, 0.0, 0.0 ) ).xyz;
 			ray.direction = focalPoint - ray.origin;
 
-			rayOut.origin = ray.origin;
-			rayOut.direction = ray.direction;
 			return true;
 
 		}

--- a/src/webgpu/shims/PhysicalCameraShim.js
+++ b/src/webgpu/shims/PhysicalCameraShim.js
@@ -139,6 +139,7 @@ PhysicalCamera.prototype.getCameraRayFn = function getCameraRayFn() {
 		apertureBlades.value = this.apertureBlades;
 		apertureRotation.value = this.apertureRotation;
 		anamorphicRatio.value = this.anamorphicRatio;
+		return false;
 
 	};
 


### PR DESCRIPTION
## Summary

- Add `ArrayCamera` ray generation support to the WebGPU path tracer.
- Migrate the Looking Glass quilt example to WebGPU.
- Add a node-based quilt preview material for storage textures.

## Details

`ArrayCamera` sub-camera inverse view-projection matrices and viewports are
uploaded as uniform arrays. The camera ray function selects the appropriate
sub-camera for each output pixel.

Changing the camera ray function rebuilds the compute kernels through
`setBVHData`, while regular camera movement only updates uniforms and resets
accumulation.

The LKG example uses the megakernel backend to avoid the large fixed buffers
required by the wavefront backend. It also requests the available storage
buffer limits needed by larger LDraw scenes.

OrbitControls now use raster rendering during interaction. When interaction
ends, the quilt cameras are updated once and path tracing resumes. This avoids
showing a cleared quilt texture while the camera is moving.