### PR TITLE
WebGPUPathTracer: Adjust demo settings

### DIFF
--- a/example/aoRender.js
+++ b/example/aoRender.js
@@ -15,7 +15,7 @@ let fsQuad, target1, target2, materials;
 let samplesEl, samples, totalSamples;
 const params = {
 
-	renderScale: 1 / window.devicePixelRatio,
+	renderScale: 1,
 	radius: 2.0,
 	samplesPerFrame: 2.0,
 	accumulate: true,

--- a/example/areaLight.js
+++ b/example/areaLight.js
@@ -38,8 +38,8 @@ const params = {
 	height: 1,
 
 	// path tracer settings
-	bounces: 5,
-	renderScale: 1 / window.devicePixelRatio,
+	bounces: 15,
+	renderScale: 1,
 	filterGlossyFactor: 1,
 	tiles: 1,
 	multipleImportanceSampling: true,
@@ -145,7 +145,7 @@ async function init() {
 
 	} );
 	ptFolder.add( params, 'filterGlossyFactor', 0, 10 ).onChange( onParamsChange );
-	ptFolder.add( params, 'bounces', 1, 15, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'multipleImportanceSampling' ).onChange( onParamsChange );
 	ptFolder.close();

--- a/example/depthOfField.js
+++ b/example/depthOfField.js
@@ -30,8 +30,8 @@ const mouse = new Vector2();
 const focusPoint = new Vector3();
 const params = {
 
-	bounces: 3,
-	renderScale: 1 / window.devicePixelRatio,
+	bounces: 15,
+	renderScale: 1,
 	filterGlossyFactor: 0.5,
 	tiles: 1,
 	autoFocus: true,
@@ -155,7 +155,7 @@ async function init() {
 		pathTracer.tiles.set( value, value );
 
 	} );
-	ptFolder.add( params, 'bounces', 1, 30, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );
 
 	const cameraFolder = gui.addFolder( 'Camera' );

--- a/example/fog.js
+++ b/example/fog.js
@@ -24,7 +24,7 @@ const params = {
 
 	multipleImportanceSampling: true,
 	tiles: 2,
-	renderScale: 1 / window.devicePixelRatio,
+	renderScale: 1,
 
 	color: '#eeeeee',
 	fog: true,
@@ -32,7 +32,7 @@ const params = {
 	lightIntensity: 500,
 	lightColor: '#ffffff',
 
-	bounces: 10,
+	bounces: 15,
 
 	...getScaledSettings(),
 
@@ -117,7 +117,7 @@ async function init() {
 	// gui
 	const gui = new GUI();
 	const ptFolder = gui.addFolder( 'Path Tracer' );
-	ptFolder.add( params, 'bounces', 1, 20, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'multipleImportanceSampling' ).onChange( onParamsChange );
 	ptFolder.add( params, 'tiles', 1, 4, 1 ).onChange( value => {
 

--- a/example/furnace_test.js
+++ b/example/furnace_test.js
@@ -11,7 +11,7 @@ const options = {
 	enable: true,
 	useMegakernel: false,
 	whiteBackground: false,
-	bounces: 5,
+	bounces: 15,
 	xAxis: 'roughness',
 	yAxis: 'metalness',
 };

--- a/example/index.js
+++ b/example/index.js
@@ -86,7 +86,7 @@ const params = {
 
 	multipleImportanceSampling: true,
 	acesToneMapping: true,
-	renderScale: 1 / window.devicePixelRatio,
+	renderScale: 1,
 	tiles: 2,
 
 	model: '',
@@ -110,7 +110,7 @@ const params = {
 
 	enable: true,
 	useMegakernel: false,
-	bounces: 5,
+	bounces: 15,
 	filterGlossyFactor: 1,
 	pause: false,
 	debugBounds: false,
@@ -439,7 +439,7 @@ function buildGui() {
 		renderer.toneMapping = v ? ACESFilmicToneMapping : NoToneMapping;
 
 	} );
-	pathTracingFolder.add( params, 'bounces', 1, 20, 1 ).onChange( onParamsChange );
+	pathTracingFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 	pathTracingFolder.add( params, 'filterGlossyFactor', 0, 10 ).onChange( onParamsChange );
 	pathTracingFolder.add( params, 'renderScale', 0.1, 1.0, 0.01 ).onChange( () => {
 
@@ -722,7 +722,7 @@ async function updateModel() {
 
 	loader.setPercentage( 1 );
 	loader.setCredits( modelInfo.credit || '' );
-	params.bounces = modelInfo.bounces || 5;
+	params.bounces = modelInfo.bounces || 15;
 	params.floorColor = modelInfo.floorColor || '#111111';
 	params.floorRoughness = modelInfo.floorRoughness || 0.2;
 	params.floorMetalness = modelInfo.floorMetalness || 0.2;

--- a/example/interior.js
+++ b/example/interior.js
@@ -29,7 +29,7 @@ const params = {
 	environmentIntensity: 1,
 	emissiveIntensity: 5,
 	bounces: 20,
-	renderScale: 1 / window.devicePixelRatio,
+	renderScale: 1,
 	tiles: 2,
 	projection: 'Perspective',
 	...getScaledSettings(),
@@ -130,7 +130,7 @@ async function init() {
 		pathTracer.tiles.set( value, value );
 
 	} );
-	ptFolder.add( params, 'bounces', 1, 30, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );
 
 	const sceneFolder = gui.addFolder( 'Scene' );

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -70,7 +70,7 @@ const params = {
 	tiles: 3,
 
 	samplesPerFrame: 1,
-	bounces: 5,
+	bounces: 15,
 	filterGlossyFactor: 0.5,
 	pause: false,
 
@@ -465,7 +465,7 @@ function buildGui() {
 
 	const ptFolder = gui.addFolder( 'Path Tracing' );
 	ptFolder.add( params, 'pause' );
-	ptFolder.add( params, 'bounces', 1, 20, 1 ).onChange( () => {
+	ptFolder.add( params, 'bounces', 1, 50, 1 ).onChange( () => {
 
 		pathTracer.bounces = params.bounces;
 

--- a/example/materialBall.js
+++ b/example/materialBall.js
@@ -50,8 +50,8 @@ const params = {
 	enable: true,
 	displaySampleDensity: false,
 	multipleImportanceSampling: true,
-	bounces: 5,
-	renderScale: 1 / window.devicePixelRatio,
+	bounces: 15,
+	renderScale: 1,
 	filterGlossyFactor: 1,
 	tiles: 3,
 };
@@ -63,7 +63,7 @@ if ( window.location.hash.includes( 'transmission' ) ) {
 	params.materialProperties.transmission = 1.0;
 	params.materialProperties.color = '#ffffff';
 
-	params.bounces = 10;
+	params.bounces = 20;
 	params.tiles = 2;
 
 } else if ( window.location.hash.includes( 'iridescent' ) ) {
@@ -169,7 +169,7 @@ async function init() {
 
 	} );
 	ptFolder.add( params, 'filterGlossyFactor', 0, 10 ).onChange( onParamsChange );
-	ptFolder.add( params, 'bounces', 1, 30, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );
 
 	const matFolder1 = gui.addFolder( 'Material' );

--- a/example/materialDatabase.js
+++ b/example/materialDatabase.js
@@ -22,9 +22,9 @@ let loader, imgEl;
 const params = {
 	material: null,
 	tiles: 2,
-	bounces: 5,
+	bounces: 15,
 	multipleImportanceSampling: true,
-	renderScale: 1 / window.devicePixelRatio,
+	renderScale: 1,
 	...getScaledSettings(),
 };
 
@@ -104,7 +104,7 @@ async function init() {
 		pathTracer.tiles.set( value, value );
 
 	} );
-	ptFolder.add( params, 'bounces', 1, 30, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );
 
 	animate();

--- a/example/overlay.js
+++ b/example/overlay.js
@@ -32,8 +32,8 @@ let loader;
 const params = {
 
 	// path tracer settings
-	bounces: 5,
-	renderScale: 1 / window.devicePixelRatio,
+	bounces: 15,
+	renderScale: 1,
 	filterGlossyFactor: 1,
 	tiles: 1,
 	multipleImportanceSampling: true,
@@ -132,7 +132,7 @@ async function init() {
 
 	} );
 	ptFolder.add( params, 'filterGlossyFactor', 0, 10 ).onChange( onParamsChange );
-	ptFolder.add( params, 'bounces', 1, 15, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'multipleImportanceSampling' ).onChange( onParamsChange );
 	ptFolder.close();

--- a/example/renderVideo.js
+++ b/example/renderVideo.js
@@ -56,7 +56,7 @@ const params = {
 	record: startRecording,
 	stop: finishRecording,
 
-	bounces: 5,
+	bounces: 15,
 	samplesPerFrame: 1,
 	renderScale: 1,
 	...getScaledSettings(),
@@ -193,7 +193,7 @@ function rebuildGUI() {
 	} );
 	renderFolder.add( params, 'samples', 1, 500, 1 );
 	renderFolder.add( params, 'samplesPerFrame', 1, 10, 1 );
-	renderFolder.add( params, 'bounces', 1, 10, 1 ).onChange( regenerateScene );
+	renderFolder.add( params, 'bounces', 1, 50, 1 ).onChange( regenerateScene );
 
 }
 

--- a/example/skinnedMesh.js
+++ b/example/skinnedMesh.js
@@ -30,7 +30,7 @@ let mixer, mixerAction;
 let loader;
 const params = {
 
-	renderScale: 1 / window.devicePixelRatio,
+	renderScale: 1,
 	pause: false,
 	continuous: false,
 	stableNoise: false,

--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -43,8 +43,8 @@ let loader;
 // gui parameters
 const params = {
 	multipleImportanceSampling: true,
-	bounces: 3,
-	renderScale: 1 / window.devicePixelRatio,
+	bounces: 15,
+	renderScale: 1,
 	tiles: 2,
 	iesProfile: - 1,
 	...getScaledSettings(),
@@ -186,7 +186,7 @@ async function init() {
 		pathTracer.tiles.set( value, value );
 
 	} );
-	ptFolder.add( params, 'bounces', 1, 30, 1 ).onChange( onParamsChange );
+	ptFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 	ptFolder.add( params, 'renderScale', 0.1, 1 ).onChange( onResize );
 
 	const lightFolder = gui.addFolder( 'Spot Light' );

--- a/example/viewerTest.js
+++ b/example/viewerTest.js
@@ -34,7 +34,7 @@ const params = {
 	showAtlas: - 1,
 
 	enable: true,
-	bounces: 10,
+	bounces: 15,
 	pause: false,
 	multipleImportanceSampling: true,
 	acesToneMapping: true,
@@ -315,7 +315,7 @@ function buildGui() {
 		}
 
 	} );
-	pathTracingFolder.add( params, 'bounces', 1, 20, 1 ).onChange( onParamsChange );
+	pathTracingFolder.add( params, 'bounces', 1, 50, 1 ).onChange( onParamsChange );
 
 	pathTracingFolder.add( params, 'iterationsPerFrame', 1, 30, 1 );
 

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -40,6 +40,12 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 
 	async getSampleCountsAsync() {
 
+		if ( this.lowResMode ) {
+
+			return { min: 0, max: 0, avg: 0 };
+
+		}
+
 		const completed = this._completedSamples;
 		const progress = this._tileProgress;
 

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -7,7 +7,7 @@ export class PathTracerBackend {
 	constructor( renderer ) {
 
 		this.renderer = renderer;
-		this.bounces = 7;
+		this.bounces = 15;
 		this.lowResMode = false;
 
 		this._renderTask = null;

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -418,7 +418,7 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 			tallySampleCountsKernel,
 		} = this;
 
-		if ( ! renderer.initialized ) {
+		if ( ! renderer.initialized || this.lowResMode ) {
 
 			return { min: 0, max: 0, avg: 0 };
 

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -135,11 +135,10 @@ export class WebGPUPathTracer {
 		// written in place. reset swaps in a new object so a late measurement can't overwrite it.
 		const counts = this._lastSampleCounts;
 		const measured = await pathTracer.getSampleCountsAsync();
-		const lowResMode = pathTracer.lowResMode;
 
-		counts.min = lowResMode ? 0 : measured.min;
-		counts.max = lowResMode ? 0 : measured.max;
-		counts.avg = lowResMode ? 0 : measured.avg;
+		counts.min = measured.min;
+		counts.max = measured.max;
+		counts.avg = measured.avg;
 
 		// averaged over the whole render, and idle time counts against it
 		const elapsed = this.getRenderTime() / 1000;

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -126,34 +126,26 @@ export class WebGPUPathTracer {
 
 	}
 
-	// Per pixel sample counts across the rendered pixels. Counts vary across the image, so there is
-	// no single "sample count" - pick the field that matches the question being asked. "min" is
-	// what convergence checks want, "avg" is the headline figure to display.
-	//
-	// On the wavefront backend this dispatches a full resolution reduction and reads it back, so
-	// call it only when the numbers are needed.
+	// Per pixel sample counts. Use "min" for convergence checks, "avg" to display. Measures on the
+	// wavefront backend, so only call it when the numbers are needed.
 	async getSampleCountsAsync() {
 
 		const pathTracer = this._pathTracer;
-		const counts = await pathTracer.getSampleCountsAsync();
 
-		if ( pathTracer.lowResMode ) {
+		// written in place. reset swaps in a new object so a late measurement can't overwrite it.
+		const counts = this._lastSampleCounts;
+		const measured = await pathTracer.getSampleCountsAsync();
+		const lowResMode = pathTracer.lowResMode;
 
-			counts.min = 0;
-			counts.max = 0;
-			counts.avg = 0;
+		counts.min = lowResMode ? 0 : measured.min;
+		counts.max = lowResMode ? 0 : measured.max;
+		counts.avg = lowResMode ? 0 : measured.avg;
 
-		}
-
-		// averaged over the whole render rather than instantaneous, and "getRenderTime" counts the
-		// gaps between "renderSample" calls, so idle time drags this down
+		// averaged over the whole render, and idle time counts against it
 		const elapsed = this.getRenderTime() / 1000;
 		counts.samplesPerSecond = elapsed > 0 ? counts.avg / elapsed : 0;
 
-		// kept so the fade and the sample density overlay have something to read without measuring
-		this._lastSampleCounts = counts;
-
-		return counts;
+		return { ...counts };
 
 	}
 
@@ -519,6 +511,9 @@ export class WebGPUPathTracer {
 		this._resetTime = - 1;
 		this._fadeState = 0;
 		this._timer.update();
+
+		// a fresh object rather than a clear, so measurements still in flight detach
+		this._lastSampleCounts = { min: 0, max: 0, avg: 0, samplesPerSecond: 0 };
 
 		if ( this.stableNoise ) {
 


### PR DESCRIPTION
- Use a default of 15 bounces (Blender uses 7 but has a separate threshold for transmission, which we don't have here)
- Adjust demos to match that bounce count, render scale