### PR TITLE
WebGPUPathTracer: Improve energy conservation for transmissive materials

### DIFF
--- a/example/furnace_test.js
+++ b/example/furnace_test.js
@@ -11,6 +11,7 @@ const options = {
 	enable: true,
 	useMegakernel: false,
 	whiteBackground: false,
+	bounces: 5,
 	xAxis: 'roughness',
 	yAxis: 'metalness',
 };
@@ -21,6 +22,7 @@ renderer.init();
 
 const pathTracer = new WebGPUPathTracer( renderer );
 pathTracer.useMegakernel( options.useMegakernel );
+pathTracer.bounces = options.bounces;
 
 document.body.appendChild( renderer.domElement );
 renderer.setSize( innerWidth, innerHeight );
@@ -63,6 +65,12 @@ gui.add( options, 'useMegakernel' ).onChange( () => {
 
 } );
 gui.add( options, 'whiteBackground' ).onChange( updateBackground );
+gui.add( options, 'bounces', 1, 100, 1 ).onChange( () => {
+
+	pathTracer.bounces = options.bounces;
+	pathTracer.reset();
+
+} );
 gui.add( options, 'xAxis', AXIS_PROPERTIES ).onChange( rebuild );
 gui.add( options, 'yAxis', AXIS_PROPERTIES ).onChange( rebuild );
 

--- a/src/webgpu/TurquinTexture.js
+++ b/src/webgpu/TurquinTexture.js
@@ -1,6 +1,6 @@
 import { Storage3DTexture, RedFormat, LinearFilter, HalfFloatType, MathUtils } from 'three/webgpu';
 import { storageTexture3D, globalId, uniform, texture3D, sampler } from 'three/tsl';
-import { albedoIntegralMetallic } from './nodes/material.wgsl.js';
+import { turquinIntegralFn } from './nodes/material.wgsl.js';
 import { ComputeKernel } from './compute/ComputeKernel.js';
 import { wgslTagFn, proxyFn } from 'three-mesh-bvh/webgpu';
 
@@ -13,7 +13,11 @@ export class TurquinTexture extends Storage3DTexture {
 
 	constructor() {
 
-		super( RESOLUTION, RESOLUTION, 11 );
+		// layer 0: conductor
+		// layer 1 - 10: dielectric reflection over the ior range
+		// layer 11 - 20: transmissive total energy entering
+		// layer 21 - 30: transmissive total energy exiting
+		super( RESOLUTION, RESOLUTION, 31 );
 
 		this.type = HalfFloatType;
 		this.format = RedFormat;
@@ -22,12 +26,14 @@ export class TurquinTexture extends Storage3DTexture {
 
 		// TODO: turquin paper suggests 32 layers for dielectric
 		this.dielectricLayerCount = 10;
+		this.transmissiveLayerCount = 10;
 		this.minIoR = 1;
 		this.maxIoR = 2.5;
 
 		// construct the fns
 		this.sampleConductorFn = proxyFn( '_sampleConductorFn', this );
 		this.sampleDielectricFn = proxyFn( '_sampleDielectricFn', this );
+		this.sampleTransmissiveFn = proxyFn( '_sampleTransmissiveFn', this );
 
 	}
 
@@ -36,6 +42,7 @@ export class TurquinTexture extends Storage3DTexture {
 
 		const {
 			dielectricLayerCount,
+			transmissiveLayerCount,
 			minIoR,
 			maxIoR,
 		} = this;
@@ -43,26 +50,47 @@ export class TurquinTexture extends Storage3DTexture {
 		const params = {
 			outputTarget: storageTexture3D( this ).toWriteOnly(),
 			globalId,
-			ior: uniform( 1.5 ),
+			eta: uniform( 1 ),
 			layer: uniform( 0, 'uint' ),
 			includeFresnel: uniform( 0 ),
+			includeRefraction: uniform( 0 ),
 		};
 
 		const dispatch = [ RESOLUTION / WORKGROUP_SIZE, RESOLUTION / WORKGROUP_SIZE, 1 ];
-		const kernel = new ComputeKernel( albedoIntegralMetallic( params ), { workgroupSize: [ WORKGROUP_SIZE, WORKGROUP_SIZE, 1 ] } );
+		const kernel = new ComputeKernel( turquinIntegralFn( params ), { workgroupSize: [ WORKGROUP_SIZE, WORKGROUP_SIZE, 1 ] } );
 
 		// metallic
 		params.layer.value = 0;
-		params.ior.value = 1.5;
+		params.eta.value = 1;
 		params.includeFresnel.value = 0;
+		params.includeRefraction.value = 0;
 		renderer.compute( kernel.kernel, dispatch );
 
 		// dielectric
 		for ( let i = 0; i < dielectricLayerCount; i ++ ) {
 
 			params.layer.value ++;
-			params.ior.value = MathUtils.mapLinear( i, 0, dielectricLayerCount - 1, minIoR, maxIoR );
+			params.eta.value = 1 / MathUtils.mapLinear( i, 0, dielectricLayerCount - 1, minIoR, maxIoR );
 			params.includeFresnel.value = 1;
+			renderer.compute( kernel.kernel, dispatch );
+
+		}
+
+		// transmissive total energy - entering and exiting layers over the same ior range
+		params.includeFresnel.value = 1;
+		params.includeRefraction.value = 1;
+		for ( let i = 0; i < transmissiveLayerCount; i ++ ) {
+
+			const ior = MathUtils.mapLinear( i, 0, transmissiveLayerCount - 1, minIoR, maxIoR );
+
+			// entering - air incident
+			params.layer.value = 1 + dielectricLayerCount + i;
+			params.eta.value = 1 / ior;
+			renderer.compute( kernel.kernel, dispatch );
+
+			// exiting - volume incident, TIR side
+			params.layer.value = 1 + dielectricLayerCount + transmissiveLayerCount + i;
+			params.eta.value = ior;
 			renderer.compute( kernel.kernel, dispatch );
 
 		}
@@ -83,7 +111,7 @@ export class TurquinTexture extends Storage3DTexture {
 		const samplerNode = sampler( this ).setName( 'turquinSampler' );
 
 		// conductor fetch fn
-		const layerDepth = 1.0 / ( 1 + dielectricLayerCount );
+		const layerDepth = 1.0 / ( 1 + dielectricLayerCount + 2 * transmissiveLayerCount );
 		this._sampleConductorFn = wgslTagFn/* wgsl */`
 			fn sampleConductor( cosTheta0: f32, roughness: f32 ) -> f32 {
 
@@ -103,6 +131,30 @@ export class TurquinTexture extends Storage3DTexture {
 					ior,
 					f32( ${ minIoR } ), f32( ${ maxIoR } ),
 					0.5, f32( ${ dielectricLayerCount } ) - 0.5,
+				) + blockStart;
+
+				let uvw = vec3f( cosTheta0, roughness, layer * ${ layerDepth } );
+				return textureSampleLevel( ${ textureNode }, ${ samplerNode }, uvw, 0 ).r;
+
+			}
+		`;
+
+		// transmissive fetch fn - entering selects the air-incident block, otherwise the
+		// volume-incident ( TIR ) block. ior is clamped at the valid range
+		const enterBlockStart = 1 + dielectricLayerCount;
+		const exitBlockStart = 1 + dielectricLayerCount + transmissiveLayerCount;
+		this._sampleTransmissiveFn = wgslTagFn/* wgsl */`
+			fn sampleTransmissive( cosTheta0: f32, roughness: f32, ior: f32, entering: bool ) -> f32 {
+
+				let blockStart = select(
+					f32( ${ exitBlockStart } ),
+					f32( ${ enterBlockStart } ),
+					entering
+				);
+				let layer = ${ mapLinearClampedFn }(
+					ior,
+					f32( ${ minIoR } ), f32( ${ maxIoR } ),
+					0.5, f32( ${ transmissiveLayerCount } ) - 0.5,
 				) + blockStart;
 
 				let uvw = vec3f( cosTheta0, roughness, layer * ${ layerDepth } );

--- a/src/webgpu/TurquinTexture.js
+++ b/src/webgpu/TurquinTexture.js
@@ -140,7 +140,7 @@ export class TurquinTexture extends Storage3DTexture {
 		`;
 
 		// transmissive fetch fn - entering selects the air-incident block, otherwise the
-		// volume-incident ( TIR ) block. ior is clamped at the valid range
+		// volume-incident (TIR) block. ior is clamped at the valid range
 		const enterBlockStart = 1 + dielectricLayerCount;
 		const exitBlockStart = 1 + dielectricLayerCount + transmissiveLayerCount;
 		this._sampleTransmissiveFn = wgslTagFn/* wgsl */`

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -12,56 +12,6 @@ import { iorToF0Func, schlickFresnelFunc, schlickFresnelVecFunc, dielectricFresn
 
 const CLEARCOAT_IOR = float( 1.5 );
 
-// TRANSMISSION / THIN WALL ENERGY PRESERVATION NOTES - for review
-//
-// Improvements:
-// - The material is organized as one self-contained scoped block per lobe in Cycles-style
-//   cascade order ( clearcoat, sheen, glass, specular, diffuse ), each accumulating into a
-//   shared result with a running attenuation.
-// - The glass lobe owns BOTH hemispheres of the transmissive share: fresnel reflection above
-//   the horizon and refraction below. The opaque specular only carries the ( 1 - transmission )
-//   remainder, matching how the glTF dielectric factors exactly into a glass lobe plus an
-//   opaque specular-over-diffuse lobe.
-// - Sampling selects reflection vs refraction by the facet fresnel AFTER sampling the half
-//   vector, so TIR facets always reflect with a matching pdf and no fallback paths.
-//   [ Cycles bsdf_microfacet.h:849 ]
-// - Hemisphere rejection: the facet choice must agree with the resulting hemisphere -
-//   mismatched samples are dropped ( isDead ) and their loss is refunded by the energy
-//   tables, mirroring Cycles' LABEL_NONE rejection. The bake counts the same samples as
-//   lost, which is the core invariant: the renderer must lose exactly what the table refunds.
-// - Per-lobe geometric flips ( clearcoat / specular / diffuse ) only rescue rays above the
-//   shading hemisphere that fall below the geometry due to normal mapping ( wi.z > 0 guard ).
-//   Below-horizon samples stay dead since the tables refund them - flipping them double-pays.
-// - Thin wall transmission is a mirrored reflection at a remapped roughness
-//   ( thinWallTransmissionRoughness, Imageworks eq 3.4 ), compensated with the conductor
-//   table at that roughness. Both thin wall halves are reflection-shaped so each uses the
-//   conductor albedo.
-// - Volumetric glass is compensated by 1 / E_total where E_total is the baked total energy
-//   ( fresnel reflection + refraction ) of the interface, so the reflect / refract ratio is
-//   preserved. Entering ( eta = 1 / ior ) and exiting ( eta = ior, includes TIR ) are baked
-//   as separate ior-swept blocks, equivalent to Cycles' ggx_glass_E / ggx_glass_inv_E
-//   [ cycles_precompute.cpp ].
-// - The opaque specular uses schlick on BOTH hit sides and the air-incident fresnel-weighted
-//   dielectric table for its attenuation on both sides. No TIR on the opaque specular - the
-//   energy removed from the base always matches the energy paid back. This mirrors Cycles,
-//   which only bakes air-incident tables for the opaque closure ( ggx_gen_schlick_ior_s ).
-//   The bake weights air-incident reflection by schlick so the table matches what the eval
-//   pays.
-//
-// Known / accepted behavior:
-// - Low-transmission volume interiors converge slowly: energy is conserved in expectation
-//   ( verified with a CPU replica - per-hit E[ throughput multiplier ] = 1 at all angles,
-//   sphere-walk response -> 1 ) but the kill + refund scheme stores the refunded energy in
-//   very rare, very bright TIR-trapped paths, so furnace charts read slightly dark at
-//   practical sample counts with occasional fireflies. Same class of behavior as Cycles.
-//
-// Sources:
-// - Turquin, "Practical multiple scattering compensation for microfacet models"
-//   https://blog.selfshadow.com/publications/turquin/ms_comp_final.pdf
-// - Blender Cycles: kernel/closure/bsdf_microfacet.h ( facet fresnel split, hemisphere
-//   rejection ), app/cycles_precompute.cpp ( baked table set ), closure layering weights
-// - Imageworks, "Revisiting Physically Based Shading" s2017_pbs_imageworks_slides_v2.pdf
-//   ( thin wall transmission roughness remap, page 40 )
 export class GltfCompliantMaterial extends PathtracingMaterial {
 
 	constructor( options = {} ) {

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -113,6 +113,21 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					// sides - only a true volume distinguishes entering from exiting hits
 					let airIncident = surf.thinWall || surf.frontFace;
 
+					// Turquin multiscatter compensation for the glass lobe: the volumetric bsdf is
+					// scaled by its total reflected + refracted energy so the reflection to
+					// refraction ratio is preserved. The thin wall halves are reflection-shaped
+					// so each is compensated with the conductor albedo at its own roughness.
+					var glassBoost = 0.0;
+					if ( surf.thinWall ) {
+
+						glassBoost = 1.0 / max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
+
+					} else {
+
+						glassBoost = 1.0 / max( ${ this.turquinTexture.sampleTransmissiveFn }( NdotV, surf.roughness, surf.ior, surf.frontFace ), 1e-5 );
+
+					}
+
 					if ( NdotL < 0.0 ) {
 
 						// TODO: transmitted light also crosses the iridescent thin film so it should be weighted by
@@ -120,15 +135,16 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 						var refraction: vec3f;
 						if ( surf.thinWall ) {
 
-							// model the double refraction as a reflection flipped through the surface
+							// evaluate the flipped reflection, compensated at the remapped roughness
 							let wiMirror = vec3f( ctx.L.xy, - ctx.L.z );
 							let thinWallAlpha = vec2f( ${ thinWallTransmissionRoughnessFunc }( alphaB, surf.ior ) );
+							let thinWallEnergySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, sqrt( thinWallAlpha.x ) ), 1e-5 );
 							let F = ${ dielectricFresnelFunc }( saturate( ctx.VdotH ), surf.eta );
-							refraction = ( 1.0 - F ) * ${ this.specularBrdf }( ctx.V, wiMirror, ctx.H, thinWallAlpha );
+							refraction = ( 1.0 - F ) * ${ this.specularBrdf }( ctx.V, wiMirror, ctx.H, thinWallAlpha ) / thinWallEnergySS;
 
 						} else {
 
-							refraction = ${ this.specularBtdf }( ctx.V, ctx.L, ctx.H, alpha, surf.eta );
+							refraction = ${ this.specularBtdf }( ctx.V, ctx.L, ctx.H, alpha, surf.eta ) * glassBoost;
 
 						}
 
@@ -137,13 +153,10 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 					} else {
 
-						// Sample the single scatter energy for specular at the given roughness
-						let energySS = max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
+						// the raw single scatter lobe scaled by the glass compensation boost rather
+						// than the opaque dielectric boost
 						let specular = ${ this.specularBrdf }( ctx.V, ctx.L, ctx.H, alpha );
-
-						// dielectric with the multiscatter comp
-						let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
-						let dielectricSpecular = specular * dielectricBoost;
+						let dielectricSpecular = specular * glassBoost;
 
 						// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
 						let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
@@ -207,22 +220,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					let dielectricBoost = 1.0 + surf.f0 * ( 1.0 - energySS ) / energySS;
 					let dielectricSpecular = specular * dielectricBoost;
 
-					// KHR_materials_specular: fold the specular color and intensity into the dielectric f0
+					// KHR_materials_specular: fold the specular color and intensity into the dielectric f0.
+					// Schlick is used on both hit sides, matching Cycles - the opaque specular carries no
+					// TIR so the energy removed from the base always matches the energy paid back
 					let dielectricF0 = min( surf.f0 * surf.specularColor, vec3f( 1.0 ) );
-
-					// front faces use schlick so the KHR_materials_specular tinted f0 applies
-					// we handle internal hits to account for cases where a surface is only partially transmissive.
-					// TODO: see if we can clean this up and make these branches more consistent
-					var dielectricFr: vec3f;
-					if ( surf.frontFace ) {
-
-						dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
-
-					} else {
-
-						dielectricFr = vec3f( ${ dielectricFresnelFunc }( abs( ctx.VdotH ), surf.eta ) );
-
-					}
+					let dielectricFr = ${ schlickFresnelVecFunc }( ctx.VdotH, dielectricF0, vec3f( 1.0 ) );
 
 					var dielectricReflectance = surf.specularIntensity * dielectricFr;
 
@@ -247,19 +249,9 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					let metallic = metallicSpecular * metallicReflectance;
 					let dielectric = dielectricSpecular * dielectricReflectance;
 
-					// the energy the specular interface takes from the layers below - we handle internal hits to account for
-					// cases where a surface is only partially transmissive.
-					// TODO: Determine how much impact just discarding under-side energy will have.
-					var fresnelEnergySS: f32;
-					if ( surf.frontFace ) {
-
-						fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
-
-					} else {
-
-						fresnelEnergySS = ${ dielectricFresnelFunc }( NdotV, surf.eta );
-
-					}
+					// the energy the specular interface takes from the layers below. The table is baked
+					// air-incident and the eval pays schlick on both sides, so the two always agree
+					let fresnelEnergySS = ${ this.turquinTexture.sampleDielectricFn }( NdotV, surf.roughness, surf.ior ) * dielectricBoost;
 
 					result += attenuation * mix( ( 1.0 - surf.transmission ) * dielectric, metallic, surf.metalness );
 					attenuation *= ( 1.0 - surf.metalness ) * mix( 1.0 - fresnelEnergySS, 1.0 - filmFresnelMax, surf.iridescence );
@@ -311,6 +303,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				var wh: vec3f;
 
 				var isTransmissionLobe = false;
+				var isDead = false;
 
 				if ( lobeSample <= cdfClearcoat ) {
 
@@ -371,7 +364,8 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					wh = ${ ggxDirectionFunc }( wo, alpha, directionUV );
 					let F = ${ dielectricFresnelFunc }( dot( wo, wh ), surf.eta );
 					let fresnelSample = ( lobeSample - cdfSpecular ) / ( cdfTransmission - cdfSpecular );
-					if ( fresnelSample < F ) {
+					let doReflect = fresnelSample < F;
+					if ( doReflect ) {
 
 						wi = - normalize( reflect( wo, wh ) );
 
@@ -389,6 +383,11 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 						wi = refract( - wo, wh, surf.eta );
 
 					}
+
+					// the facet choice must agree with the resulting hemisphere - reflection above,
+					// transmission below. Mismatched samples are dropped since their loss is
+					// refunded by the energy compensation tables
+					isDead = doReflect != ( wi.z > 0.0 );
 
 				} else if ( lobeSample <= cdfTotal ) {
 
@@ -476,8 +475,6 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 
 				}
 
-				//
-
 				// construct the scatter context
 				var ctx: ${ bxdfContextStruct };
 				ctx.V = wo;
@@ -487,7 +484,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				ctx.VdotH = saturate( dot( wo, wh ) );
 
 				// evaluate the bsdf for the sampled direction
-				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isTransmissionLobe );
+				result.color = ${ bsdfEvalFunc }( ctx, surf ) * select( max( 0.0, wi.z ), abs( wi.z ), isTransmissionLobe ) * select( 1.0, 0.0, isDead );
 				result.direction = normalize( surf.normalBasis * wi );
 
 				// a glass ray crossing below the surface enters or leaves the volume

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -113,17 +113,16 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					// sides - only a true volume distinguishes entering from exiting hits
 					let airIncident = surf.thinWall || surf.frontFace;
 
-					// Turquin multiscatter compensation for the glass lobe: the volumetric bsdf is
-					// scaled by its total reflected + refracted energy so the reflection to
-					// refraction ratio is preserved. The thin wall halves are reflection-shaped
-					// so each is compensated with the conductor albedo at its own roughness.
+					// multiscatter compensation
 					var glassBoost = 0.0;
 					if ( surf.thinWall ) {
 
+						// thin wall halves are reflection-shaped so each is compensated with the conductor albedo at its own roughness.
 						glassBoost = 1.0 / max( ${ this.turquinTexture.sampleConductorFn }( NdotV, surf.roughness ), 1e-5 );
 
 					} else {
 
+						// volumetric bsdf is scaled by its total reflected + refracted energy
 						glassBoost = 1.0 / max( ${ this.turquinTexture.sampleTransmissiveFn }( NdotV, surf.roughness, surf.ior, surf.frontFace ), 1e-5 );
 
 					}
@@ -300,6 +299,7 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 				var wi: vec3f;
 				var wh: vec3f;
 
+				// TODO: see if we can clean up these flags so they're not necessary
 				var isTransmissionLobe = false;
 				var isDead = false;
 
@@ -472,6 +472,8 @@ export class GltfCompliantMaterial extends PathtracingMaterial {
 					result.pdf += weights.diffuse * max( wi.z, 0.0 ) / PI;
 
 				}
+
+				//
 
 				// construct the scatter context
 				var ctx: ${ bxdfContextStruct };

--- a/src/webgpu/materials/GltfCompliantMaterial.js
+++ b/src/webgpu/materials/GltfCompliantMaterial.js
@@ -12,6 +12,56 @@ import { iorToF0Func, schlickFresnelFunc, schlickFresnelVecFunc, dielectricFresn
 
 const CLEARCOAT_IOR = float( 1.5 );
 
+// TRANSMISSION / THIN WALL ENERGY PRESERVATION NOTES - for review
+//
+// Improvements:
+// - The material is organized as one self-contained scoped block per lobe in Cycles-style
+//   cascade order ( clearcoat, sheen, glass, specular, diffuse ), each accumulating into a
+//   shared result with a running attenuation.
+// - The glass lobe owns BOTH hemispheres of the transmissive share: fresnel reflection above
+//   the horizon and refraction below. The opaque specular only carries the ( 1 - transmission )
+//   remainder, matching how the glTF dielectric factors exactly into a glass lobe plus an
+//   opaque specular-over-diffuse lobe.
+// - Sampling selects reflection vs refraction by the facet fresnel AFTER sampling the half
+//   vector, so TIR facets always reflect with a matching pdf and no fallback paths.
+//   [ Cycles bsdf_microfacet.h:849 ]
+// - Hemisphere rejection: the facet choice must agree with the resulting hemisphere -
+//   mismatched samples are dropped ( isDead ) and their loss is refunded by the energy
+//   tables, mirroring Cycles' LABEL_NONE rejection. The bake counts the same samples as
+//   lost, which is the core invariant: the renderer must lose exactly what the table refunds.
+// - Per-lobe geometric flips ( clearcoat / specular / diffuse ) only rescue rays above the
+//   shading hemisphere that fall below the geometry due to normal mapping ( wi.z > 0 guard ).
+//   Below-horizon samples stay dead since the tables refund them - flipping them double-pays.
+// - Thin wall transmission is a mirrored reflection at a remapped roughness
+//   ( thinWallTransmissionRoughness, Imageworks eq 3.4 ), compensated with the conductor
+//   table at that roughness. Both thin wall halves are reflection-shaped so each uses the
+//   conductor albedo.
+// - Volumetric glass is compensated by 1 / E_total where E_total is the baked total energy
+//   ( fresnel reflection + refraction ) of the interface, so the reflect / refract ratio is
+//   preserved. Entering ( eta = 1 / ior ) and exiting ( eta = ior, includes TIR ) are baked
+//   as separate ior-swept blocks, equivalent to Cycles' ggx_glass_E / ggx_glass_inv_E
+//   [ cycles_precompute.cpp ].
+// - The opaque specular uses schlick on BOTH hit sides and the air-incident fresnel-weighted
+//   dielectric table for its attenuation on both sides. No TIR on the opaque specular - the
+//   energy removed from the base always matches the energy paid back. This mirrors Cycles,
+//   which only bakes air-incident tables for the opaque closure ( ggx_gen_schlick_ior_s ).
+//   The bake weights air-incident reflection by schlick so the table matches what the eval
+//   pays.
+//
+// Known / accepted behavior:
+// - Low-transmission volume interiors converge slowly: energy is conserved in expectation
+//   ( verified with a CPU replica - per-hit E[ throughput multiplier ] = 1 at all angles,
+//   sphere-walk response -> 1 ) but the kill + refund scheme stores the refunded energy in
+//   very rare, very bright TIR-trapped paths, so furnace charts read slightly dark at
+//   practical sample counts with occasional fireflies. Same class of behavior as Cycles.
+//
+// Sources:
+// - Turquin, "Practical multiple scattering compensation for microfacet models"
+//   https://blog.selfshadow.com/publications/turquin/ms_comp_final.pdf
+// - Blender Cycles: kernel/closure/bsdf_microfacet.h ( facet fresnel split, hemisphere
+//   rejection ), app/cycles_precompute.cpp ( baked table set ), closure layering weights
+// - Imageworks, "Revisiting Physically Based Shading" s2017_pbs_imageworks_slides_v2.pdf
+//   ( thin wall transmission roughness remap, page 40 )
 export class GltfCompliantMaterial extends PathtracingMaterial {
 
 	constructor( options = {} ) {

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -17,6 +17,7 @@ import {
 	ggxDistributionFunc,
 	ggxDirectionFunc,
 	ggxReflectionAdjustedPDFFunc,
+	ggxRefractionAdjustedPDFFunc,
 	ggxShadowMaskG1Func,
 } from './ggx.wgsl.js';
 import { constants, surfaceRecordStruct } from './structs.wgsl.js';
@@ -721,12 +722,15 @@ export const fresnelCoatFunc = wgslFn( /* wgsl */ `
 
 `, [ iorToF0Func, schlickFresnelFunc ] );
 
-// GGX Multibounce compensation using Turquin's method
-export const albedoIntegralMetallic = wgslTagFn/* wgsl */ `
+// GGX Multibounce compensation using Turquin's method. Bakes the directional albedo of the
+// reflection lobe, optionally fresnel-weighted, and optionally including the refraction lobe
+// for the full transmissive bsdf. "eta" is the incident over transmitted ior ratio.
+export const turquinIntegralFn = wgslTagFn/* wgsl */ `
 
 	fn albedo(
-		ior: f32,
+		eta: f32,
 		includeFresnel: bool,
+		includeRefraction: bool,
 		outputTarget: texture_storage_3d<r16float, write>,
 		globalId: vec3u,
 		layer: u32,
@@ -747,44 +751,64 @@ export const albedoIntegralMetallic = wgslTagFn/* wgsl */ `
 
 		let wo = vec3( sqrt( 1 - cosThetaO * cosThetaO ), 0 , cosThetaO );
 
+		let f0 = ${ iorToF0Func }( eta );
+
 		var result = 0.0;
 		for ( var x = 0u; x < GRID_SIZE; x++ ) {
 
 			for ( var y = 0u; y < GRID_SIZE; y++ ) {
 
-				// calculate the incident vector to sample
+				// calculate the half vector to sample
 				let gridPoint = vec2f( vec2u( x, y ) ) + vec2f( 0.5 );
 				let sampleUv = gridPoint / f32( GRID_SIZE );
 				let wh = ${ ggxDirectionFunc }( wo, vec2( alpha ), sampleUv );
-				var wi = - reflect( wo, wh );
 
-				// if the incident vector is below the surface then skip it
-				let NdotL = wi.z;
-				if ( NdotL <= 0.0 ) {
-
-					continue;
-
-				}
-
-				let specular = ${ specularBrdfFunc }( wo, wi, wh, vec2f( alpha ) );
-				let pdf = ${ ggxReflectionAdjustedPDFFunc }( wo, wh, vec2f( alpha ) );
 				var f = 1.0;
 				if ( includeFresnel ) {
 
 					// use the exact dielectric fresnel so the table agrees with the fresnel used
 					// for lobe sampling
-					f = ${ dielectricFresnelFunc }( dot( wo, wh ), 1.0 / ior );
+					f = ${ dielectricFresnelFunc }( dot( wo, wh ), eta );
 
 				}
 
-				var weight = 0.0;
-				if ( pdf != 0.0 ) {
+				// air-incident reflection is evaluated with schlick in bsdfEval - only the
+				// volume-incident ( TIR ) glass reflection uses the exact fresnel
+				var reflectionF = f;
+				if ( eta < 1.0 ) {
 
-					weight = 1 / pdf;
+					reflectionF = ${ schlickFresnelFunc }( dot( wo, wh ), f0 );
 
 				}
 
-				result += specular.x * NdotL * weight * f;
+				// reflection lobe - samples landing below the surface are lost
+				let wi = - reflect( wo, wh );
+				let reflectionPdf = ${ ggxReflectionAdjustedPDFFunc }( wo, wh, vec2f( alpha ) );
+				if ( wi.z > 0.0 && reflectionPdf != 0.0 ) {
+
+					let specular = ${ specularBrdfFunc }( wo, wi, wh, vec2f( alpha ) );
+					result += reflectionF * specular.x * wi.z / reflectionPdf;
+
+				}
+
+				// refraction lobe - the btdf carries its own ( 1 - F ) fresnel weight, and
+				// samples landing back above the surface are lost
+				if ( includeRefraction ) {
+
+					let wiRefract = refract( - wo, wh, eta );
+					if ( wiRefract.z < 0.0 ) {
+
+						let transmission = ${ specularBtdfFunc }( wo, wiRefract, wh, vec2f( alpha ), eta );
+						let pdf = ${ ggxRefractionAdjustedPDFFunc }( wo, wiRefract, wh, vec2f( alpha ), eta );
+						if ( pdf != 0.0 ) {
+
+							result += transmission.x * abs( wiRefract.z ) / pdf;
+
+						}
+
+					}
+
+				}
 
 			}
 


### PR DESCRIPTION
Fix #784 
Related to #777

- Extend Turquin table to include transmissive layers adding total refracted and reflected energy
- Boost transmissive lobes to compensate for energy loss
- Discard rays that scatter to the wrong hemisphere

The volume furnace test below is not _perfect_ but it's a big improvement and I expect some of the remaining loss is from rays that terminate due to the bounce limit or from loss due to discarding energy from rays entering the back side of an opaque lobe.

**TODO**
- See if we can remove the "isDead" path. Flipping rays instead? Turn below surface rays into transmissive? Turquin texture must agree.
- Opacity path not working correctly.
- Further review

### Volume Transmission

| Roughness | Before | After |
|---|---|---|
| 0 | <img width="100" src="https://github.com/user-attachments/assets/c935ee2b-0bc3-49db-ab9e-5b77ffdbbd43" /> | <img width="100" src="https://github.com/user-attachments/assets/95b6fb16-1ac0-4b13-b158-6ad6e04a853a" /> |
| 0.333 | <img width="100" src="https://github.com/user-attachments/assets/95be6cf6-b193-49cf-ba56-0b5173fe43dd" /> | <img width="100" src="https://github.com/user-attachments/assets/c0785b8d-c50d-4a5c-b6f0-bb7a0643f2f4" /> |
| 0.666 | <img width="100" src="https://github.com/user-attachments/assets/ddd73098-8a74-4104-b572-341333dee593" /> | <img width="100" src="https://github.com/user-attachments/assets/23def6c8-9dcc-46bc-93c9-286d18d90ae9" /> |
| 1 | <img width="100" src="https://github.com/user-attachments/assets/5a1bc2b9-aded-48c5-8998-2030aab96b93" /> | <img width="100" src="https://github.com/user-attachments/assets/e3e0c8a3-ec5f-44f4-98cf-3111b8c21821" /> |

### Thin Wall Transmission

| Roughness | Before | After |
|---|---|---|
| 0 | <img width="100" src="https://github.com/user-attachments/assets/dfe105c9-8d4c-41d8-91d2-dec896a9fca1" /> | <img width="100" src="https://github.com/user-attachments/assets/06b80d0a-4286-4963-83b9-39a7cb44f4ae" /> |
| 0.333 | <img width="100" src="https://github.com/user-attachments/assets/50054a1d-ba47-4c75-bfcc-37603cfbb28a" /> | <img width="100" src="https://github.com/user-attachments/assets/52a5a325-623e-48bf-b51e-336ce1010940" /> |
| 0.666 | <img width="100" src="https://github.com/user-attachments/assets/486ae239-275c-4472-b5f6-a17bc6f081dd" /> | <img width="100" src="https://github.com/user-attachments/assets/249bacc1-d8b8-4526-b4d2-79794f8b0f62" /> |
| 1 | <img width="100" src="https://github.com/user-attachments/assets/2db629a6-3f8a-4f3f-803e-1d5be27ed664" /> | <img width="100" src="https://github.com/user-attachments/assets/5a549612-8914-4bff-8ce6-7b859f78716c" /> |

### Volume Furnace Test

100 bounces

<img width="300" src="https://github.com/user-attachments/assets/6e6413a4-88f6-4bb1-881e-0ebb865375b9" />

### Thin Wall Furnace Test

10 bounces

<img width="300" src="https://github.com/user-attachments/assets/7c194e76-03d5-45e7-8e93-56b33cb6bde8" />
