### PR TITLE
WebGPU: Reorganize lobes into categorized as layers

### DIFF
--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -1,7 +1,7 @@
 import { float } from 'three/tsl';
 import { wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { PathtracingMaterial } from './PathtracingMaterial';
-import { specularBrdfFunc, specularBtdfFunc, lambertBrdfFunc, fresnelMixFunc, conductorFresnelFunc, fresnelCoatFunc, iridescentDielectricLayerFunc, iridescentConductorLayerFunc, thinWallTransmissionRoughnessFunc } from '../nodes/material.wgsl.js';
+import { specularBrdfFunc, specularBtdfFunc, lambertBrdfFunc, fresnelMixFunc, conductorFresnelFunc, fresnelCoatFunc, iridescentFresnelFunc, thinWallTransmissionRoughnessFunc } from '../nodes/material.wgsl.js';
 import { sheenColorFunc, sheenAlbedoScalingFunc } from '../nodes/sheen.wgsl.js';
 import { diffuseDirectionFunc, getLobeWeightsFunc } from '../nodes/sampling.wgsl.js';
 import { ggxDirectionFunc, ggxReflectionAdjustedPDFFunc, ggxRefractionAdjustedPDFFunc } from '../nodes/ggx.wgsl.js';
@@ -25,8 +25,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 			fresnelMix = fresnelMixFunc,
 			conductorFresnel = conductorFresnelFunc,
 			fresnelCoat = fresnelCoatFunc,
-			iridescentDielectricLayer = iridescentDielectricLayerFunc,
-			iridescentConductorLayer = iridescentConductorLayerFunc,
+			iridescentFresnel = iridescentFresnelFunc,
 		} = options;
 
 		this.turquinTexture = new TurquinTexture();
@@ -36,8 +35,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 		this.fresnelMix = fresnelMix;
 		this.conductorFresnel = conductorFresnel;
 		this.fresnelCoat = fresnelCoat;
-		this.iridescentDielectricLayer = iridescentDielectricLayer;
-		this.iridescentConductorLayer = iridescentConductorLayer;
+		this.iridescentFresnel = iridescentFresnel;
 
 	}
 
@@ -51,6 +49,9 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 		const bsdfEvalFunc = wgslTagFn/* wgsl */`
 
+			// The material is organized as one scoped block per lobe in cascade order - clearcoat,
+			// sheen, transmission ( glass ), specular, diffuse - each accumulating into a shared
+			// result and guarding its own hemisphere.
 			fn bsdfEval( ctx: ${ bxdfContextStruct }, surf: ${ surfaceRecordStruct } ) -> vec3f {
 
 				let NdotV = ctx.V.z;
@@ -62,106 +63,202 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
 				let alpha = vec2( alphaT, alphaB );
 
-				// Sample the single scatter energy for specular at the given roughness.
-				let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
-				let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
+				// Each lobe contributes into "result" within its own scope, evaluated in cascade
+				// order. "attenuation" carries the fraction of energy each layer passes through to
+				// the layers beneath it. Every lobe guards its own hemisphere, matching how Cycles
+				// closures return zero for directions outside their domain.
+				var result = vec3f( 0.0 );
+				var attenuation = vec3f( 1.0 );
 
-				// transmitted directions only gather the refracted lobe — the reflection lobes are
-				// gated to the upper hemisphere, matching the WebGL implementation
-				if ( NdotL < 0.0 ) {
+				// clearcoat
+				{
 
-					// TODO: transmitted light also crosses the thin film so it should be weighted by
-					// the film-aware fresnel complement (1 - filmF) rather than the plain dielectric
-					// fresnel, tinting transmission with the film's complementary color. Deferred until
-					// the material is generalized into a layer stack that owns the fresnel per interface.
-					var refraction: vec3f;
-					if ( surf.thinWall ) {
+					if ( NdotL > 0.0 ) {
 
-						// evaluate the flipped reflection
-						let wiMirror = vec3f( ctx.L.xy, - ctx.L.z );
-						let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
-						let F = ${ dielectricFresnelFunc }( saturate( ctx.VdotH ), surf.eta );
-						refraction = ( 1.0 - F ) * ${ this.specularBrdf }( ctx.V, wiMirror, ctx.H, thinWallAlpha );
+						// reuse the same pattern for energy conservation used in the dielectric layer
+						let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
+						let clearcoatEnergySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotVc, surf.clearcoatRoughness ), 1e-5 );
+						let clearcoatBoost = 1.0 + ${ iorToF0Func }( 1.5 ) * ( 1.0 - clearcoatEnergySS ) / clearcoatEnergySS;
+						let clearcoatFresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotVc, surf.clearcoatRoughness, 1.5 ) * clearcoatBoost;
+						let clearcoatSpecular = ${ this.specularBrdf }( ctx.Vc, ctx.Lc, ctx.Hc, vec2( clearcoatAlpha ) ) * clearcoatBoost;
+						let clearcoatFresnel = ${ schlickFresnelFunc }( abs( dot( ctx.Vc, ctx.Hc ) ), ${ iorToF0Func }( 1.5 ) );
 
-					} else {
-
-						refraction = ${ this.specularBtdf }( ctx.V, ctx.L, ctx.H, alpha, surf.eta );
+						result += surf.clearcoat * clearcoatFresnel * clearcoatSpecular;
+						attenuation *= 1.0 - surf.clearcoat * clearcoatFresnelEnergySS;
 
 					}
 
-					return ( 1.0 - surf.metalness ) * surf.transmission * refraction * surf.color;
-
 				}
-
-				// specular and diffuse components
-				let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
-				let boostedSpecular = specular * dielectricBoost;
-				let reflection = ${ this.diffuseBrdf }( NdotV, NdotL, ctx.VdotH, surf );
-				let diffuse = ( 1.0 - surf.transmission ) * reflection;
-
-				// Sample the single scatter energy, including fresnel, for the specular layer, boosting by the
-				// compensation formula above to account for multi scatter. Attenuate the energy allocated for
-				// diffuse by the remaining energy from specular single scatter.
-				let fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
-				let dielectricDiffuse = ( 1.0 - fresnelEnergySS ) * diffuse;
-
-				// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
-				let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
-
-				// front faces use schlick so the KHR_materials_specular tinted f0 applies - interior
-				// hits use the exact dielectric fresnel since schlick cannot represent TIR
-				// TODO: see if we can clean this up and make these branches more consistent
-				var dielectricFr: vec3f;
-				if ( surf.frontFace ) {
-
-					dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
-
-				} else {
-
-					dielectricFr = vec3f( ${ dielectricFresnelFunc }( abs( ctx.VdotH ), surf.eta ) );
-
-				}
-
-				let dielectricSpecular = boostedSpecular * surf.specularIntensity * dielectricFr;
-				let dielectricBase = dielectricDiffuse + dielectricSpecular;
-
-				// the media on either side of the film - air outside and the volume interior
-				// as the base on front faces, swapped on back faces so TIR can take effect
-				let outsideIor = select( surf.ior, 1.0, surf.frontFace );
-				let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
-
-				let dielectric = ${ this.iridescentDielectricLayer }(
-					dielectricBase, diffuse, boostedSpecular, ctx.VdotH, outsideIor,
-					filmBaseIor, surf.iridescenceIor, surf.iridescenceThickness, surf.iridescence
-				);
-
-				// Fresnel-weighted specular with the multiscatter comp
-				let metallicBoost = 1.0 + surf.color * ( 1.0 - energySS ) / energySS;
-				let metallicSpecular = specular * metallicBoost;
-				let metallicBase = ${ this.conductorFresnel }( ctx.VdotH, surf.color, metallicSpecular );
-				let metallic = ${ this.iridescentConductorLayer }(
-					metallicBase, metallicSpecular, surf.color, ctx.VdotH, outsideIor,
-					surf.iridescenceIor, surf.iridescenceThickness, surf.iridescence
-				);
-
-				let baseMaterial = mix( dielectric, metallic, surf.metalness );
 
 				// sheen
-				let sheenScale = mix( 1.0, ${ sheenAlbedoScalingFunc }( ctx.V, ctx.L, surf ), surf.sheen );
-				let material = baseMaterial * sheenScale + ${ sheenColorFunc }( ctx.V, ctx.L, ctx.H, surf ) * surf.sheen;
+				{
 
-				// clearcoat
-				// reuse the same pattern for energy conservation used in the dielectric layer
-				let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
-				let clearcoatEnergySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotVc, surf.clearcoatRoughness ), 1e-5 );
-				let clearcoatBoost = 1.0 + ${ iorToF0Func }( 1.5 ) * ( 1.0 - clearcoatEnergySS ) / clearcoatEnergySS;
-				let clearcoatFresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotVc, surf.clearcoatRoughness, 1.5 ) * clearcoatBoost;
+					if ( NdotL > 0.0 ) {
 
-				let clearcoatSpecular = ${ this.specularBrdf }( ctx.Vc, ctx.Lc, ctx.Hc, vec2( clearcoatAlpha ) ) * clearcoatBoost;
-				let clearcoatBase = ( 1.0 - clearcoatFresnelEnergySS ) * material;
-				let coatedMaterial = clearcoatBase + clearcoatSpecular * ${ schlickFresnelFunc }( abs( dot( ctx.Vc, ctx.Hc ) ), ${ iorToF0Func }( 1.5 ) );
+						result += attenuation * surf.sheen * ${ sheenColorFunc }( ctx.V, ctx.L, ctx.H, surf );
+						attenuation *= mix( 1.0, ${ sheenAlbedoScalingFunc }( ctx.V, ctx.L, surf ), surf.sheen );
 
-				return mix( material, coatedMaterial, surf.clearcoat );
+					}
+
+				}
+
+				// transmission ( glass )
+				// the full transmissive dielectric interface: fresnel reflection above the horizon
+				// and refraction below it, so the specular lobe only serves the opaque remainder.
+				// The refracted half is not attenuated by the layers above, matching the WebGL
+				// implementation.
+				{
+
+					if ( surf.transmission > 0.0 ) {
+
+						if ( NdotL < 0.0 ) {
+
+							// TODO: transmitted light also crosses the thin film so it should be weighted by
+							// the film-aware fresnel complement (1 - filmF) rather than the plain dielectric
+							// fresnel, tinting transmission with the film's complementary color. Deferred until
+							// the material is generalized into a layer stack that owns the fresnel per interface.
+							var refraction: vec3f;
+							if ( surf.thinWall ) {
+
+								// evaluate the flipped reflection
+								let wiMirror = vec3f( ctx.L.xy, - ctx.L.z );
+								let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
+								let F = ${ dielectricFresnelFunc }( saturate( ctx.VdotH ), surf.eta );
+								refraction = ( 1.0 - F ) * ${ this.specularBrdf }( ctx.V, wiMirror, ctx.H, thinWallAlpha );
+
+							} else {
+
+								refraction = ${ this.specularBtdf }( ctx.V, ctx.L, ctx.H, alpha, surf.eta );
+
+							}
+
+							result += ( 1.0 - surf.metalness ) * surf.transmission * refraction * surf.color;
+
+						} else {
+
+							// fresnel reflection of the glass interface, mirroring the dielectric half
+							// of the specular lobe below
+							// Sample the single scatter energy for specular at the given roughness.
+							let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
+							let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
+							let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
+							let boostedSpecular = specular * dielectricBoost;
+
+							// the media on either side of the film - air outside and the volume interior
+							// as the base on front faces, swapped on back faces so TIR can take effect
+							let outsideIor = select( surf.ior, 1.0, surf.frontFace );
+							let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
+
+							// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
+							let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
+
+							// front faces use schlick so the KHR_materials_specular tinted f0 applies - interior
+							// hits use the exact dielectric fresnel since schlick cannot represent TIR
+							var dielectricFr: vec3f;
+							if ( surf.frontFace ) {
+
+								dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
+
+							} else {
+
+								dielectricFr = vec3f( ${ dielectricFresnelFunc }( abs( ctx.VdotH ), surf.eta ) );
+
+							}
+
+							// iridescence blending toward the film fresnel
+							let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
+							let glassSpecular = boostedSpecular * mix( surf.specularIntensity * dielectricFr, dielectricFilmFresnel, surf.iridescence );
+
+							result += attenuation * ( 1.0 - surf.metalness ) * surf.transmission * glassSpecular;
+
+						}
+
+					}
+
+				}
+
+				// specular
+				// the metallic and dielectric halves share the ggx lobe with their own fresnel.
+				// Iridescence swaps each half's fresnel for the thin film response, matching how
+				// Cycles folds the film into the closure fresnel rather than adding a layer.
+				{
+
+					if ( NdotL > 0.0 ) {
+
+						// Sample the single scatter energy for specular at the given roughness.
+						let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
+						let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
+						let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
+						let boostedSpecular = specular * dielectricBoost;
+
+						// the media on either side of the film - air outside and the volume interior
+						// as the base on front faces, swapped on back faces so TIR can take effect
+						let outsideIor = select( surf.ior, 1.0, surf.frontFace );
+						let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
+
+						// metallic half with the multiscatter comp, iridescence blending toward the
+						// film fresnel over the conductor response
+						let metallicBoost = 1.0 + surf.color * ( 1.0 - energySS ) / energySS;
+						let metallicSpecular = specular * metallicBoost;
+						let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
+						let metallicBase = ${ this.conductorFresnel }( ctx.VdotH, surf.color, metallicSpecular );
+						let metallic = mix( metallicBase, metallicSpecular * metallicFilmFresnel, surf.iridescence );
+
+						result += attenuation * surf.metalness * metallic;
+
+						// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
+						let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
+
+						// front faces use schlick so the KHR_materials_specular tinted f0 applies - interior
+						// hits use the exact dielectric fresnel since schlick cannot represent TIR
+						// TODO: see if we can clean this up and make these branches more consistent
+						var dielectricFr: vec3f;
+						if ( surf.frontFace ) {
+
+							dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
+
+						} else {
+
+							dielectricFr = vec3f( ${ dielectricFresnelFunc }( abs( ctx.VdotH ), surf.eta ) );
+
+						}
+
+						// dielectric half, iridescence blending toward the film fresnel. Weighted by the
+						// opaque share - the transmissive portion's reflection belongs to the glass lobe
+						let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
+						let dielectricSpecular = boostedSpecular * mix( surf.specularIntensity * dielectricFr, dielectricFilmFresnel, surf.iridescence );
+
+						result += attenuation * ( 1.0 - surf.metalness ) * ( 1.0 - surf.transmission ) * dielectricSpecular;
+
+						// Attenuate the layers below by the energy taken by the specular interface - the
+						// fresnel-weighted single scatter energy with the multiscatter boost, or the film
+						// fresnel when iridescent, using its strongest channel so the base is not tinted
+						// with the film's inverse color. Only the dielectric half passes light downward.
+						let fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
+						let filmFresnelMax = max( max( dielectricFilmFresnel.r, dielectricFilmFresnel.g ), dielectricFilmFresnel.b );
+						attenuation *= ( 1.0 - surf.metalness ) * mix( 1.0 - fresnelEnergySS, 1.0 - filmFresnelMax, surf.iridescence );
+
+					}
+
+				}
+
+				// diffuse
+				{
+
+					if ( NdotL > 0.0 ) {
+
+						// the dielectric base mixes diffuse with transmission - the transmissive half
+						// is carried by the glass lobe above
+						let reflection = ${ this.diffuseBrdf }( NdotV, NdotL, ctx.VdotH, surf );
+						let diffuse = ( 1.0 - surf.transmission ) * reflection;
+
+						result += attenuation * diffuse;
+
+					}
+
+				}
+
+				return result;
 
 			}
 
@@ -189,15 +286,15 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let wo = normalize( invBasis * worldWo );
 				let woClearcoat = normalize( invClearcoatBasis * worldWo );
 
+				// lobe selection weights and cumulative bounds in cascade order:
+				// clearcoat, specular, transmission ( glass ), diffuse
 				let weights = ${ getLobeWeightsFunc }( wo, wo, woClearcoat, vec3( 0, 0, 1 ), ${ CLEARCOAT_IOR }, surf );
+				let cdfClearcoat = weights.clearcoat;
+				let cdfSpecular = cdfClearcoat + weights.specular;
+				let cdfTransmission = cdfSpecular + weights.transmission;
+				let cdfTotal = cdfTransmission + weights.diffuse;
 
-				var cdf: vec4f;
-				cdf.x = weights.diffuse;
-				cdf.y = weights.specular + cdf.x;
-				cdf.z = weights.clearcoat + cdf.y;
-				cdf.w = weights.transmission + cdf.z;
-
-				let r = ${ rand1 }( ${ RNG_INDEX_SCATTER_TYPE } ) * cdf.w;
+				let r = ${ rand1 }( ${ RNG_INDEX_SCATTER_TYPE } ) * cdfTotal;
 
 				let directionUV = ${ rand2 }( ${ RNG_INDEX_SCATTER_DIRECTION } );
 				var wi: vec3f;
@@ -206,23 +303,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				var whClearcoat: vec3f;
 				var isTransmissive = false;
 
-				if ( r <= cdf.x ) { // diffuse
-
-					wi = ${ diffuseDirectionFunc }( wo, directionUV );
-					wh = normalize( wi + wo );
-
-					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
-					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
-
-				} else if ( r <= cdf.y ) { // specular
-
-					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
-					wi = - normalize( reflect( wo, wh ) );
-
-					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
-					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
-
-				} else if ( r <= cdf.z ) { // clearcoat
+				if ( r <= cdfClearcoat ) { // clearcoat
 
 					whClearcoat = ${ ggxDirectionFunc }( woClearcoat, vec2( clearcoatAlpha ), directionUV );
 					wiClearcoat = - normalize( reflect( woClearcoat, whClearcoat ) );
@@ -230,7 +311,15 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					wi = normalize( invBasis * clearcoatBasis * wiClearcoat );
 					wh = normalize( invBasis * clearcoatBasis * whClearcoat );
 
-				} else if ( r <= cdf.w ) { // transmission / refraction
+				} else if ( r <= cdfSpecular ) { // specular
+
+					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
+					wi = - normalize( reflect( wo, wh ) );
+
+					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
+					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
+
+				} else if ( r <= cdfTransmission ) { // transmission ( glass )
 
 					isTransmissive = true;
 
@@ -244,18 +333,32 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					} else {
 
+						// sample the half vector first and select reflection or refraction by the
+						// facet fresnel, matching Cycles - total internal reflection drives the
+						// fresnel to 1 so TIR facets always reflect with a matching pdf
 						wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
-						wi = refract( - wo, wh, surf.eta );
+						let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
+						let rFresnel = ( r - cdfSpecular ) / ( cdfTransmission - cdfSpecular );
+						if ( rFresnel < F ) {
 
-						if ( all( wi == vec3f( 0.0 ) ) ) {
-
-							// total internal reflection - refract returns a zero vector, so bounce the
-							// ray off the inside of the surface instead of terminating it
 							wi = - normalize( reflect( wo, wh ) );
+							isTransmissive = false;
+
+						} else {
+
+							wi = refract( - wo, wh, surf.eta );
 
 						}
 
 					}
+
+					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
+					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
+
+				} else if ( r <= cdfTotal ) { // diffuse
+
+					wi = ${ diffuseDirectionFunc }( wo, directionUV );
+					wh = normalize( wi + wo );
 
 					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
 					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
@@ -273,35 +376,73 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				ctx.Lc = wiClearcoat;
 				ctx.Hc = whClearcoat;
 
-				if ( weights.diffuse > 0.0 ) {
+				// pdf mixture - every lobe that can produce the sampled direction contributes its
+				// share, in the same cascade order as the eval blocks
 
-					result.pdf += weights.diffuse * max( wi.z, 0.0 ) / PI;
+				// clearcoat
+				{
 
-				}
+					if ( weights.clearcoat > 0.0 && wiClearcoat.z > 0.0 ) {
 
-				if ( weights.specular > 0.0 && wi.z > 0.0 ) {
+						result.pdf += weights.clearcoat * ${ ggxReflectionAdjustedPDFFunc }( woClearcoat, whClearcoat, vec2( clearcoatAlpha ) );
 
-					result.pdf += weights.specular * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
-
-				}
-
-				if ( weights.clearcoat > 0.0 && wiClearcoat.z > 0.0 ) {
-
-					result.pdf += weights.clearcoat * ${ ggxReflectionAdjustedPDFFunc }( woClearcoat, whClearcoat, vec2( clearcoatAlpha ) );
+					}
 
 				}
 
-				if ( weights.transmission > 0.0 && wi.z < 0.0 ) {
+				// specular
+				{
 
-					if ( surf.thinWall ) {
+					if ( weights.specular > 0.0 && wi.z > 0.0 ) {
 
-						// the flipped reflection shares the reflection pdf
-						let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
-						result.pdf += weights.transmission * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, thinWallAlpha );
+						result.pdf += weights.specular * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
 
-					} else {
+					}
 
-						result.pdf += weights.transmission * ${ ggxRefractionAdjustedPDFFunc }( wo, wi, wh, alpha, surf.eta );
+				}
+
+				// transmission ( glass )
+				{
+
+					if ( weights.transmission > 0.0 ) {
+
+						if ( surf.thinWall ) {
+
+							if ( wi.z < 0.0 ) {
+
+								// the flipped reflection shares the reflection pdf
+								let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
+								result.pdf += weights.transmission * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, thinWallAlpha );
+
+							}
+
+						} else {
+
+							// the glass lobe selects reflection or refraction by the facet fresnel so
+							// each side carries the corresponding share of the transmission pdf
+							let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
+							if ( wi.z > 0.0 ) {
+
+								result.pdf += weights.transmission * F * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
+
+							} else {
+
+								result.pdf += weights.transmission * ( 1.0 - F ) * ${ ggxRefractionAdjustedPDFFunc }( wo, wi, wh, alpha, surf.eta );
+
+							}
+
+						}
+
+					}
+
+				}
+
+				// diffuse
+				{
+
+					if ( weights.diffuse > 0.0 ) {
+
+						result.pdf += weights.diffuse * max( wi.z, 0.0 ) / PI;
 
 					}
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -324,10 +324,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					wh = normalize( invBasis * clearcoatBasis * whClearcoat );
 
 					// reflected rays must leave above the geometry surface - flip rays that land
-					// below it due to the shading normal
+					// below it due to the shading normal. Rays below the shading hemisphere are
+					// left as is since their loss is refunded by the energy compensation tables
 					let faceNormal = normalize( invBasis * surf.faceNormal );
 					let geomDotDir = dot( wi, faceNormal );
-					if ( geomDotDir < 0.0 ) {
+					if ( wi.z > 0.0 && geomDotDir < 0.0 ) {
 
 						wi = normalize( wi - 2.0 * geomDotDir * faceNormal );
 
@@ -346,10 +347,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					wi = - normalize( reflect( wo, wh ) );
 
 					// reflected rays must leave above the geometry surface - flip rays that land
-					// below it due to the shading normal
+					// below it due to the shading normal. Rays below the shading hemisphere are
+					// left as is since their loss is refunded by the energy compensation tables
 					let faceNormal = normalize( invBasis * surf.faceNormal );
 					let geomDotDir = dot( wi, faceNormal );
-					if ( geomDotDir < 0.0 ) {
+					if ( wi.z > 0.0 && geomDotDir < 0.0 ) {
 
 						wi = normalize( wi - 2.0 * geomDotDir * faceNormal );
 
@@ -401,10 +403,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					wh = normalize( wi + wo );
 
 					// reflected rays must leave above the geometry surface - flip rays that land
-					// below it due to the shading normal
+					// below it due to the shading normal. Rays below the shading hemisphere are
+					// left as is since their loss is refunded by the energy compensation tables
 					let faceNormal = normalize( invBasis * surf.faceNormal );
 					let geomDotDir = dot( wi, faceNormal );
-					if ( geomDotDir < 0.0 ) {
+					if ( wi.z > 0.0 && geomDotDir < 0.0 ) {
 
 						wi = normalize( wi - 2.0 * geomDotDir * faceNormal );
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -52,6 +52,9 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 			// The material is organized as one scoped block per lobe in cascade order - clearcoat,
 			// sheen, transmission, specular, diffuse - each accumulating into a shared result and
 			// guarding its own hemisphere.
+			//
+			// TODO: energy only cascades downward through front faces, so the layers are always traversed
+			// outside-in and cannot reflect energy back into the glass from below.
 			fn bsdfEval( ctx: ${ bxdfContextStruct }, surf: ${ surfaceRecordStruct } ) -> vec3f {
 
 				let NdotV = ctx.V.z;
@@ -107,16 +110,18 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
 					let alpha = vec2( alphaT, alphaB );
 
+					// a thin wall has no interior volume so air is the incident medium on both
+					// sides - only a true volume distinguishes entering from exiting hits
+					let airIncident = surf.thinWall || surf.frontFace;
+
 					if ( NdotL < 0.0 ) {
 
-						// TODO: transmitted light also crosses the thin film so it should be weighted by
-						// the film-aware fresnel complement (1 - filmF) rather than the plain dielectric
-						// fresnel, tinting transmission with the film's complementary color. Deferred until
-						// the material is generalized into a layer stack that owns the fresnel per interface.
+						// TODO: transmitted light also crosses the iridescent thin film so it should be weighted by
+						// the iridescence-aware fresnel complement rather than the plain dielectric fresnel
 						var refraction: vec3f;
 						if ( surf.thinWall ) {
 
-							// evaluate the flipped reflection
+							// model the double refraction as a reflection flipped through the surface
 							let wiMirror = vec3f( ctx.L.xy, - ctx.L.z );
 							let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
 							let F = ${ dielectricFresnelFunc }( saturate( ctx.VdotH ), surf.eta );
@@ -128,30 +133,23 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 						}
 
+						// the refracted half is not attenuated by the layers above
 						result += ( 1.0 - surf.metalness ) * surf.transmission * refraction * surf.color;
 
 					} else {
 
-						// fresnel reflection of the glass interface, mirroring the dielectric half
-						// of the specular lobe below
-						// Sample the single scatter energy for specular at the given roughness.
+						// the glass interface reflection, mirroring the dielectric half of the specular lobe
 						let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
-						let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
-						let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
-						let boostedSpecular = specular * dielectricBoost;
-
-						// the media on either side of the film - air outside and the volume interior
-						// as the base on front faces, swapped on back faces so TIR can take effect
-						let outsideIor = select( surf.ior, 1.0, surf.frontFace );
-						let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
+						let glassBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
+						let glassSpecular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha ) * glassBoost;
 
 						// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 						let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
 
-						// front faces use schlick so the KHR_materials_specular tinted f0 applies - interior
-						// hits use the exact dielectric fresnel since schlick cannot represent TIR
+						// air-incident hits use schlick so the tinted f0 applies - interior hits use
+						// the exact fresnel since schlick cannot represent TIR
 						var dielectricFr: vec3f;
-						if ( surf.frontFace ) {
+						if ( airIncident ) {
 
 							dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
 
@@ -161,18 +159,24 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 						}
 
-						// iridescence blending toward the film fresnel
-						var glassFresnel = surf.specularIntensity * dielectricFr;
+						var glassReflectance = surf.specularIntensity * dielectricFr;
+
+						// iridescence
 						if ( surf.iridescence > 0.0 ) {
 
+							// the media on either side of the film - air outside and the volume interior
+							// as the base, swapped on interior hits so TIR can take effect
+							let outsideIor = select( surf.ior, 1.0, airIncident );
+							let filmBaseIor = select( 1.0, surf.ior, airIncident );
+
 							let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-							glassFresnel = mix( glassFresnel, dielectricFilmFresnel, surf.iridescence );
+							glassReflectance = mix( glassReflectance, dielectricFilmFresnel, surf.iridescence );
 
 						}
 
-						let glassSpecular = boostedSpecular * glassFresnel;
+						let reflection = glassSpecular * glassReflectance;
 
-						result += attenuation * ( 1.0 - surf.metalness ) * surf.transmission * glassSpecular;
+						result += attenuation * ( 1.0 - surf.metalness ) * surf.transmission * reflection;
 
 					}
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -268,44 +268,43 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				var result: ${ scatterRecordStruct };
 				result.pdf = 0.0;
 
-				let normalBasis = surf.normalBasis;
-				let invBasis = surf.normalInvBasis;
-				let clearcoatBasis = surf.clearcoatBasis;
-				let invClearcoatBasis = surf.clearcoatInvBasis;
-
-				let wo = normalize( invBasis * worldWo );
-				let woClearcoat = normalize( invClearcoatBasis * worldWo );
+				let wo = normalize( surf.normalInvBasis * worldWo );
+				let woClearcoat = normalize( surf.clearcoatInvBasis * worldWo );
 
 				// lobe selection weights and cumulative bounds in cascade order:
-				// clearcoat, specular, transmission ( glass ), diffuse
+				// clearcoat, specular, transmission, diffuse
 				let weights = ${ getLobeWeightsFunc }( wo, wo, woClearcoat, vec3( 0, 0, 1 ), ${ CLEARCOAT_IOR }, surf );
 				let cdfClearcoat = weights.clearcoat;
 				let cdfSpecular = cdfClearcoat + weights.specular;
 				let cdfTransmission = cdfSpecular + weights.transmission;
 				let cdfTotal = cdfTransmission + weights.diffuse;
 
-				let r = ${ rand1 }( ${ RNG_INDEX_SCATTER_TYPE } ) * cdfTotal;
-
+				// random samples for lobes
+				let lobeSample = ${ rand1 }( ${ RNG_INDEX_SCATTER_TYPE } ) * cdfTotal;
 				let directionUV = ${ rand2 }( ${ RNG_INDEX_SCATTER_DIRECTION } );
+
 				var wi: vec3f;
-				var wiClearcoat: vec3f;
 				var wh: vec3f;
+
+				var wiClearcoat: vec3f;
 				var whClearcoat: vec3f;
+
 				var isGlass = false;
 
-				if ( r <= cdfClearcoat ) { // clearcoat
+				if ( lobeSample <= cdfClearcoat ) {
 
+					// clearcoat
 					let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
 					whClearcoat = ${ ggxDirectionFunc }( woClearcoat, vec2( clearcoatAlpha ), directionUV );
 					wiClearcoat = - normalize( reflect( woClearcoat, whClearcoat ) );
 
-					wi = normalize( invBasis * clearcoatBasis * wiClearcoat );
-					wh = normalize( invBasis * clearcoatBasis * whClearcoat );
+					wi = normalize( surf.normalInvBasis * surf.clearcoatBasis * wiClearcoat );
+					wh = normalize( surf.normalInvBasis * surf.clearcoatBasis * whClearcoat );
 
 					// reflected rays must leave above the geometry surface - flip rays that land
 					// below it due to the shading normal. Rays below the shading hemisphere are
 					// left as is since their loss is refunded by the energy compensation tables
-					let faceNormal = normalize( invBasis * surf.faceNormal );
+					let faceNormal = normalize( surf.normalInvBasis * surf.faceNormal );
 					let geomDotDir = dot( wi, faceNormal );
 					if ( wi.z > 0.0 && geomDotDir < 0.0 ) {
 
@@ -313,10 +312,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
+					wiClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wi );
 
-				} else if ( r <= cdfSpecular ) { // specular
+				} else if ( lobeSample <= cdfSpecular ) {
 
+					// specular
 					// anisotropic roughness along tangent, bitangent
 					let alphaB = surf.roughness * surf.roughness;
 					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
@@ -328,7 +328,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					// reflected rays must leave above the geometry surface - flip rays that land
 					// below it due to the shading normal. Rays below the shading hemisphere are
 					// left as is since their loss is refunded by the energy compensation tables
-					let faceNormal = normalize( invBasis * surf.faceNormal );
+					let faceNormal = normalize( surf.normalInvBasis * surf.faceNormal );
 					let geomDotDir = dot( wi, faceNormal );
 					if ( wi.z > 0.0 && geomDotDir < 0.0 ) {
 
@@ -336,11 +336,12 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
-					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
+					wiClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wi );
+					whClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wh );
 
-				} else if ( r <= cdfTransmission ) { // transmission ( glass )
+				} else if ( lobeSample <= cdfTransmission ) {
 
+					// transmission
 					isGlass = true;
 
 					// anisotropic roughness along tangent, bitangent
@@ -353,8 +354,8 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					// fresnel to 1 so TIR facets always reflect with a matching pdf
 					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
 					let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
-					let rFresnel = ( r - cdfSpecular ) / ( cdfTransmission - cdfSpecular );
-					if ( rFresnel < F ) {
+					let fresnelSample = ( lobeSample - cdfSpecular ) / ( cdfTransmission - cdfSpecular );
+					if ( fresnelSample < F ) {
 
 						wi = - normalize( reflect( wo, wh ) );
 
@@ -373,18 +374,19 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
-					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
+					wiClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wi );
+					whClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wh );
 
-				} else if ( r <= cdfTotal ) { // diffuse
+				} else if ( lobeSample <= cdfTotal ) {
 
+					// diffuse
 					wi = ${ diffuseDirectionFunc }( wo, directionUV );
 					wh = normalize( wi + wo );
 
 					// reflected rays must leave above the geometry surface - flip rays that land
 					// below it due to the shading normal. Rays below the shading hemisphere are
 					// left as is since their loss is refunded by the energy compensation tables
-					let faceNormal = normalize( invBasis * surf.faceNormal );
+					let faceNormal = normalize( surf.normalInvBasis * surf.faceNormal );
 					let geomDotDir = dot( wi, faceNormal );
 					if ( wi.z > 0.0 && geomDotDir < 0.0 ) {
 
@@ -392,21 +394,10 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
-					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
+					wiClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wi );
+					whClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wh );
 
 				}
-
-				var ctx: ${ bxdfContextStruct };
-				ctx.V = wo;
-				ctx.L = wi;
-				ctx.H = wh;
-
-				ctx.VdotH = saturate( dot( wo, wh ) );
-
-				ctx.Vc = woClearcoat;
-				ctx.Lc = wiClearcoat;
-				ctx.Hc = whClearcoat;
 
 				// pdf mixture - every lobe that can produce the sampled direction contributes its
 				// share, in the same cascade order as the eval blocks
@@ -467,12 +458,25 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				}
 
-				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isGlass );
-				result.direction = normalize( normalBasis * wi );
+				//
 
-				// the glass lobe accepts rays on either side of the geometry surface - the ray is
-				// labeled transmitted when it crosses below so it is treated as entering or
-				// leaving the volume
+				// construct the scatter context
+				var ctx: ${ bxdfContextStruct };
+				ctx.V = wo;
+				ctx.L = wi;
+				ctx.H = wh;
+
+				ctx.VdotH = saturate( dot( wo, wh ) );
+
+				ctx.Vc = woClearcoat;
+				ctx.Lc = wiClearcoat;
+				ctx.Hc = whClearcoat;
+
+				// evaluate the bsdf for the sampled direction
+				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isGlass );
+				result.direction = normalize( surf.normalBasis * wi );
+
+				// a glass ray crossing below the surface enters or leaves the volume
 				result.isTransmissive = isGlass && dot( result.direction, surf.faceNormal ) < 0.0;
 
 				return result;

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -58,138 +58,75 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let NdotVc = ctx.Vc.z;
 				let NdotL = ctx.L.z;
 
-				// Each lobe contributes into "result" within its own scope, evaluated in cascade
-				// order. "attenuation" carries the fraction of energy each layer passes through to
-				// the layers beneath it. Every lobe guards its own hemisphere, matching how Cycles
-				// closures return zero for directions outside their domain.
+				// Each lobe contributes into "result" within its own scope, evaluated in cascade.
+				// "attenuation" carries the fraction of energy each layer passes through to
+				// the layers beneath it. Every lobe guards its own hemisphere.
 				var result = vec3f( 0.0 );
 				var attenuation = vec3f( 1.0 );
 
 				// clearcoat
-				{
+				if ( NdotL > 0.0 && surf.clearcoat > 0.0 ) {
 
-					if ( NdotL > 0.0 ) {
+					// reuse the same pattern for energy conservation used in the dielectric layer
+					let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
+					let clearcoatEnergySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotVc, surf.clearcoatRoughness ), 1e-5 );
+					let clearcoatBoost = 1.0 + ${ iorToF0Func }( 1.5 ) * ( 1.0 - clearcoatEnergySS ) / clearcoatEnergySS;
+					let clearcoatFresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotVc, surf.clearcoatRoughness, 1.5 ) * clearcoatBoost;
+					let clearcoatSpecular = ${ this.specularBrdf }( ctx.Vc, ctx.Lc, ctx.Hc, vec2( clearcoatAlpha ) ) * clearcoatBoost;
+					let clearcoatFresnel = ${ schlickFresnelFunc }( abs( dot( ctx.Vc, ctx.Hc ) ), ${ iorToF0Func }( 1.5 ) );
 
-						// reuse the same pattern for energy conservation used in the dielectric layer
-						let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
-						let clearcoatEnergySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotVc, surf.clearcoatRoughness ), 1e-5 );
-						let clearcoatBoost = 1.0 + ${ iorToF0Func }( 1.5 ) * ( 1.0 - clearcoatEnergySS ) / clearcoatEnergySS;
-						let clearcoatFresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotVc, surf.clearcoatRoughness, 1.5 ) * clearcoatBoost;
-						let clearcoatSpecular = ${ this.specularBrdf }( ctx.Vc, ctx.Lc, ctx.Hc, vec2( clearcoatAlpha ) ) * clearcoatBoost;
-						let clearcoatFresnel = ${ schlickFresnelFunc }( abs( dot( ctx.Vc, ctx.Hc ) ), ${ iorToF0Func }( 1.5 ) );
-
-						result += surf.clearcoat * clearcoatFresnel * clearcoatSpecular;
-						attenuation *= 1.0 - surf.clearcoat * clearcoatFresnelEnergySS;
-
-					}
+					result += surf.clearcoat * clearcoatFresnel * clearcoatSpecular;
+					attenuation *= 1.0 - surf.clearcoat * clearcoatFresnelEnergySS;
 
 				}
 
 				// sheen
-				{
+				if ( NdotL > 0.0 && surf.sheen > 0.0 ) {
 
-					if ( NdotL > 0.0 ) {
-
-						result += attenuation * surf.sheen * ${ sheenColorFunc }( ctx.V, ctx.L, ctx.H, surf );
-						attenuation *= mix( 1.0, ${ sheenAlbedoScalingFunc }( ctx.V, ctx.L, surf ), surf.sheen );
-
-					}
+					result += attenuation * surf.sheen * ${ sheenColorFunc }( ctx.V, ctx.L, ctx.H, surf );
+					attenuation *= mix( 1.0, ${ sheenAlbedoScalingFunc }( ctx.V, ctx.L, surf ), surf.sheen );
 
 				}
 
-				// transmission ( glass )
+				// transmission
 				// the full transmissive dielectric interface: fresnel reflection above the horizon
 				// and refraction below it, so the specular lobe only serves the opaque remainder.
 				// The refracted half is not attenuated by the layers above, matching the WebGL
 				// implementation.
-				{
+				if ( surf.transmission > 0.0 ) {
 
-					if ( surf.transmission > 0.0 ) {
+					// anisotropic roughness along tangent, bitangent
+					let alphaB = surf.roughness * surf.roughness;
+					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+					let alpha = vec2( alphaT, alphaB );
 
-						// anisotropic roughness along tangent, bitangent
-						let alphaB = surf.roughness * surf.roughness;
-						let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
-						let alpha = vec2( alphaT, alphaB );
+					if ( NdotL < 0.0 ) {
 
-						if ( NdotL < 0.0 ) {
+						// TODO: transmitted light also crosses the thin film so it should be weighted by
+						// the film-aware fresnel complement (1 - filmF) rather than the plain dielectric
+						// fresnel, tinting transmission with the film's complementary color. Deferred until
+						// the material is generalized into a layer stack that owns the fresnel per interface.
+						var refraction: vec3f;
+						if ( surf.thinWall ) {
 
-							// TODO: transmitted light also crosses the thin film so it should be weighted by
-							// the film-aware fresnel complement (1 - filmF) rather than the plain dielectric
-							// fresnel, tinting transmission with the film's complementary color. Deferred until
-							// the material is generalized into a layer stack that owns the fresnel per interface.
-							var refraction: vec3f;
-							if ( surf.thinWall ) {
-
-								// evaluate the flipped reflection
-								let wiMirror = vec3f( ctx.L.xy, - ctx.L.z );
-								let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
-								let F = ${ dielectricFresnelFunc }( saturate( ctx.VdotH ), surf.eta );
-								refraction = ( 1.0 - F ) * ${ this.specularBrdf }( ctx.V, wiMirror, ctx.H, thinWallAlpha );
-
-							} else {
-
-								refraction = ${ this.specularBtdf }( ctx.V, ctx.L, ctx.H, alpha, surf.eta );
-
-							}
-
-							result += ( 1.0 - surf.metalness ) * surf.transmission * refraction * surf.color;
+							// evaluate the flipped reflection
+							let wiMirror = vec3f( ctx.L.xy, - ctx.L.z );
+							let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
+							let F = ${ dielectricFresnelFunc }( saturate( ctx.VdotH ), surf.eta );
+							refraction = ( 1.0 - F ) * ${ this.specularBrdf }( ctx.V, wiMirror, ctx.H, thinWallAlpha );
 
 						} else {
 
-							// fresnel reflection of the glass interface, mirroring the dielectric half
-							// of the specular lobe below
-							// Sample the single scatter energy for specular at the given roughness.
-							let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
-							let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
-							let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
-							let boostedSpecular = specular * dielectricBoost;
-
-							// the media on either side of the film - air outside and the volume interior
-							// as the base on front faces, swapped on back faces so TIR can take effect
-							let outsideIor = select( surf.ior, 1.0, surf.frontFace );
-							let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
-
-							// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
-							let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
-
-							// front faces use schlick so the KHR_materials_specular tinted f0 applies - interior
-							// hits use the exact dielectric fresnel since schlick cannot represent TIR
-							var dielectricFr: vec3f;
-							if ( surf.frontFace ) {
-
-								dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
-
-							} else {
-
-								dielectricFr = vec3f( ${ dielectricFresnelFunc }( abs( ctx.VdotH ), surf.eta ) );
-
-							}
-
-							// iridescence blending toward the film fresnel
-							let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-							let glassSpecular = boostedSpecular * mix( surf.specularIntensity * dielectricFr, dielectricFilmFresnel, surf.iridescence );
-
-							result += attenuation * ( 1.0 - surf.metalness ) * surf.transmission * glassSpecular;
+							refraction = ${ this.specularBtdf }( ctx.V, ctx.L, ctx.H, alpha, surf.eta );
 
 						}
 
-					}
+						result += ( 1.0 - surf.metalness ) * surf.transmission * refraction * surf.color;
 
-				}
+					} else {
 
-				// specular
-				// the metallic and dielectric halves share the ggx lobe with their own fresnel.
-				// Iridescence swaps each half's fresnel for the thin film response, matching how
-				// Cycles folds the film into the closure fresnel rather than adding a layer.
-				{
-
-					if ( NdotL > 0.0 ) {
-
-						// anisotropic roughness along tangent, bitangent
-						let alphaB = surf.roughness * surf.roughness;
-						let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
-						let alpha = vec2( alphaT, alphaB );
-
+						// fresnel reflection of the glass interface, mirroring the dielectric half
+						// of the specular lobe below
 						// Sample the single scatter energy for specular at the given roughness.
 						let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
 						let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
@@ -201,22 +138,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 						let outsideIor = select( surf.ior, 1.0, surf.frontFace );
 						let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
 
-						// metallic half with the multiscatter comp, iridescence blending toward the
-						// film fresnel over the conductor response
-						let metallicBoost = 1.0 + surf.color * ( 1.0 - energySS ) / energySS;
-						let metallicSpecular = specular * metallicBoost;
-						let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-						let metallicBase = ${ this.conductorFresnel }( ctx.VdotH, surf.color, metallicSpecular );
-						let metallic = mix( metallicBase, metallicSpecular * metallicFilmFresnel, surf.iridescence );
-
-						result += attenuation * surf.metalness * metallic;
-
 						// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 						let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
 
 						// front faces use schlick so the KHR_materials_specular tinted f0 applies - interior
 						// hits use the exact dielectric fresnel since schlick cannot represent TIR
-						// TODO: see if we can clean this up and make these branches more consistent
 						var dielectricFr: vec3f;
 						if ( surf.frontFace ) {
 
@@ -228,51 +154,104 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 						}
 
-						// dielectric half, iridescence blending toward the film fresnel. Weighted by the
-						// opaque share - the transmissive portion's reflection belongs to the glass lobe
+						// iridescence blending toward the film fresnel
 						let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-						let dielectricSpecular = boostedSpecular * mix( surf.specularIntensity * dielectricFr, dielectricFilmFresnel, surf.iridescence );
+						let glassSpecular = boostedSpecular * mix( surf.specularIntensity * dielectricFr, dielectricFilmFresnel, surf.iridescence );
 
-						result += attenuation * ( 1.0 - surf.metalness ) * ( 1.0 - surf.transmission ) * dielectricSpecular;
-
-						// Attenuate the layers below by the energy taken by the specular interface - the
-						// fresnel-weighted single scatter energy with the multiscatter boost, or the film
-						// fresnel when iridescent, using its strongest channel so the base is not tinted
-						// with the film's inverse color. Only the dielectric half passes light downward.
-						// The table is baked for the air-incident case so volume-incident hits use the
-						// exact fresnel instead - total internal reflection then fades the base out at
-						// grazing interior angles.
-						var fresnelEnergySS: f32;
-						if ( surf.frontFace ) {
-
-							fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
-
-						} else {
-
-							fresnelEnergySS = ${ dielectricFresnelFunc }( NdotV, surf.eta );
-
-						}
-
-						let filmFresnelMax = max( max( dielectricFilmFresnel.r, dielectricFilmFresnel.g ), dielectricFilmFresnel.b );
-						attenuation *= ( 1.0 - surf.metalness ) * mix( 1.0 - fresnelEnergySS, 1.0 - filmFresnelMax, surf.iridescence );
+						result += attenuation * ( 1.0 - surf.metalness ) * surf.transmission * glassSpecular;
 
 					}
 
 				}
 
-				// diffuse
-				{
+				// specular
+				// the metallic and dielectric halves share the ggx lobe with their own fresnel.
+				// Iridescence swaps each half's fresnel for the thin film response, matching how
+				// Cycles folds the film into the closure fresnel rather than adding a layer.
+				if ( NdotL > 0.0 ) {
 
-					if ( NdotL > 0.0 ) {
+					// anisotropic roughness along tangent, bitangent
+					let alphaB = surf.roughness * surf.roughness;
+					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+					let alpha = vec2( alphaT, alphaB );
 
-						// the dielectric base mixes diffuse with transmission - the transmissive half
-						// is carried by the glass lobe above
-						let reflection = ${ this.diffuseBrdf }( NdotV, NdotL, ctx.VdotH, surf );
-						let diffuse = ( 1.0 - surf.transmission ) * reflection;
+					// Sample the single scatter energy for specular at the given roughness.
+					let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
+					let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
+					let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
+					let boostedSpecular = specular * dielectricBoost;
 
-						result += attenuation * diffuse;
+					// the media on either side of the film - air outside and the volume interior
+					// as the base on front faces, swapped on back faces so TIR can take effect
+					let outsideIor = select( surf.ior, 1.0, surf.frontFace );
+					let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
+
+					// metallic half with the multiscatter comp, iridescence blending toward the
+					// film fresnel over the conductor response
+					let metallicBoost = 1.0 + surf.color * ( 1.0 - energySS ) / energySS;
+					let metallicSpecular = specular * metallicBoost;
+					let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
+					let metallicBase = ${ this.conductorFresnel }( ctx.VdotH, surf.color, metallicSpecular );
+					let metallic = mix( metallicBase, metallicSpecular * metallicFilmFresnel, surf.iridescence );
+
+					result += attenuation * surf.metalness * metallic;
+
+					// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
+					let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
+
+					// front faces use schlick so the KHR_materials_specular tinted f0 applies - interior
+					// hits use the exact dielectric fresnel since schlick cannot represent TIR
+					// TODO: see if we can clean this up and make these branches more consistent
+					var dielectricFr: vec3f;
+					if ( surf.frontFace ) {
+
+						dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
+
+					} else {
+
+						dielectricFr = vec3f( ${ dielectricFresnelFunc }( abs( ctx.VdotH ), surf.eta ) );
 
 					}
+
+					// dielectric half, iridescence blending toward the film fresnel. Weighted by the
+					// opaque share - the transmissive portion's reflection belongs to the glass lobe
+					let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
+					let dielectricSpecular = boostedSpecular * mix( surf.specularIntensity * dielectricFr, dielectricFilmFresnel, surf.iridescence );
+
+					result += attenuation * ( 1.0 - surf.metalness ) * ( 1.0 - surf.transmission ) * dielectricSpecular;
+
+					// Attenuate the layers below by the energy taken by the specular interface - the
+					// fresnel-weighted single scatter energy with the multiscatter boost, or the film
+					// fresnel when iridescent, using its strongest channel so the base is not tinted
+					// with the film's inverse color. Only the dielectric half passes light downward.
+					// The table is baked for the air-incident case so volume-incident hits use the
+					// exact fresnel instead - total internal reflection then fades the base out at
+					// grazing interior angles.
+					var fresnelEnergySS: f32;
+					if ( surf.frontFace ) {
+
+						fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
+
+					} else {
+
+						fresnelEnergySS = ${ dielectricFresnelFunc }( NdotV, surf.eta );
+
+					}
+
+					let filmFresnelMax = max( max( dielectricFilmFresnel.r, dielectricFilmFresnel.g ), dielectricFilmFresnel.b );
+					attenuation *= ( 1.0 - surf.metalness ) * mix( 1.0 - fresnelEnergySS, 1.0 - filmFresnelMax, surf.iridescence );
+
+				}
+
+				// diffuse
+				if ( NdotL > 0.0 ) {
+
+					// the dielectric base mixes diffuse with transmission - the transmissive half
+					// is carried by the glass lobe above
+					let reflection = ${ this.diffuseBrdf }( NdotV, NdotL, ctx.VdotH, surf );
+					let diffuse = ( 1.0 - surf.transmission ) * reflection;
+
+					result += attenuation * diffuse;
 
 				}
 
@@ -433,74 +412,58 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				// share, in the same cascade order as the eval blocks
 
 				// clearcoat
-				{
+				if ( weights.clearcoat > 0.0 && wiClearcoat.z > 0.0 ) {
 
-					if ( weights.clearcoat > 0.0 && wiClearcoat.z > 0.0 ) {
-
-						let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
-						result.pdf += weights.clearcoat * ${ ggxReflectionAdjustedPDFFunc }( woClearcoat, whClearcoat, vec2( clearcoatAlpha ) );
-
-					}
+					let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
+					result.pdf += weights.clearcoat * ${ ggxReflectionAdjustedPDFFunc }( woClearcoat, whClearcoat, vec2( clearcoatAlpha ) );
 
 				}
 
 				// specular
-				{
+				if ( weights.specular > 0.0 && wi.z > 0.0 ) {
 
-					if ( weights.specular > 0.0 && wi.z > 0.0 ) {
+					// anisotropic roughness along tangent, bitangent
+					let alphaB = surf.roughness * surf.roughness;
+					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+					let alpha = vec2( alphaT, alphaB );
 
-						// anisotropic roughness along tangent, bitangent
-						let alphaB = surf.roughness * surf.roughness;
-						let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
-						let alpha = vec2( alphaT, alphaB );
-
-						result.pdf += weights.specular * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
-
-					}
+					result.pdf += weights.specular * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
 
 				}
 
 				// transmission ( glass )
-				{
+				if ( weights.transmission > 0.0 ) {
 
-					if ( weights.transmission > 0.0 ) {
+					// anisotropic roughness along tangent, bitangent
+					let alphaB = surf.roughness * surf.roughness;
+					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+					let alpha = vec2( alphaT, alphaB );
 
-						// anisotropic roughness along tangent, bitangent
-						let alphaB = surf.roughness * surf.roughness;
-						let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
-						let alpha = vec2( alphaT, alphaB );
+					// the glass lobe selects reflection or refraction by the facet fresnel so
+					// each side carries the corresponding share of the transmission pdf
+					let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
+					if ( wi.z > 0.0 ) {
 
-						// the glass lobe selects reflection or refraction by the facet fresnel so
-						// each side carries the corresponding share of the transmission pdf
-						let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
-						if ( wi.z > 0.0 ) {
+						result.pdf += weights.transmission * F * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
 
-							result.pdf += weights.transmission * F * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
+					} else if ( surf.thinWall ) {
 
-						} else if ( surf.thinWall ) {
+						// the flipped reflection shares the reflection pdf at the remapped roughness
+						let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
+						result.pdf += weights.transmission * ( 1.0 - F ) * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, thinWallAlpha );
 
-							// the flipped reflection shares the reflection pdf at the remapped roughness
-							let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
-							result.pdf += weights.transmission * ( 1.0 - F ) * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, thinWallAlpha );
+					} else {
 
-						} else {
-
-							result.pdf += weights.transmission * ( 1.0 - F ) * ${ ggxRefractionAdjustedPDFFunc }( wo, wi, wh, alpha, surf.eta );
-
-						}
+						result.pdf += weights.transmission * ( 1.0 - F ) * ${ ggxRefractionAdjustedPDFFunc }( wo, wi, wh, alpha, surf.eta );
 
 					}
 
 				}
 
 				// diffuse
-				{
+				if ( weights.diffuse > 0.0 ) {
 
-					if ( weights.diffuse > 0.0 ) {
-
-						result.pdf += weights.diffuse * max( wi.z, 0.0 ) / PI;
-
-					}
+					result.pdf += weights.diffuse * max( wi.z, 0.0 ) / PI;
 
 				}
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -73,13 +73,17 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					let Hc = normalize( toClearcoatMat * ctx.H );
 					let NdotVc = Vc.z;
 
-					// reuse the same pattern for energy conservation used in the dielectric layer
 					let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
+
+					// reuse the same pattern for energy conservation used in the dielectric layer
 					let clearcoatEnergySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotVc, surf.clearcoatRoughness ), 1e-5 );
 					let clearcoatBoost = 1.0 + ${ iorToF0Func }( 1.5 ) * ( 1.0 - clearcoatEnergySS ) / clearcoatEnergySS;
-					let clearcoatFresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotVc, surf.clearcoatRoughness, 1.5 ) * clearcoatBoost;
+
 					let clearcoatSpecular = ${ this.specularBrdf }( Vc, Lc, Hc, vec2( clearcoatAlpha ) ) * clearcoatBoost;
 					let clearcoatFresnel = ${ schlickFresnelFunc }( abs( dot( Vc, Hc ) ), ${ iorToF0Func }( 1.5 ) );
+
+					// retrieve specular energy reflected by this layer
+					let clearcoatFresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotVc, surf.clearcoatRoughness, 1.5 ) * clearcoatBoost;
 
 					result += surf.clearcoat * clearcoatFresnel * clearcoatSpecular;
 					attenuation *= 1.0 - surf.clearcoat * clearcoatFresnelEnergySS;
@@ -95,10 +99,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				}
 
 				// transmission
-				// the full transmissive dielectric interface: fresnel reflection above the horizon
-				// and refraction below it, so the specular lobe only serves the opaque remainder.
-				// The refracted half is not attenuated by the layers above, matching the WebGL
-				// implementation.
+				// handles specular reflection and transmission
 				if ( surf.transmission > 0.0 ) {
 
 					// anisotropic roughness along tangent, bitangent
@@ -178,9 +179,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				}
 
 				// specular
-				// the metallic and dielectric halves share the ggx lobe with their own fresnel.
-				// Iridescence swaps each half's fresnel for the thin film response, matching how
-				// Cycles folds the film into the closure fresnel rather than adding a layer.
+				// metallic + dielectric + iridescence
 				if ( NdotL > 0.0 ) {
 
 					// anisotropic roughness along tangent, bitangent
@@ -304,7 +303,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				var wi: vec3f;
 				var wh: vec3f;
 
-				var isGlass = false;
+				var isTransmissionLobe = false;
 
 				if ( lobeSample <= cdfClearcoat ) {
 
@@ -352,7 +351,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				} else if ( lobeSample <= cdfTransmission ) {
 
 					// transmission
-					isGlass = true;
+					isTransmissionLobe = true;
 
 					// anisotropic roughness along tangent, bitangent
 					let alphaB = surf.roughness * surf.roughness;
@@ -481,11 +480,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				ctx.VdotH = saturate( dot( wo, wh ) );
 
 				// evaluate the bsdf for the sampled direction
-				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isGlass );
+				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isTransmissionLobe );
 				result.direction = normalize( surf.normalBasis * wi );
 
 				// a glass ray crossing below the surface enters or leaves the volume
-				result.isTransmissive = isGlass && dot( result.direction, surf.faceNormal ) < 0.0;
+				result.isTransmissive = isTransmissionLobe && dot( result.direction, surf.faceNormal ) < 0.0;
 
 				return result;
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -55,7 +55,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 			fn bsdfEval( ctx: ${ bxdfContextStruct }, surf: ${ surfaceRecordStruct } ) -> vec3f {
 
 				let NdotV = ctx.V.z;
-				let NdotVc = ctx.Vc.z;
 				let NdotL = ctx.L.z;
 
 				// Each lobe contributes into "result" within its own scope, evaluated in cascade.
@@ -67,13 +66,20 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				// clearcoat
 				if ( NdotL > 0.0 && surf.clearcoat > 0.0 ) {
 
+					// the clearcoat evaluates in its own frame
+					let toClearcoatMat = surf.clearcoatInvBasis * surf.normalBasis;
+					let Vc = normalize( toClearcoatMat * ctx.V );
+					let Lc = normalize( toClearcoatMat * ctx.L );
+					let Hc = normalize( toClearcoatMat * ctx.H );
+					let NdotVc = Vc.z;
+
 					// reuse the same pattern for energy conservation used in the dielectric layer
 					let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
 					let clearcoatEnergySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotVc, surf.clearcoatRoughness ), 1e-5 );
 					let clearcoatBoost = 1.0 + ${ iorToF0Func }( 1.5 ) * ( 1.0 - clearcoatEnergySS ) / clearcoatEnergySS;
 					let clearcoatFresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotVc, surf.clearcoatRoughness, 1.5 ) * clearcoatBoost;
-					let clearcoatSpecular = ${ this.specularBrdf }( ctx.Vc, ctx.Lc, ctx.Hc, vec2( clearcoatAlpha ) ) * clearcoatBoost;
-					let clearcoatFresnel = ${ schlickFresnelFunc }( abs( dot( ctx.Vc, ctx.Hc ) ), ${ iorToF0Func }( 1.5 ) );
+					let clearcoatSpecular = ${ this.specularBrdf }( Vc, Lc, Hc, vec2( clearcoatAlpha ) ) * clearcoatBoost;
+					let clearcoatFresnel = ${ schlickFresnelFunc }( abs( dot( Vc, Hc ) ), ${ iorToF0Func }( 1.5 ) );
 
 					result += surf.clearcoat * clearcoatFresnel * clearcoatSpecular;
 					attenuation *= 1.0 - surf.clearcoat * clearcoatFresnelEnergySS;
@@ -283,11 +289,9 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let lobeSample = ${ rand1 }( ${ RNG_INDEX_SCATTER_TYPE } ) * cdfTotal;
 				let directionUV = ${ rand2 }( ${ RNG_INDEX_SCATTER_DIRECTION } );
 
+				// output
 				var wi: vec3f;
 				var wh: vec3f;
-
-				var wiClearcoat: vec3f;
-				var whClearcoat: vec3f;
 
 				var isGlass = false;
 
@@ -295,11 +299,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					// clearcoat
 					let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
-					whClearcoat = ${ ggxDirectionFunc }( woClearcoat, vec2( clearcoatAlpha ), directionUV );
-					wiClearcoat = - normalize( reflect( woClearcoat, whClearcoat ) );
+					let whCoat = ${ ggxDirectionFunc }( woClearcoat, vec2( clearcoatAlpha ), directionUV );
+					let wiCoat = - normalize( reflect( woClearcoat, whCoat ) );
 
-					wi = normalize( surf.normalInvBasis * surf.clearcoatBasis * wiClearcoat );
-					wh = normalize( surf.normalInvBasis * surf.clearcoatBasis * whClearcoat );
+					wi = normalize( surf.normalInvBasis * surf.clearcoatBasis * wiCoat );
+					wh = normalize( surf.normalInvBasis * surf.clearcoatBasis * whCoat );
 
 					// reflected rays must leave above the geometry surface - flip rays that land
 					// below it due to the shading normal. Rays below the shading hemisphere are
@@ -311,8 +315,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 						wi = normalize( wi - 2.0 * geomDotDir * faceNormal );
 
 					}
-
-					wiClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wi );
 
 				} else if ( lobeSample <= cdfSpecular ) {
 
@@ -335,9 +337,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 						wi = normalize( wi - 2.0 * geomDotDir * faceNormal );
 
 					}
-
-					wiClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wi );
-					whClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wh );
 
 				} else if ( lobeSample <= cdfTransmission ) {
 
@@ -374,9 +373,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					wiClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wi );
-					whClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wh );
-
 				} else if ( lobeSample <= cdfTotal ) {
 
 					// diffuse
@@ -394,19 +390,24 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					wiClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wi );
-					whClearcoat = normalize( surf.clearcoatInvBasis * surf.normalBasis * wh );
-
 				}
 
 				// pdf mixture - every lobe that can produce the sampled direction contributes its
 				// share, in the same cascade order as the eval blocks
 
 				// clearcoat
-				if ( weights.clearcoat > 0.0 && wiClearcoat.z > 0.0 ) {
+				if ( weights.clearcoat > 0.0 ) {
 
-					let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
-					result.pdf += weights.clearcoat * ${ ggxReflectionAdjustedPDFFunc }( woClearcoat, whClearcoat, vec2( clearcoatAlpha ) );
+					// the clearcoat lobe evaluates in its own frame
+					let toClearcoatMat = surf.clearcoatInvBasis * surf.normalBasis;
+					let wiClearcoat = normalize( toClearcoatMat * wi );
+					if ( wiClearcoat.z > 0.0 ) {
+
+						let whClearcoat = normalize( toClearcoatMat * wh );
+						let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
+						result.pdf += weights.clearcoat * ${ ggxReflectionAdjustedPDFFunc }( woClearcoat, whClearcoat, vec2( clearcoatAlpha ) );
+
+					}
 
 				}
 
@@ -422,7 +423,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				}
 
-				// transmission ( glass )
+				// transmission
 				if ( weights.transmission > 0.0 ) {
 
 					// anisotropic roughness along tangent, bitangent
@@ -467,10 +468,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				ctx.H = wh;
 
 				ctx.VdotH = saturate( dot( wo, wh ) );
-
-				ctx.Vc = woClearcoat;
-				ctx.Lc = wiClearcoat;
-				ctx.Hc = whClearcoat;
 
 				// evaluate the bsdf for the sampled direction
 				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isGlass );

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -137,10 +137,13 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					} else {
 
-						// the glass interface reflection, mirroring the dielectric half of the specular lobe
+						// Sample the single scatter energy for specular at the given roughness
 						let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
+						let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
+
+						// dielectric with the multiscatter comp
 						let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
-						let dielectricSpecular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha ) * dielectricBoost;
+						let dielectricSpecular = specular * dielectricBoost;
 
 						// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 						let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
@@ -191,10 +194,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
 					let alpha = vec2( alphaT, alphaB );
 
-					// a thin wall has no interior volume so air is the incident medium on both
-					// sides - only a true volume distinguishes entering from exiting hits
-					let airIncident = surf.thinWall || surf.frontFace;
-
 					// Sample the single scatter energy for specular at the given roughness
 					let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
 					let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
@@ -211,11 +210,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 					let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
 
-					// air-incident hits use schlick so the tinted f0 applies - interior hits use
-					// the exact fresnel since schlick cannot represent TIR
+					// front faces use schlick so the KHR_materials_specular tinted f0 applies
+					// we handle internal hits to account for cases where a surface is only partially transmissive.
 					// TODO: see if we can clean this up and make these branches more consistent
 					var dielectricFr: vec3f;
-					if ( airIncident ) {
+					if ( surf.frontFace ) {
 
 						dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
 
@@ -232,9 +231,9 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					if ( surf.iridescence > 0.0 ) {
 
 						// the media on either side of the film - air outside and the volume interior
-						// as the base, swapped on interior hits so TIR can take effect
-						let outsideIor = select( surf.ior, 1.0, airIncident );
-						let filmBaseIor = select( 1.0, surf.ior, airIncident );
+						// as the base on front faces, swapped on back faces so TIR can take effect
+						let outsideIor = select( surf.ior, 1.0, surf.frontFace );
+						let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
 
 						let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
 						metallicReflectance = mix( metallicReflectance, metallicFilmFresnel, surf.iridescence );
@@ -252,7 +251,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					// cases where a surface is only partially transmissive.
 					// TODO: Determine how much impact just discarding under-side energy will have.
 					var fresnelEnergySS: f32;
-					if ( airIncident ) {
+					if ( surf.frontFace ) {
 
 						fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -50,8 +50,8 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 		const bsdfEvalFunc = wgslTagFn/* wgsl */`
 
 			// The material is organized as one scoped block per lobe in cascade order - clearcoat,
-			// sheen, transmission ( glass ), specular, diffuse - each accumulating into a shared
-			// result and guarding its own hemisphere.
+			// sheen, transmission, specular, diffuse - each accumulating into a shared result and
+			// guarding its own hemisphere.
 			fn bsdfEval( ctx: ${ bxdfContextStruct }, surf: ${ surfaceRecordStruct } ) -> vec3f {
 
 				let NdotV = ctx.V.z;
@@ -161,8 +161,15 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 						}
 
 						// iridescence blending toward the film fresnel
-						let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-						let glassSpecular = boostedSpecular * mix( surf.specularIntensity * dielectricFr, dielectricFilmFresnel, surf.iridescence );
+						var glassFresnel = surf.specularIntensity * dielectricFr;
+						if ( surf.iridescence > 0.0 ) {
+
+							let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
+							glassFresnel = mix( glassFresnel, dielectricFilmFresnel, surf.iridescence );
+
+						}
+
+						let glassSpecular = boostedSpecular * glassFresnel;
 
 						result += attenuation * ( 1.0 - surf.metalness ) * surf.transmission * glassSpecular;
 
@@ -196,9 +203,13 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					// film fresnel over the conductor response
 					let metallicBoost = 1.0 + surf.color * ( 1.0 - energySS ) / energySS;
 					let metallicSpecular = specular * metallicBoost;
-					let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-					let metallicBase = ${ this.conductorFresnel }( ctx.VdotH, surf.color, metallicSpecular );
-					let metallic = mix( metallicBase, metallicSpecular * metallicFilmFresnel, surf.iridescence );
+					var metallic = ${ this.conductorFresnel }( ctx.VdotH, surf.color, metallicSpecular );
+					if ( surf.iridescence > 0.0 ) {
+
+						let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
+						metallic = mix( metallic, metallicSpecular * metallicFilmFresnel, surf.iridescence );
+
+					}
 
 					result += attenuation * surf.metalness * metallic;
 
@@ -221,8 +232,17 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					// dielectric half, iridescence blending toward the film fresnel. Weighted by the
 					// opaque share - the transmissive portion's reflection belongs to the glass lobe
-					let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-					let dielectricSpecular = boostedSpecular * mix( surf.specularIntensity * dielectricFr, dielectricFilmFresnel, surf.iridescence );
+					var specularFresnel = surf.specularIntensity * dielectricFr;
+					var filmFresnelMax = 0.0;
+					if ( surf.iridescence > 0.0 ) {
+
+						let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
+						specularFresnel = mix( specularFresnel, dielectricFilmFresnel, surf.iridescence );
+						filmFresnelMax = max( max( dielectricFilmFresnel.r, dielectricFilmFresnel.g ), dielectricFilmFresnel.b );
+
+					}
+
+					let dielectricSpecular = boostedSpecular * specularFresnel;
 
 					result += attenuation * ( 1.0 - surf.metalness ) * ( 1.0 - surf.transmission ) * dielectricSpecular;
 
@@ -244,7 +264,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					let filmFresnelMax = max( max( dielectricFilmFresnel.r, dielectricFilmFresnel.g ), dielectricFilmFresnel.b );
 					attenuation *= ( 1.0 - surf.metalness ) * mix( 1.0 - fresnelEnergySS, 1.0 - filmFresnelMax, surf.iridescence );
 
 				}

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -183,36 +183,27 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				// Cycles folds the film into the closure fresnel rather than adding a layer.
 				if ( NdotL > 0.0 ) {
 
+
 					// anisotropic roughness along tangent, bitangent
 					let alphaB = surf.roughness * surf.roughness;
 					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
 					let alpha = vec2( alphaT, alphaB );
 
+					// metalness
 					// Sample the single scatter energy for specular at the given roughness.
 					let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
 					let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
 					let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
 					let boostedSpecular = specular * dielectricBoost;
 
-					// the media on either side of the film - air outside and the volume interior
-					// as the base on front faces, swapped on back faces so TIR can take effect
-					let outsideIor = select( surf.ior, 1.0, surf.frontFace );
-					let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
-
-					// metallic half with the multiscatter comp, iridescence blending toward the
-					// film fresnel over the conductor response
+					// metallic half with the multiscatter comp
 					let metallicBoost = 1.0 + surf.color * ( 1.0 - energySS ) / energySS;
 					let metallicSpecular = specular * metallicBoost;
-					var metallic = ${ this.conductorFresnel }( ctx.VdotH, surf.color, metallicSpecular );
-					if ( surf.iridescence > 0.0 ) {
+					var metallicFresnel = ${ this.conductorFresnel }( ctx.VdotH, surf.color, vec3f( 1.0 ) );
 
-						let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-						metallic = mix( metallic, metallicSpecular * metallicFilmFresnel, surf.iridescence );
+					//
 
-					}
-
-					result += attenuation * surf.metalness * metallic;
-
+					// dielectric
 					// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 					let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
 
@@ -230,11 +221,19 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					// dielectric half, iridescence blending toward the film fresnel. Weighted by the
-					// opaque share - the transmissive portion's reflection belongs to the glass lobe
 					var specularFresnel = surf.specularIntensity * dielectricFr;
+
+					// iridescence
 					var filmFresnelMax = 0.0;
 					if ( surf.iridescence > 0.0 ) {
+
+						// the media on either side of the film - air outside and the volume interior
+						// as the base on front faces, swapped on back faces so TIR can take effect
+						let outsideIor = select( surf.ior, 1.0, surf.frontFace );
+						let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
+
+						let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
+						metallicFresnel = mix( metallicFresnel, metallicFilmFresnel, surf.iridescence );
 
 						let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
 						specularFresnel = mix( specularFresnel, dielectricFilmFresnel, surf.iridescence );
@@ -242,9 +241,8 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
+					let metallic = metallicSpecular * metallicFresnel;
 					let dielectricSpecular = boostedSpecular * specularFresnel;
-
-					result += attenuation * ( 1.0 - surf.metalness ) * ( 1.0 - surf.transmission ) * dielectricSpecular;
 
 					// Attenuate the layers below by the energy taken by the specular interface - the
 					// fresnel-weighted single scatter energy with the multiscatter boost, or the film
@@ -264,6 +262,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
+					result += attenuation * mix( ( 1.0 - surf.transmission ) * dielectricSpecular, metallic, surf.metalness );
 					attenuation *= ( 1.0 - surf.metalness ) * mix( 1.0 - fresnelEnergySS, 1.0 - filmFresnelMax, surf.iridescence );
 
 				}

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -209,21 +209,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 					let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
-
-					// front faces use schlick so the KHR_materials_specular tinted f0 applies
-					// we handle internal hits to account for cases where a surface is only partially transmissive.
-					// TODO: see if we can clean this up and make these branches more consistent
-					var dielectricFr: vec3f;
-					if ( surf.frontFace ) {
-
-						dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
-
-					} else {
-
-						dielectricFr = vec3f( ${ dielectricFresnelFunc }( abs( ctx.VdotH ), surf.eta ) );
-
-					}
-
+					let dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
 					var dielectricReflectance = surf.specularIntensity * dielectricFr;
 
 					// iridescence
@@ -247,19 +233,8 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					let metallic = metallicSpecular * metallicReflectance;
 					let dielectric = dielectricSpecular * dielectricReflectance;
 
-					// the energy the specular interface takes from the layers below - we handle internal hits to account for
-					// cases where a surface is only partially transmissive.
-					// TODO: Determine how much impact just discarding under-side energy will have.
-					var fresnelEnergySS: f32;
-					if ( surf.frontFace ) {
-
-						fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
-
-					} else {
-
-						fresnelEnergySS = ${ dielectricFresnelFunc }( NdotV, surf.eta );
-
-					}
+					// the energy the specular interface takes from the layers below
+					let fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
 
 					result += attenuation * mix( ( 1.0 - surf.transmission ) * dielectric, metallic, surf.metalness );
 					attenuation *= ( 1.0 - surf.metalness ) * mix( 1.0 - fresnelEnergySS, 1.0 - filmFresnelMax, surf.iridescence );

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -52,7 +52,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 			// The material is organized as one scoped block per lobe in cascade order - clearcoat,
 			// sheen, transmission, specular, diffuse - each accumulating into a shared result and
 			// guarding its own hemisphere.
-			//
 			// TODO: energy only cascades downward through front faces, so the layers are always traversed
 			// outside-in and cannot reflect energy back into the glass from below.
 			fn bsdfEval( ctx: ${ bxdfContextStruct }, surf: ${ surfaceRecordStruct } ) -> vec3f {
@@ -140,14 +139,15 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 						// the glass interface reflection, mirroring the dielectric half of the specular lobe
 						let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
-						let glassBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
-						let glassSpecular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha ) * glassBoost;
+						let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
+						let dielectricSpecular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha ) * dielectricBoost;
 
 						// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 						let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
 
 						// air-incident hits use schlick so the tinted f0 applies - interior hits use
 						// the exact fresnel since schlick cannot represent TIR
+						// TODO: see if we can clean this up and make these branches more consistent
 						var dielectricFr: vec3f;
 						if ( airIncident ) {
 
@@ -159,7 +159,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 						}
 
-						var glassReflectance = surf.specularIntensity * dielectricFr;
+						var dielectricReflectance = surf.specularIntensity * dielectricFr;
 
 						// iridescence
 						if ( surf.iridescence > 0.0 ) {
@@ -170,11 +170,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 							let filmBaseIor = select( 1.0, surf.ior, airIncident );
 
 							let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-							glassReflectance = mix( glassReflectance, dielectricFilmFresnel, surf.iridescence );
+							dielectricReflectance = mix( dielectricReflectance, dielectricFilmFresnel, surf.iridescence );
 
 						}
 
-						let reflection = glassSpecular * glassReflectance;
+						let reflection = dielectricSpecular * dielectricReflectance;
 
 						result += attenuation * ( 1.0 - surf.metalness ) * surf.transmission * reflection;
 
@@ -190,6 +190,10 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					let alphaB = surf.roughness * surf.roughness;
 					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
 					let alpha = vec2( alphaT, alphaB );
+
+					// a thin wall has no interior volume so air is the incident medium on both
+					// sides - only a true volume distinguishes entering from exiting hits
+					let airIncident = surf.thinWall || surf.frontFace;
 
 					// Sample the single scatter energy for specular at the given roughness
 					let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
@@ -207,11 +211,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 					let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
 
-					// front faces use schlick so the KHR_materials_specular tinted f0 applies
-					// we handle internal hits to account for cases where a surface is only partially transmissive.
+					// air-incident hits use schlick so the tinted f0 applies - interior hits use
+					// the exact fresnel since schlick cannot represent TIR
 					// TODO: see if we can clean this up and make these branches more consistent
 					var dielectricFr: vec3f;
-					if ( surf.frontFace ) {
+					if ( airIncident ) {
 
 						dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
 
@@ -228,9 +232,9 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					if ( surf.iridescence > 0.0 ) {
 
 						// the media on either side of the film - air outside and the volume interior
-						// as the base on front faces, swapped on back faces so TIR can take effect
-						let outsideIor = select( surf.ior, 1.0, surf.frontFace );
-						let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
+						// as the base, swapped on interior hits so TIR can take effect
+						let outsideIor = select( surf.ior, 1.0, airIncident );
+						let filmBaseIor = select( 1.0, surf.ior, airIncident );
 
 						let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
 						metallicReflectance = mix( metallicReflectance, metallicFilmFresnel, surf.iridescence );
@@ -248,7 +252,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					// cases where a surface is only partially transmissive.
 					// TODO: Determine how much impact just discarding under-side energy will have.
 					var fresnelEnergySS: f32;
-					if ( surf.frontFace ) {
+					if ( airIncident ) {
 
 						fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -239,7 +239,20 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 						// fresnel-weighted single scatter energy with the multiscatter boost, or the film
 						// fresnel when iridescent, using its strongest channel so the base is not tinted
 						// with the film's inverse color. Only the dielectric half passes light downward.
-						let fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
+						// The table is baked for the air-incident case so volume-incident hits use the
+						// exact fresnel instead - total internal reflection then fades the base out at
+						// grazing interior angles.
+						var fresnelEnergySS: f32;
+						if ( surf.frontFace ) {
+
+							fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
+
+						} else {
+
+							fresnelEnergySS = ${ dielectricFresnelFunc }( NdotV, surf.eta );
+
+						}
+
 						let filmFresnelMax = max( max( dielectricFilmFresnel.r, dielectricFilmFresnel.g ), dielectricFilmFresnel.b );
 						attenuation *= ( 1.0 - surf.metalness ) * mix( 1.0 - fresnelEnergySS, 1.0 - filmFresnelMax, surf.iridescence );
 
@@ -299,7 +312,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				var wiClearcoat: vec3f;
 				var wh: vec3f;
 				var whClearcoat: vec3f;
-				var isTransmissive = false;
+				var isGlass = false;
 
 				if ( r <= cdfClearcoat ) { // clearcoat
 
@@ -309,6 +322,18 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					wi = normalize( invBasis * clearcoatBasis * wiClearcoat );
 					wh = normalize( invBasis * clearcoatBasis * whClearcoat );
+
+					// reflected rays must leave above the geometry surface - flip rays that land
+					// below it due to the shading normal
+					let faceNormal = normalize( invBasis * surf.faceNormal );
+					let geomDotDir = dot( wi, faceNormal );
+					if ( geomDotDir < 0.0 ) {
+
+						wi = normalize( wi - 2.0 * geomDotDir * faceNormal );
+
+					}
+
+					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
 
 				} else if ( r <= cdfSpecular ) { // specular
 
@@ -320,21 +345,42 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
 					wi = - normalize( reflect( wo, wh ) );
 
+					// reflected rays must leave above the geometry surface - flip rays that land
+					// below it due to the shading normal
+					let faceNormal = normalize( invBasis * surf.faceNormal );
+					let geomDotDir = dot( wi, faceNormal );
+					if ( geomDotDir < 0.0 ) {
+
+						wi = normalize( wi - 2.0 * geomDotDir * faceNormal );
+
+					}
+
 					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
 					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
 
 				} else if ( r <= cdfTransmission ) { // transmission ( glass )
 
-					isTransmissive = true;
+					isGlass = true;
 
 					// anisotropic roughness along tangent, bitangent
 					let alphaB = surf.roughness * surf.roughness;
 					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
 					let alpha = vec2( alphaT, alphaB );
 
-					if ( surf.thinWall ) {
+					// sample the half vector first and select reflection or refraction by the
+					// facet fresnel, matching Cycles - total internal reflection drives the
+					// fresnel to 1 so TIR facets always reflect with a matching pdf
+					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
+					let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
+					let rFresnel = ( r - cdfSpecular ) / ( cdfTransmission - cdfSpecular );
+					if ( rFresnel < F ) {
 
-						// model the double refraction as a single reflection flipped through the surface
+						wi = - normalize( reflect( wo, wh ) );
+
+					} else if ( surf.thinWall ) {
+
+						// model the double refraction as a single reflection flipped through the
+						// surface at the remapped thin wall roughness
 						let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
 						wh = ${ ggxDirectionFunc }( wo, thinWallAlpha, directionUV );
 						wi = - normalize( reflect( wo, wh ) );
@@ -342,22 +388,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					} else {
 
-						// sample the half vector first and select reflection or refraction by the
-						// facet fresnel, matching Cycles - total internal reflection drives the
-						// fresnel to 1 so TIR facets always reflect with a matching pdf
-						wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
-						let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
-						let rFresnel = ( r - cdfSpecular ) / ( cdfTransmission - cdfSpecular );
-						if ( rFresnel < F ) {
-
-							wi = - normalize( reflect( wo, wh ) );
-							isTransmissive = false;
-
-						} else {
-
-							wi = refract( - wo, wh, surf.eta );
-
-						}
+						wi = refract( - wo, wh, surf.eta );
 
 					}
 
@@ -368,6 +399,16 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					wi = ${ diffuseDirectionFunc }( wo, directionUV );
 					wh = normalize( wi + wo );
+
+					// reflected rays must leave above the geometry surface - flip rays that land
+					// below it due to the shading normal
+					let faceNormal = normalize( invBasis * surf.faceNormal );
+					let geomDotDir = dot( wi, faceNormal );
+					if ( geomDotDir < 0.0 ) {
+
+						wi = normalize( wi - 2.0 * geomDotDir * faceNormal );
+
+					}
 
 					wiClearcoat = normalize( invClearcoatBasis * normalBasis * wi );
 					whClearcoat = normalize( invClearcoatBasis * normalBasis * wh );
@@ -426,30 +467,22 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 						let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
 						let alpha = vec2( alphaT, alphaB );
 
-						if ( surf.thinWall ) {
+						// the glass lobe selects reflection or refraction by the facet fresnel so
+						// each side carries the corresponding share of the transmission pdf
+						let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
+						if ( wi.z > 0.0 ) {
 
-							if ( wi.z < 0.0 ) {
+							result.pdf += weights.transmission * F * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
 
-								// the flipped reflection shares the reflection pdf
-								let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
-								result.pdf += weights.transmission * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, thinWallAlpha );
+						} else if ( surf.thinWall ) {
 
-							}
+							// the flipped reflection shares the reflection pdf at the remapped roughness
+							let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
+							result.pdf += weights.transmission * ( 1.0 - F ) * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, thinWallAlpha );
 
 						} else {
 
-							// the glass lobe selects reflection or refraction by the facet fresnel so
-							// each side carries the corresponding share of the transmission pdf
-							let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
-							if ( wi.z > 0.0 ) {
-
-								result.pdf += weights.transmission * F * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
-
-							} else {
-
-								result.pdf += weights.transmission * ( 1.0 - F ) * ${ ggxRefractionAdjustedPDFFunc }( wo, wi, wh, alpha, surf.eta );
-
-							}
+							result.pdf += weights.transmission * ( 1.0 - F ) * ${ ggxRefractionAdjustedPDFFunc }( wo, wi, wh, alpha, surf.eta );
 
 						}
 
@@ -468,20 +501,13 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				}
 
-				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isTransmissive );
+				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isGlass );
 				result.direction = normalize( normalBasis * wi );
-				result.isTransmissive = isTransmissive;
 
-				// Flip the scattered ray through the surface if it lands on the wrong side of the
-				// geometry due to the shading normal - reflected rays must leave above the surface
-				// and transmitted rays below it
-				let scatterNormal = surf.faceNormal * select( 1.0, - 1.0, isTransmissive );
-				let geomDotDir = dot( result.direction, scatterNormal );
-				if ( geomDotDir < 0.0 ) {
-
-					result.direction = normalize( result.direction - 2.0 * geomDotDir * scatterNormal );
-
-				}
+				// the glass lobe accepts rays on either side of the geometry surface - the ray is
+				// labeled transmitted when it crosses below so it is treated as entering or
+				// leaving the volume
+				result.isTransmissive = isGlass && dot( result.direction, surf.faceNormal ) < 0.0;
 
 				return result;
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -58,11 +58,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				let NdotVc = ctx.Vc.z;
 				let NdotL = ctx.L.z;
 
-				// anisotropic roughness along tangent, bitangent
-				let alphaB = surf.roughness * surf.roughness;
-				let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
-				let alpha = vec2( alphaT, alphaB );
-
 				// Each lobe contributes into "result" within its own scope, evaluated in cascade
 				// order. "attenuation" carries the fraction of energy each layer passes through to
 				// the layers beneath it. Every lobe guards its own hemisphere, matching how Cycles
@@ -110,6 +105,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				{
 
 					if ( surf.transmission > 0.0 ) {
+
+						// anisotropic roughness along tangent, bitangent
+						let alphaB = surf.roughness * surf.roughness;
+						let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+						let alpha = vec2( alphaT, alphaB );
 
 						if ( NdotL < 0.0 ) {
 
@@ -184,6 +184,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				{
 
 					if ( NdotL > 0.0 ) {
+
+						// anisotropic roughness along tangent, bitangent
+						let alphaB = surf.roughness * surf.roughness;
+						let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+						let alpha = vec2( alphaT, alphaB );
 
 						// Sample the single scatter energy for specular at the given roughness.
 						let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
@@ -271,13 +276,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				var result: ${ scatterRecordStruct };
 				result.pdf = 0.0;
 
-				// anisotropic roughness along tangent, bitangent
-				let alphaB = surf.roughness * surf.roughness;
-				let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
-				let alpha = vec2( alphaT, alphaB );
-
-				let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
-
 				let normalBasis = surf.normalBasis;
 				let invBasis = surf.normalInvBasis;
 				let clearcoatBasis = surf.clearcoatBasis;
@@ -305,6 +303,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				if ( r <= cdfClearcoat ) { // clearcoat
 
+					let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
 					whClearcoat = ${ ggxDirectionFunc }( woClearcoat, vec2( clearcoatAlpha ), directionUV );
 					wiClearcoat = - normalize( reflect( woClearcoat, whClearcoat ) );
 
@@ -312,6 +311,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					wh = normalize( invBasis * clearcoatBasis * whClearcoat );
 
 				} else if ( r <= cdfSpecular ) { // specular
+
+					// anisotropic roughness along tangent, bitangent
+					let alphaB = surf.roughness * surf.roughness;
+					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+					let alpha = vec2( alphaT, alphaB );
 
 					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
 					wi = - normalize( reflect( wo, wh ) );
@@ -322,6 +326,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				} else if ( r <= cdfTransmission ) { // transmission ( glass )
 
 					isTransmissive = true;
+
+					// anisotropic roughness along tangent, bitangent
+					let alphaB = surf.roughness * surf.roughness;
+					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+					let alpha = vec2( alphaT, alphaB );
 
 					if ( surf.thinWall ) {
 
@@ -384,6 +393,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					if ( weights.clearcoat > 0.0 && wiClearcoat.z > 0.0 ) {
 
+						let clearcoatAlpha = surf.clearcoatRoughness * surf.clearcoatRoughness;
 						result.pdf += weights.clearcoat * ${ ggxReflectionAdjustedPDFFunc }( woClearcoat, whClearcoat, vec2( clearcoatAlpha ) );
 
 					}
@@ -395,6 +405,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					if ( weights.specular > 0.0 && wi.z > 0.0 ) {
 
+						// anisotropic roughness along tangent, bitangent
+						let alphaB = surf.roughness * surf.roughness;
+						let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+						let alpha = vec2( alphaT, alphaB );
+
 						result.pdf += weights.specular * ${ ggxReflectionAdjustedPDFFunc }( wo, wh, alpha );
 
 					}
@@ -405,6 +420,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				{
 
 					if ( weights.transmission > 0.0 ) {
+
+						// anisotropic roughness along tangent, bitangent
+						let alphaB = surf.roughness * surf.roughness;
+						let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
+						let alpha = vec2( alphaT, alphaB );
 
 						if ( surf.thinWall ) {
 

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -183,32 +183,29 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				// Cycles folds the film into the closure fresnel rather than adding a layer.
 				if ( NdotL > 0.0 ) {
 
-
 					// anisotropic roughness along tangent, bitangent
 					let alphaB = surf.roughness * surf.roughness;
 					let alphaT = mix( alphaB, 1.0, surf.anisotropy * surf.anisotropy );
 					let alpha = vec2( alphaT, alphaB );
 
-					// metalness
-					// Sample the single scatter energy for specular at the given roughness.
+					// Sample the single scatter energy for specular at the given roughness
 					let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
-					let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
 					let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
-					let boostedSpecular = specular * dielectricBoost;
 
-					// metallic half with the multiscatter comp
+					// metallic with the multiscatter comp
 					let metallicBoost = 1.0 + surf.color * ( 1.0 - energySS ) / energySS;
 					let metallicSpecular = specular * metallicBoost;
-					var metallicFresnel = ${ this.conductorFresnel }( ctx.VdotH, surf.color, vec3f( 1.0 ) );
+					var metallicReflectance = ${ this.conductorFresnel }( ctx.VdotH, surf.color, vec3f( 1.0 ) );
 
-					//
+					// dielectric with the multiscatter comp
+					let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
+					let dielectricSpecular = specular * dielectricBoost;
 
-					// dielectric
 					// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 					let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
 
-					// front faces use schlick so the KHR_materials_specular tinted f0 applies - interior
-					// hits use the exact dielectric fresnel since schlick cannot represent TIR
+					// front faces use schlick so the KHR_materials_specular tinted f0 applies
+					// we handle internal hits to account for cases where a surface is only partially transmissive.
 					// TODO: see if we can clean this up and make these branches more consistent
 					var dielectricFr: vec3f;
 					if ( surf.frontFace ) {
@@ -221,7 +218,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					var specularFresnel = surf.specularIntensity * dielectricFr;
+					var dielectricReflectance = surf.specularIntensity * dielectricFr;
 
 					// iridescence
 					var filmFresnelMax = 0.0;
@@ -233,24 +230,20 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 						let filmBaseIor = select( 1.0, surf.ior, surf.frontFace );
 
 						let metallicFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, surf.color, surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-						metallicFresnel = mix( metallicFresnel, metallicFilmFresnel, surf.iridescence );
+						metallicReflectance = mix( metallicReflectance, metallicFilmFresnel, surf.iridescence );
 
 						let dielectricFilmFresnel = ${ this.iridescentFresnel }( ctx.VdotH, vec3f( ${ iorToF0Func }( filmBaseIor ) ), surf.iridescenceIor, outsideIor, surf.iridescenceThickness );
-						specularFresnel = mix( specularFresnel, dielectricFilmFresnel, surf.iridescence );
+						dielectricReflectance = mix( dielectricReflectance, dielectricFilmFresnel, surf.iridescence );
 						filmFresnelMax = max( max( dielectricFilmFresnel.r, dielectricFilmFresnel.g ), dielectricFilmFresnel.b );
 
 					}
 
-					let metallic = metallicSpecular * metallicFresnel;
-					let dielectricSpecular = boostedSpecular * specularFresnel;
+					let metallic = metallicSpecular * metallicReflectance;
+					let dielectric = dielectricSpecular * dielectricReflectance;
 
-					// Attenuate the layers below by the energy taken by the specular interface - the
-					// fresnel-weighted single scatter energy with the multiscatter boost, or the film
-					// fresnel when iridescent, using its strongest channel so the base is not tinted
-					// with the film's inverse color. Only the dielectric half passes light downward.
-					// The table is baked for the air-incident case so volume-incident hits use the
-					// exact fresnel instead - total internal reflection then fades the base out at
-					// grazing interior angles.
+					// the energy the specular interface takes from the layers below - we handle internal hits to account for
+					// cases where a surface is only partially transmissive.
+					// TODO: Determine how much impact just discarding under-side energy will have.
 					var fresnelEnergySS: f32;
 					if ( surf.frontFace ) {
 
@@ -262,7 +255,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					}
 
-					result += attenuation * mix( ( 1.0 - surf.transmission ) * dielectricSpecular, metallic, surf.metalness );
+					result += attenuation * mix( ( 1.0 - surf.transmission ) * dielectric, metallic, surf.metalness );
 					attenuation *= ( 1.0 - surf.metalness ) * mix( 1.0 - fresnelEnergySS, 1.0 - filmFresnelMax, surf.iridescence );
 
 				}

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -698,49 +698,6 @@ export const iridescentFresnelFunc = wgslFn( /* wgsl */ `
 
 `, [ iorToF0GeneralFunc, iorToF0GeneralVecFunc, schlickFresnelFunc, fresnel0ToIorFunc, evalSensitivityFunc, totalInternalReflectionVecFunc ] );
 
-const rgbMixFunc = wgslFn( /* wgsl */ `
-
-	fn rgbMix( base: vec3f, specular: vec3f, rgbAlpha: vec3f ) -> vec3f {
-
-		let alphaMax = max( max( rgbAlpha.x, rgbAlpha.y ), rgbAlpha.z );
-		return ( 1 - alphaMax ) * base + rgbAlpha * specular;
-
-	}
-
-` );
-
-export const iridescentDielectricLayerFunc = wgslFn( /* wgsl */ `
-
-	fn iridescentDielectricLayer(
-		dielectricBase: vec3f, base: vec3f, specular: vec3f, HdotL: f32,
-		outsideIor: f32, baseIor: f32, iridescenceIor: f32, thickness: f32, strength: f32,
-	) -> vec3f {
-
-		let baseF0 = vec3( iorToF0( baseIor ) );
-
-		let iridescentF = iridescentFresnel( HdotL, baseF0, iridescenceIor, outsideIor, thickness );
-
-		return mix( dielectricBase, rgbMix( base, specular, iridescentF ), strength );
-
-	}
-
-`, [ iorToF0Func, iridescentFresnelFunc, rgbMixFunc ] );
-
-export const iridescentConductorLayerFunc = wgslFn( /* wgsl */ `
-
-	fn iridescentConductorLayer(
-		metalBase: vec3f, specular: vec3f, baseF0: vec3f, HdotL: f32,
-		outsideIor: f32, iridescenceIor: f32, thickness: f32, strength: f32,
-	) -> vec3f {
-
-		let iridescenceF = iridescentFresnel( HdotL, baseF0, iridescenceIor, outsideIor, thickness );
-
-		return mix( metalBase, specular * iridescenceF, strength );
-
-	}
-
-`, [ iridescentFresnelFunc ] );
-
 export const conductorFresnelFunc = wgslFn( /* wgsl */ `
 
 	fn conductorFresnel( VdotH: f32, f0: vec3f, specular: vec3f ) -> vec3f {

--- a/src/webgpu/nodes/sampling.wgsl.js
+++ b/src/webgpu/nodes/sampling.wgsl.js
@@ -52,10 +52,13 @@ export const getLobeWeightsFunc = wgslFn( /* wgsl */ `
 		weights.clearcoat = surf.clearcoat * clearcoatFresnel;
 		remaining -= weights.clearcoat;
 
+		// the opaque share - metals and the fresnel reflection of the non-transmissive
+		// dielectric. The transmissive portion's reflection is carried by the glass lobe.
 		let fEstimate = disneyFresnel( wo, wi, wh, surf.f0, surf.eta, surf.metalness );
-		weights.specular = remaining * ( surf.metalness + ( 1.0 - surf.metalness ) * fEstimate );
+		weights.specular = remaining * ( surf.metalness + ( 1.0 - surf.metalness ) * ( 1.0 - surf.transmission ) * fEstimate );
 		remaining -= weights.specular;
 
+		// the glass lobe covers both the reflected and refracted halves of the transmissive portion
 		weights.transmission = remaining * surf.transmission;
 		remaining -= weights.transmission;
 

--- a/src/webgpu/nodes/sampling.wgsl.js
+++ b/src/webgpu/nodes/sampling.wgsl.js
@@ -52,13 +52,12 @@ export const getLobeWeightsFunc = wgslFn( /* wgsl */ `
 		weights.clearcoat = surf.clearcoat * clearcoatFresnel;
 		remaining -= weights.clearcoat;
 
-		// the opaque share - metals and the fresnel reflection of the non-transmissive
-		// dielectric. The transmissive portion's reflection is carried by the glass lobe.
+		// this specular lobe only handles the opaque portion of the specular
 		let fEstimate = disneyFresnel( wo, wi, wh, surf.f0, surf.eta, surf.metalness );
 		weights.specular = remaining * ( surf.metalness + ( 1.0 - surf.metalness ) * ( 1.0 - surf.transmission ) * fEstimate );
 		remaining -= weights.specular;
 
-		// the glass lobe covers both the reflected and refracted halves of the transmissive portion
+		// the transmission lobe covers both the reflected and refracted halves of the transmissive portion
 		weights.transmission = remaining * surf.transmission;
 		remaining -= weights.transmission;
 

--- a/src/webgpu/nodes/structs.wgsl.js
+++ b/src/webgpu/nodes/structs.wgsl.js
@@ -221,10 +221,6 @@ export const bxdfContextStruct = new StructTypeNode( {
 	L: 'vec3f', // light dir
 	H: 'vec3f', // half dir
 
-	Vc: 'vec3f', // clearcoat view dir
-	Lc: 'vec3f', // clearcoat light dir
-	Hc: 'vec3f', // clearcoat half dir
-
 	VdotH: 'float',
 
 }, 'BxDFContext' );


### PR DESCRIPTION
Related to #777

I've asked Claude to organize the lobes so the logic per-lobe is more self contained so it's easier to understand, energy is maybe easier to track, and we can possibly expand to more layers in the future.

- Separate lobes into dedicated blocks
- Adjust transmission lobe sample and eval to handle reflection & transmission
- Remove pre-calculate clearcoat values and compute them as-needed
- Calculate iridescence in the specular / transmission branch

**NEXT**
- Remove unused disney functions
- Consider splitting up specular and metallic lobes into separate branches