### PR TITLE
Add scale-independent ray origin offsets

### DIFF
--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -4,7 +4,7 @@ import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
 import { rngInit, rngNextBounce, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_ENVIRONMENT_SAMPLE, RNG_INDEX_DIRECT_LIGHT_SAMPLE } from '../nodes/random.wgsl.js';
 import { misHeuristicFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
 import { proxy, proxyFn, wgslTagFn, rayStruct } from 'three-mesh-bvh/webgpu';
-import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
+import { isTerminatingScatterFunc, offsetRayOriginFunc } from '../nodes/utils.wgsl.js';
 
 export class PathTracerMegaKernel extends ComputeKernel {
 
@@ -134,9 +134,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 							let evalRec = ${ bsdfEvalPdfFn }( worldWo, envSample.direction, surface );
 							if ( envSample.pdf > 0.0 && evalRec.pdf > 0.0 ) {
 
-								// TODO: is an offset needed here?
 								var shadowRay: ${ rayStruct };
-								shadowRay.origin = vertexData.position.xyz;
+								shadowRay.origin = ${ offsetRayOriginFunc }( vertexData.position.xyz, envSample.direction, hitResult.normal );
 								shadowRay.direction = envSample.direction;
 
 								var shadowHit: ${ raycastOutput };
@@ -162,10 +161,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						throughputColor /= scatterRec.pdf;
 						bsdfPdf = scatterRec.pdf;
 
-						// TODO: Investigate offsetting this position to not self-intersect multiple times
-						// Adding + scatterRec.direction * 1e-1 seems to fix almost all the fireflies
-						// However that seems like a very large distance to offset
-						ray.origin = vertexData.position.xyz;
+						ray.origin = ${ offsetRayOriginFunc }( vertexData.position.xyz, scatterRec.direction, hitResult.normal );
 						ray.direction = scatterRec.direction;
 
 					} else {

--- a/src/webgpu/compute/wavefront/LightConnectionKernel.js
+++ b/src/webgpu/compute/wavefront/LightConnectionKernel.js
@@ -4,6 +4,7 @@ import { uniform, storage, globalId, texture, sampler } from 'three/tsl';
 import { hitQueueStruct } from './structs.js';
 import { proxy, proxyFn, wgslTagFn, rayStruct } from 'three-mesh-bvh/webgpu';
 import { misHeuristicFn } from '../../nodes/sampling.wgsl.js';
+import { offsetRayOriginFunc } from '../../nodes/utils.wgsl.js';
 import { rngInit, rand2, RNG_INDEX_DIRECT_LIGHT_SAMPLE } from '../../nodes/random.wgsl.js';
 
 export class LightConnectionKernel extends ComputeKernel {
@@ -91,9 +92,8 @@ export class LightConnectionKernel extends ComputeKernel {
 				let evalRec = ${ bsdfEvalPdfFn }( input.view, envSample.direction, surface );
 				if ( envSample.pdf > 0.0 && evalRec.pdf > 0.0 ) {
 
-					// TODO: is an offset needed here?
 					var shadowRay: ${ rayStruct };
-					shadowRay.origin = vertexData.position.xyz;
+					shadowRay.origin = ${ offsetRayOriginFunc }( vertexData.position.xyz, envSample.direction, input.normal );
 					shadowRay.direction = envSample.direction;
 
 					var shadowHit: ${ raycastOutput };

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -4,7 +4,7 @@ import { uniform, storage, textureStore, globalId, texture, sampler } from 'thre
 import { rayQueueAtomicStruct, hitQueueStruct } from './structs.js';
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
-import { isTerminatingScatterFunc } from '../../nodes/utils.wgsl.js';
+import { isTerminatingScatterFunc, offsetRayOriginFunc } from '../../nodes/utils.wgsl.js';
 import { rngInit } from '../../nodes/random.wgsl.js';
 
 export class ProcessHitsKernel extends ComputeKernel {
@@ -102,7 +102,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 					let rayQueueCapacity = arrayLength( &rayQueue.elements );
 					let index = atomicAdd( &rayQueue.end, 1 ) % rayQueueCapacity;
-					rayQueue.elements[ index ].origin = vertexData.position.xyz;
+					rayQueue.elements[ index ].origin = ${ offsetRayOriginFunc }( vertexData.position.xyz, scatterRec.direction, input.normal );
 					rayQueue.elements[ index ].direction = scatterRec.direction;
 					rayQueue.elements[ index ].pixel = indexUV;
 					rayQueue.elements[ index ].throughputColor = input.throughputColor * scatterRec.color / scatterRec.pdf;

--- a/src/webgpu/compute/wavefront/RayGenerationKernel.js
+++ b/src/webgpu/compute/wavefront/RayGenerationKernel.js
@@ -85,6 +85,7 @@ export class RayGenerationKernel extends ComputeKernel {
 				rayQueue.elements[ index ].pixel = indexUV;
 				rayQueue.elements[ index ].throughputColor = vec3f( 1.0 );
 				rayQueue.elements[ index ].currentBounce = 0;
+				rayQueue.elements[ index ].bsdfPdf = 0.0;
 				rayQueue.elements[ index ].resultColor = vec4f( 0.0, 0.0, 0.0, 1.0 );
 				rayQueue.elements[ index ].seed = seed + samples;
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -134,6 +134,8 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 			fn bsdfSample( worldWo: vec3f, surf: ${ surfaceRecordStruct } ) -> ${ scatterRecordStruct } {
 
 				var result: ${ scatterRecordStruct };
+				result.color = vec3f( 0.0 );
+				result.direction = vec3f( 0.0 );
 				result.pdf = 0.0;
 
 				// anisotropic roughness along tangent, bitangent

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -259,7 +259,7 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 						let b = ${ storage.attributes }[ i1 ].position.xyz;
 						let c = ${ storage.attributes }[ i2 ].position.xyz;
 
-						var triResult = ${ intersectRayTriangle }( ray, a, b, c, 1e-5 );
+						var triResult = ${ intersectRayTriangle }( ray, a, b, c, 0.0 );
 						triResult.dist *= ${ scratchRayScalar };
 						if ( triResult.didHit && ( ! result.didHit || triResult.dist < result.dist ) ) {
 

--- a/src/webgpu/nodes/sampling.wgsl.js
+++ b/src/webgpu/nodes/sampling.wgsl.js
@@ -166,7 +166,7 @@ export const equirectDirectionPdfFn = wgslFn( /* wgsl */ `
 		let uv = equirectDirectionToUv( direction );
 		let theta = uv.y * PI;
 		let sinTheta = sin( theta );
-		if ( sinTheta == 0.0 ) {
+		if ( sinTheta <= EPSILON ) {
 
 			return 0.0;
 

--- a/src/webgpu/nodes/sampling.wgsl.js
+++ b/src/webgpu/nodes/sampling.wgsl.js
@@ -166,7 +166,7 @@ export const equirectDirectionPdfFn = wgslFn( /* wgsl */ `
 		let uv = equirectDirectionToUv( direction );
 		let theta = uv.y * PI;
 		let sinTheta = sin( theta );
-		if ( sinTheta <= EPSILON ) {
+		if ( sinTheta == 0.0 ) {
 
 			return 0.0;
 

--- a/src/webgpu/nodes/utils.wgsl.js
+++ b/src/webgpu/nodes/utils.wgsl.js
@@ -172,8 +172,11 @@ export const applyWrapFunc = wgslFn( /* wgsl */ `
 
 ` );
 
-// Bit-level origin offset from Ray Tracing Gems, also used by Cycles. It keeps
-// secondary and shadow rays off the source triangle without a scene-scale bias.
+// Bit-level ray origin offset based on Section 6.2.2 of "A Fast and Robust
+// Method for Avoiding Self-Intersection" in Ray Tracing Gems:
+// https://github.com/Apress/ray-tracing-gems/blob/master/Ch_06_A_Fast_and_Robust_Method_for_Avoiding_Self-Intersection/offset_ray.cu
+// The original implementation expects a normal oriented for the outgoing ray;
+// this version orients the geometric normal internally.
 export const offsetRayOriginFunc = wgslFn( /* wgsl */ `
 
 	fn offsetRayOrigin( point: vec3f, direction: vec3f, geometricNormal: vec3f ) -> vec3f {

--- a/src/webgpu/nodes/utils.wgsl.js
+++ b/src/webgpu/nodes/utils.wgsl.js
@@ -172,6 +172,26 @@ export const applyWrapFunc = wgslFn( /* wgsl */ `
 
 ` );
 
+// Bit-level origin offset from Ray Tracing Gems, also used by Cycles. It keeps
+// secondary and shadow rays off the source triangle without a scene-scale bias.
+export const offsetRayOriginFunc = wgslFn( /* wgsl */ `
+
+	fn offsetRayOrigin( point: vec3f, direction: vec3f, geometricNormal: vec3f ) -> vec3f {
+
+		let normal = normalize( select( -geometricNormal, geometricNormal, dot( direction, geometricNormal ) >= 0.0 ) );
+		let intScale = 256.0;
+		let integerOffset = vec3i( intScale * normal );
+		let pointBits = bitcast<vec3i>( point );
+		let signedOffset = select( integerOffset, -integerOffset, point < vec3f( 0.0 ) );
+		let offsetPoint = bitcast<vec3f>( pointBits + signedOffset );
+		let origin = 1.0 / 32.0;
+		let floatScale = 1.0 / 65536.0;
+		return select( offsetPoint, point + floatScale * normal, abs( point ) < vec3f( origin ) );
+
+	}
+
+` );
+
 // Factory: builds sampleTexel bound to the given per-instance textureInfo uniform
 // array node ( must be named "textureInfo" ). Called once per scene so a single
 // sampleTexel / textureInfo binding is shared by every caller in a pipeline.


### PR DESCRIPTION
## Summary

Adds scale-independent ray origin offsets and removes the fixed local-space triangle intersection threshold.

## Changes

- Add the Ray Tracing Gems bit-level ray origin offset used by [Cycles.](https://github.com/blender/blender/blob/main/intern/cycles/kernel/bvh/util.h)
- Apply the offset to secondary and shadow rays in both MegaKernel and
  Wavefront paths.
- Orient the offset using the outgoing direction and geometric normal.
- Change the triangle intersection threshold from `1e-5` to `0.0`.

The previous `1e-5` threshold was evaluated in object-local space, making its effective size dependent on object scale. It could either fail to prevent self-intersections or skip valid nearby geometry.
