### PR TITLE
Fix webgpu environment MIS radiance

### DIFF
--- a/src/uniforms/EquirectHdrInfoUniform.js
+++ b/src/uniforms/EquirectHdrInfoUniform.js
@@ -178,6 +178,12 @@ export class EquirectHdrInfoUniform {
 
 	}
 
+	getPixelWeight( r, g, b ) {
+
+		return colorToLuminance( r, g, b );
+
+	}
+
 	dispose() {
 
 		this.marginalWeights.dispose();
@@ -218,10 +224,7 @@ export class EquirectHdrInfoUniform {
 				const g = DataUtils.fromHalfFloat( data[ 4 * i + 1 ] );
 				const b = DataUtils.fromHalfFloat( data[ 4 * i + 2 ] );
 
-				// the probability of the pixel being selected in this row is the
-				// scale of the luminance relative to the rest of the pixels.
-				// TODO: this should also account for the solid angle of the pixel when sampling
-				const weight = colorToLuminance( r, g, b );
+				const weight = this.getPixelWeight( r, g, b, y, height );
 				cumulativeRowWeight += weight;
 				totalSumValue += weight;
 

--- a/src/uniforms/EquirectHdrInfoUniform.js
+++ b/src/uniforms/EquirectHdrInfoUniform.js
@@ -224,6 +224,8 @@ export class EquirectHdrInfoUniform {
 				const g = DataUtils.fromHalfFloat( data[ 4 * i + 1 ] );
 				const b = DataUtils.fromHalfFloat( data[ 4 * i + 2 ] );
 
+				// the probability of the pixel being selected in its row is proportional
+				// to its luminance relative to the other pixels.
 				const weight = this.getPixelWeight( r, g, b, y, height );
 				cumulativeRowWeight += weight;
 				totalSumValue += weight;

--- a/src/webgpu/EquirectHdrInfoNode.js
+++ b/src/webgpu/EquirectHdrInfoNode.js
@@ -1,9 +1,20 @@
 import { Matrix3 } from 'three/webgpu';
-import { texture, sampler, uniform } from 'three/tsl';
+import { texture, sampler, uniform, wgslFn } from 'three/tsl';
 import { EquirectHdrInfoUniform } from '../uniforms/EquirectHdrInfoUniform.js';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
-import { environmentSampleStruct } from './nodes/structs.wgsl.js';
-import { equirectLuminancePdfFn, equirectDirectionToUvFn, equirectUvToDirectionFn, luminanceFn } from './nodes/sampling.wgsl.js';
+import { constants, environmentSampleStruct } from './nodes/structs.wgsl.js';
+import { equirectDirectionToUvFn, equirectUvToDirectionFn, luminanceFn } from './nodes/sampling.wgsl.js';
+
+// totalWeight includes sin( theta ), which cancels in the solid-angle conversion.
+const equirectLuminancePdfFn = wgslFn( /* wgsl */ `
+
+	fn equirectLuminancePdf( luminance: f32, totalWeight: f32, resolution: vec2u ) -> f32 {
+
+		return f32( resolution.x * resolution.y ) * luminance / ( 2.0 * PI * PI * totalWeight );
+
+	}
+
+`, [ constants ] );
 
 export class EquirectHdrInfoNode extends EquirectHdrInfoUniform {
 
@@ -30,6 +41,7 @@ export class EquirectHdrInfoNode extends EquirectHdrInfoUniform {
 
 	getPixelWeight( r, g, b, row, height ) {
 
+		// weight the pixel contribution by its spherical solid angle.
 		const theta = Math.PI * ( row + 0.5 ) / height;
 		return super.getPixelWeight( r, g, b ) * Math.sin( theta );
 

--- a/src/webgpu/EquirectHdrInfoNode.js
+++ b/src/webgpu/EquirectHdrInfoNode.js
@@ -3,7 +3,7 @@ import { texture, sampler, uniform } from 'three/tsl';
 import { EquirectHdrInfoUniform } from '../uniforms/EquirectHdrInfoUniform.js';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { environmentSampleStruct } from './nodes/structs.wgsl.js';
-import { equirectDirectionPdfFn, equirectDirectionToUvFn, equirectUvToDirectionFn, luminanceFn, sampleHemisphereFn } from './nodes/sampling.wgsl.js';
+import { equirectLuminancePdfFn, equirectDirectionToUvFn, equirectUvToDirectionFn, luminanceFn } from './nodes/sampling.wgsl.js';
 
 export class EquirectHdrInfoNode extends EquirectHdrInfoUniform {
 
@@ -25,6 +25,13 @@ export class EquirectHdrInfoNode extends EquirectHdrInfoUniform {
 		this.totalSumNode = uniform( this.totalSum );
 
 		this._initFns();
+
+	}
+
+	getPixelWeight( r, g, b, row, height ) {
+
+		const theta = Math.PI * ( row + 0.5 ) / height;
+		return super.getPixelWeight( r, g, b ) * Math.sin( theta );
 
 	}
 
@@ -68,10 +75,9 @@ export class EquirectHdrInfoNode extends EquirectHdrInfoUniform {
 		} = this;
 
 		this.sampleColor = wgslTagFn/* wgsl */`
-			fn sampleEnv( direction: vec3f, uv: vec2f ) -> vec4f {
+			fn sampleEnv( direction: vec3f ) -> vec4f {
 
-				let offsetDir = ${ sampleHemisphereFn }( direction, uv ) * 0.5;
-				let sampleDir = normalize( ${ rotationNode } * direction + offsetDir );
+				let sampleDir = ${ rotationNode } * direction;
 				let mapUv = ${ equirectDirectionToUvFn }( sampleDir );
 				let col = textureSampleLevel( ${ mapNode }, ${ mapSampler }, mapUv, 0 );
 
@@ -101,8 +107,7 @@ export class EquirectHdrInfoNode extends EquirectHdrInfoUniform {
 
 					let lum = ${ luminanceFn }( color );
 					let resolution = textureDimensions( ${ mapNode } );
-					let pdf = lum / totalSum;
-					result.pdf = f32( resolution.x * resolution.y ) * pdf * ${ equirectDirectionPdfFn }( direction );
+					result.pdf = ${ equirectLuminancePdfFn }( lum, totalSum, resolution );
 
 				} else {
 
@@ -129,9 +134,8 @@ export class EquirectHdrInfoNode extends EquirectHdrInfoUniform {
 				let color = textureSampleLevel( ${ mapNode }, ${ mapSampler }, mapUv, 0 ).rgb;
 				let lum = ${ luminanceFn }( color );
 				let resolution = textureDimensions( ${ mapNode } );
-				let pdf = lum / ${ totalSumNode };
 
-				return f32( resolution.x * resolution.y ) * pdf * ${ equirectDirectionPdfFn }( rotatedDir );
+				return ${ equirectLuminancePdfFn }( lum, ${ totalSumNode }, resolution );
 
 			}
 		`;

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -181,7 +181,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 							}
 
-							resultColor += ${ sampleEnvColor }( ray.direction, rng ) * vec4f( throughputColor * misWeight, 0.0 );
+							resultColor += ${ sampleEnvColor }( ray.direction ) * vec4f( throughputColor * misWeight, 0.0 );
 
 						} else {
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -1,7 +1,7 @@
 import { DataTexture, Vector2, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from './ComputeKernel.js';
 import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
-import { rngInit, rngNextBounce, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_ENVIRONMENT_SAMPLE, RNG_INDEX_DIRECT_LIGHT_SAMPLE } from '../nodes/random.wgsl.js';
+import { rngInit, rngNextBounce, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_BACKGROUND_SAMPLE, RNG_INDEX_DIRECT_LIGHT_SAMPLE } from '../nodes/random.wgsl.js';
 import { misHeuristicFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
 import { proxy, proxyFn, wgslTagFn, rayStruct } from 'three-mesh-bvh/webgpu';
 import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
@@ -170,7 +170,6 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 					} else {
 
-						let rng = ${ rand2 }( ${ RNG_INDEX_ENVIRONMENT_SAMPLE } );
 						if ( bounce > 0u ) {
 
 							var misWeight = 1.0;
@@ -185,6 +184,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						} else {
 
+							let rng = ${ rand2 }( ${ RNG_INDEX_BACKGROUND_SAMPLE } );
 							resultColor = ${ sampleBackground }( ray.direction, rng );
 
 						}

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -100,7 +100,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 						}
 
-						resultColor += ${ sampleEnvColor }( input.direction, rng ) * vec4f( input.throughputColor * misWeight, 0.0 );
+						resultColor += ${ sampleEnvColor }( input.direction ) * vec4f( input.throughputColor * misWeight, 0.0 );
 
 					} else {
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -1,7 +1,7 @@
 import { StorageBufferAttribute, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from '../ComputeKernel.js';
 import { uniform, storage, textureStore, globalId } from 'three/tsl';
-import { rngInit, rand2, RNG_INDEX_ENVIRONMENT_SAMPLE } from '../../nodes/random.wgsl.js';
+import { rngInit, rand2, RNG_INDEX_BACKGROUND_SAMPLE } from '../../nodes/random.wgsl.js';
 import { rayQueueStruct, hitQueueAtomicStruct } from './structs.js';
 import { proxy, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { misHeuristicFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
@@ -88,7 +88,6 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 				} else {
 
-					let rng = ${ rand2 }( ${ RNG_INDEX_ENVIRONMENT_SAMPLE } );
 					var resultColor = input.resultColor;
 					if ( input.currentBounce > 0u ) {
 
@@ -104,6 +103,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 					} else {
 
+						let rng = ${ rand2 }( ${ RNG_INDEX_BACKGROUND_SAMPLE } );
 						resultColor = ${ sampleBackground }( input.direction, rng );
 
 					}

--- a/src/webgpu/nodes/random.wgsl.js
+++ b/src/webgpu/nodes/random.wgsl.js
@@ -1,6 +1,6 @@
 // Alpha test should be the last index as it is summed with triangle index
 export const RNG_INDEX_RAY_JITTER = 0;
-export const RNG_INDEX_ENVIRONMENT_SAMPLE = 1;
+export const RNG_INDEX_BACKGROUND_SAMPLE = 1;
 export const RNG_INDEX_SCATTER_TYPE = 2;
 export const RNG_INDEX_SCATTER_DIRECTION = 3;
 export const RNG_INDEX_APERTURE_SAMPLE = 4;

--- a/src/webgpu/nodes/sampling.wgsl.js
+++ b/src/webgpu/nodes/sampling.wgsl.js
@@ -178,17 +178,6 @@ export const equirectDirectionPdfFn = wgslFn( /* wgsl */ `
 
 `, [ constants, equirectDirectionToUvFn ] );
 
-// solid-angle pdf for an equirect CDF weighted by luminance * sin( theta )
-export const equirectLuminancePdfFn = wgslFn( /* wgsl */ `
-
-	fn equirectLuminancePdf( luminance: f32, totalWeight: f32, resolution: vec2u ) -> f32 {
-
-		return f32( resolution.x * resolution.y ) * luminance / ( 2.0 * PI * PI * totalWeight );
-
-	}
-
-`, [ constants ] );
-
 export const weightedAlphaBlendFn = wgslFn( /* wgsl */`
 
 	fn weightedAlphaBlend( prevColor: vec4f, newColor: vec4f, weight: f32 ) -> vec4f {

--- a/src/webgpu/nodes/sampling.wgsl.js
+++ b/src/webgpu/nodes/sampling.wgsl.js
@@ -178,6 +178,17 @@ export const equirectDirectionPdfFn = wgslFn( /* wgsl */ `
 
 `, [ constants, equirectDirectionToUvFn ] );
 
+// solid-angle pdf for an equirect CDF weighted by luminance * sin( theta )
+export const equirectLuminancePdfFn = wgslFn( /* wgsl */ `
+
+	fn equirectLuminancePdf( luminance: f32, totalWeight: f32, resolution: vec2u ) -> f32 {
+
+		return f32( resolution.x * resolution.y ) * luminance / ( 2.0 * PI * PI * totalWeight );
+
+	}
+
+`, [ constants ] );
+
 export const weightedAlphaBlendFn = wgslFn( /* wgsl */`
 
 	fn weightedAlphaBlend( prevColor: vec4f, newColor: vec4f, weight: f32 ) -> vec4f {


### PR DESCRIPTION
The WebGPU BSDF miss path now evaluates the environment using the exact ray direction instead of applying an additional stochastic direction offset. This ensures that the BSDF and NEE strategies evaluate the same environment
radiance.

The equirectangular CDF now uses `luminance * sin(theta)` so each texel's spherical solid angle is included in its sampling weight. This follows Cycles' `background_cdf` construction: [light.cpp](https://github.com/blender/blender/blob/main/intern/cycles/scene/light.cpp).

| Before | After |
| :---: | :---: |
| <img width="450" height="300" alt="95e431a893855faa8cd40ee819cad165" src="https://github.com/user-attachments/assets/b13141be-38c0-48f5-99bb-4eaddd9e5058" /> | <img width="450" height="300" alt="90b166e117c0b20dc9220edca246aa83" src="https://github.com/user-attachments/assets/b58489e0-9eb6-4ceb-992d-0b13f185a61e" /> |
| <img width="450" height="300" alt="f4c551085e4e8f97a379b93956395fcf" src="https://github.com/user-attachments/assets/6cb3e7b9-7ad2-4997-9f6f-7e41497d45de" /> | <img width="450" height="300" alt="1f0164cbadf8320cec3794054cdcdc7b" src="https://github.com/user-attachments/assets/e531bb51-8e80-4ffe-b05f-070d351bd0e3" /> |
| <img width="450" height="300" alt="9afea8e0c36e7941fee3d16fe3199c12" src="https://github.com/user-attachments/assets/1253b89d-d6b1-4d86-bcc9-fd5cfce569a1" /> | <img width="450" height="300" alt="0d784cd0577a60e3c4151d96b565bf07" src="https://github.com/user-attachments/assets/8ab04eef-2101-4580-9ca4-73ecd5c5dac6" /> |

As for the firefly noise occurring at glossy boundaries and transmission areas on the model, the exact cause has not yet been identified.