### PR TITLE
Add configurable direct and indirect path-contribution clamping

### DIFF
--- a/example/basic.js
+++ b/example/basic.js
@@ -39,7 +39,6 @@ async function init() {
 
 	// path tracer
 	pathTracer = new WebGPUPathTracer( renderer );
-	pathTracer.filterGlossyFactor = 0.5;
 	pathTracer.renderScale = renderScale;
 	pathTracer.tiles.set( tiles, tiles );
 

--- a/example/depthOfField.js
+++ b/example/depthOfField.js
@@ -32,7 +32,7 @@ const params = {
 
 	bounces: 15,
 	renderScale: 1,
-	filterGlossyFactor: 0.5,
+	filterGlossyFactor: 1,
 	tiles: 1,
 	autoFocus: true,
 

--- a/example/hdr.js
+++ b/example/hdr.js
@@ -64,7 +64,6 @@ async function init() {
 
 	// path tracer
 	pathTracer = new WebGPUPathTracer( renderer );
-	pathTracer.filterGlossyFactor = 0.5;
 	pathTracer.minSamples = 1;
 	pathTracer.renderScale = params.renderScale;
 	pathTracer.tiles.set( params.tiles, params.tiles );

--- a/example/interior.js
+++ b/example/interior.js
@@ -52,7 +52,6 @@ async function init() {
 	// path tracer
 	pathTracer = new WebGPUPathTracer( renderer );
 	pathTracer.dynamicLowRes = true;
-	pathTracer.filterGlossyFactor = 0.25;
 	pathTracer.tiles.set( params.tiles, params.tiles );
 
 	// camera

--- a/example/lkg.js
+++ b/example/lkg.js
@@ -71,7 +71,7 @@ const params = {
 
 	samplesPerFrame: 1,
 	bounces: 15,
-	filterGlossyFactor: 0.5,
+	filterGlossyFactor: 1,
 	pause: false,
 
 	tiltingPreview: true,

--- a/example/materialDatabase.js
+++ b/example/materialDatabase.js
@@ -50,7 +50,6 @@ async function init() {
 	pathTracer = new WebGPUPathTracer( renderer );
 	pathTracer.multipleImportanceSampling = params.multipleImportanceSampling;
 	pathTracer.tiles.set( params.tiles, params.tiles );
-	pathTracer.filterGlossyFactor = 0.5;
 
 	// scene
 	scene = new Scene();

--- a/example/renderVideo.js
+++ b/example/renderVideo.js
@@ -78,7 +78,6 @@ async function init() {
 
 	// path tracer
 	pathTracer = new WebGPUPathTracer( renderer );
-	pathTracer.filterGlossyFactor = 0.25;
 	pathTracer.tiles.set( params.tiles, params.tiles );
 	pathTracer.renderDelay = 0;
 	pathTracer.minSamples = 1;

--- a/example/skinnedMesh.js
+++ b/example/skinnedMesh.js
@@ -56,7 +56,6 @@ async function init() {
 	pathTracer = new WebGPUPathTracer( renderer );
 	pathTracer.multipleImportanceSampling = false;
 	pathTracer.tiles.set( params.tiles, params.tiles );
-	pathTracer.filterGlossyFactor = 0.25;
 	pathTracer.minSamples = 1;
 	// keep a live low-res preview while the camera or animation is moving
 	pathTracer.dynamicLowRes = true;

--- a/example/spotLights.js
+++ b/example/spotLights.js
@@ -68,7 +68,6 @@ async function init() {
 	// path tracer
 	pathTracer = new WebGPUPathTracer( renderer );
 	pathTracer.tiles.set( params.tiles, params.tiles );
-	pathTracer.filterGlossyFactor = 0.5;
 
 	// camera
 	const aspect = window.innerWidth / window.innerHeight;

--- a/example/viewer.js
+++ b/example/viewer.js
@@ -45,8 +45,6 @@ async function init() {
 
 	// path tracer
 	pathTracer = new WebGPUPathTracer( renderer );
-	pathTracer.filterGlossyFactor = 0.5;
-	pathTracer.clampIndirect = 10;
 	pathTracer.renderScale = renderScale;
 	pathTracer.tiles.set( tiles, tiles );
 

--- a/example/viewer.js
+++ b/example/viewer.js
@@ -46,6 +46,7 @@ async function init() {
 	// path tracer
 	pathTracer = new WebGPUPathTracer( renderer );
 	pathTracer.filterGlossyFactor = 0.5;
+	pathTracer.clampIndirect = 10;
 	pathTracer.renderScale = renderScale;
 	pathTracer.tiles.set( tiles, tiles );
 

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -101,6 +101,14 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 
 	}
 
+	setClamping( direct, indirect ) {
+
+		this.kernel.clampDirect = direct;
+		this.kernel.clampIndirect = indirect;
+		this.reset();
+
+	}
+
 	setEnvironment( envMap ) {
 
 		this.envInfo.updateFrom( envMap );

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -57,6 +57,10 @@ export class PathTracerBackend {
 
 	}
 
+	setClamping( _direct, _indirect ) {
+
+	}
+
 	setEnvironment(
 		envMap,
 		envMapIntensity,

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -163,6 +163,18 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 
 	}
 
+	setClamping( direct, indirect ) {
+
+		this.rayIntersectionKernel.clampDirect = direct;
+		this.rayIntersectionKernel.clampIndirect = indirect;
+		this.hitProcessKernel.clampDirect = direct;
+		this.hitProcessKernel.clampIndirect = indirect;
+		this.lightConnectionKernel.clampDirect = direct;
+		this.lightConnectionKernel.clampIndirect = indirect;
+		this.reset();
+
+	}
+
 	setEnvironment( envMap ) {
 
 		this.envInfo.updateFrom( envMap );

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -182,6 +182,42 @@ export class WebGPUPathTracer {
 
 	}
 
+	get clampDirect() {
+
+		return this._clampDirect;
+
+	}
+
+	set clampDirect( v ) {
+
+		v = Math.max( 0, v );
+		if ( this._clampDirect !== v ) {
+
+			this._clampDirect = v;
+			this._pathTracer.setClamping( v, this._clampIndirect );
+
+		}
+
+	}
+
+	get clampIndirect() {
+
+		return this._clampIndirect;
+
+	}
+
+	set clampIndirect( v ) {
+
+		v = Math.max( 0, v );
+		if ( this._clampIndirect !== v ) {
+
+			this._clampIndirect = v;
+			this._pathTracer.setClamping( this._clampDirect, v );
+
+		}
+
+	}
+
 	// --- WebGLPathTracer compatibility stubs ---
 	// These mirror the WebGLPathTracer API surface so existing examples run unchanged.
 	// They are currently no-ops on the WebGPU path tracer until the corresponding
@@ -224,6 +260,7 @@ export class WebGPUPathTracer {
 		this._pathTracer.setMultipleImportanceSampling( this.multipleImportanceSampling );
 		this._pathTracer.setTransmissiveBackground( this._transmissiveBackground );
 		this._pathTracer.setFilterGlossy( this._filterGlossyFactor );
+		this._pathTracer.setClamping( this._clampDirect, this._clampIndirect );
 		this.setCamera( this.camera );
 		this.updateEnvironment();
 
@@ -265,6 +302,8 @@ export class WebGPUPathTracer {
 		this.pause = false;
 
 		this.filterGlossyFactor = 1;
+		this._clampDirect = 0;
+		this._clampIndirect = 0;
 
 		// WebGLPathTracer compatibility stubs (see getters above)
 		// TOOD: implement these correctly

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -303,7 +303,7 @@ export class WebGPUPathTracer {
 
 		this.filterGlossyFactor = 1;
 		this._clampDirect = 0;
-		this._clampIndirect = 0;
+		this._clampIndirect = 10;
 
 		// WebGLPathTracer compatibility stubs (see getters above)
 		// TOOD: implement these correctly

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -32,7 +32,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			misEnabled: uniform( 1, 'uint' ),
 			filterGlossy: uniform( 1 ),
 			clampDirect: uniform( 0 ),
-			clampIndirect: uniform( 0 ),
+			clampIndirect: uniform( 10 ),
 
 			backgroundInfo: { value: null },
 
@@ -163,7 +163,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						}
 
 						// emission
-						let emission = ${ clampPathContributionFunc }( throughputColor * surface.emission, bounce, clampDirect, clampIndirect );
+						let emission = ${ clampPathContributionFunc }( throughputColor * surface.emission, bounce + 1u, clampDirect, clampIndirect );
 						resultColor += vec4f( emission, 0.0 );
 
 						// next event estimation
@@ -249,7 +249,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 							}
 
 							let environment = ${ sampleEnvColor }( ray.direction ).rgb * throughputColor * misWeight;
-							let contribution = ${ clampPathContributionFunc }( environment, bounce, clampDirect, clampIndirect );
+							let contribution = ${ clampPathContributionFunc }( environment, bounce + 1u, clampDirect, clampIndirect );
 							resultColor += vec4f( contribution, 0.0 );
 
 						} else {
@@ -261,7 +261,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 							if ( bounce == 0u ) {
 
 								// sample the background directly if this is the primary ray
-								let background = ${ clampPathContributionFunc }( bg.a * bg.rgb, bounce, clampDirect, clampIndirect );
+								let background = ${ clampPathContributionFunc }( bg.a * bg.rgb, bounce + 1u, clampDirect, clampIndirect );
 								resultColor = vec4f( background, bg.a );
 
 							} else {
@@ -274,7 +274,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 								if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
 									// display the env map through transmissive surfaces
-									let background = ${ clampPathContributionFunc }( env.rgb * throughputColor, bounce, clampDirect, clampIndirect );
+									let background = ${ clampPathContributionFunc }( env.rgb * throughputColor, bounce + 1u, clampDirect, clampIndirect );
 									resultColor = vec4f(
 										resultColor.rgb + background,
 										1.0,
@@ -283,7 +283,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 								} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
 
 									// fade the background by the throughput color average
-									let background = ${ clampPathContributionFunc }( bg.a * bg.rgb * throughputColor, bounce, clampDirect, clampIndirect );
+									let background = ${ clampPathContributionFunc }( bg.a * bg.rgb * throughputColor, bounce + 1u, clampDirect, clampIndirect );
 									resultColor = vec4f(
 										resultColor.rgb + background,
 										1.0 - transparency,
@@ -293,7 +293,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 									// fade the background by the throughput color average, mixing in env lighting
 									var light = mix( env.rgb, bg.rgb, bg.a );
-									let background = ${ clampPathContributionFunc }( light * throughputColor, bounce, clampDirect, clampIndirect );
+									let background = ${ clampPathContributionFunc }( light * throughputColor, bounce + 1u, clampDirect, clampIndirect );
 									resultColor = vec4f(
 										resultColor.rgb + background,
 										1.0 - transparency,

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -4,7 +4,7 @@ import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
 import { rngInit, rngNextBounce, rand1, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_BACKGROUND_SAMPLE, RNG_INDEX_DIRECT_LIGHT_SAMPLE, RNG_INDEX_RUSSIAN_ROULETTE } from '../nodes/random.wgsl.js';
 import { misHeuristicFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
 import { proxy, proxyFn, rayStruct, wgslTagFn } from 'three-mesh-bvh/webgpu';
-import { isTerminatingScatterFunc, offsetRayOriginFunc } from '../nodes/utils.wgsl.js';
+import { clampPathContributionFunc, isTerminatingScatterFunc, offsetRayOriginFunc } from '../nodes/utils.wgsl.js';
 import { transmissionAttenuationFunc } from '../nodes/material.wgsl.js';
 import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_OVERLAY, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../constants.js';
 
@@ -31,6 +31,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			bounces: uniform( 5 ),
 			misEnabled: uniform( 1, 'uint' ),
 			filterGlossy: uniform( 1 ),
+			clampDirect: uniform( 0 ),
+			clampIndirect: uniform( 0 ),
 
 			backgroundInfo: { value: null },
 
@@ -74,6 +76,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				bounces: u32,
 				misEnabled: u32,
 				filterGlossy: f32,
+				clampDirect: f32,
+				clampIndirect: f32,
 
 				transmissiveBackground: u32,
 
@@ -159,7 +163,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						}
 
 						// emission
-						resultColor += vec4f( throughputColor * surface.emission, 0.0 );
+						let emission = ${ clampPathContributionFunc }( throughputColor * surface.emission, bounce, clampDirect, clampIndirect );
+						resultColor += vec4f( emission, 0.0 );
 
 						// next event estimation
 						// importance-sample the environment, MIS-weighted against the bsdf pdf.
@@ -179,7 +184,9 @@ export class PathTracerMegaKernel extends ComputeKernel {
 								if ( ! ${ raycastFirstHitFn }( shadowRay, &shadowHit ) ) {
 
 									let misWeight = ${ misHeuristicFn }( envSample.pdf, evalRec.pdf );
-									resultColor += vec4f( throughputColor * envSample.color * evalRec.color * misWeight / envSample.pdf, 0.0 );
+									let directLight = throughputColor * envSample.color * evalRec.color * misWeight / envSample.pdf;
+									let contribution = ${ clampPathContributionFunc }( directLight, bounce + 1u, clampDirect, clampIndirect );
+									resultColor += vec4f( contribution, 0.0 );
 
 								}
 
@@ -241,7 +248,9 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 							}
 
-							resultColor += ${ sampleEnvColor }( ray.direction ) * vec4f( throughputColor * misWeight, 0.0 );
+							let environment = ${ sampleEnvColor }( ray.direction ).rgb * throughputColor * misWeight;
+							let contribution = ${ clampPathContributionFunc }( environment, bounce, clampDirect, clampIndirect );
+							resultColor += vec4f( contribution, 0.0 );
 
 						} else {
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -261,7 +261,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 							if ( bounce == 0u ) {
 
 								// sample the background directly if this is the primary ray
-								resultColor = vec4f( bg.a * bg.rgb, bg.a );
+								let background = ${ clampPathContributionFunc }( bg.a * bg.rgb, bounce, clampDirect, clampIndirect );
+								resultColor = vec4f( background, bg.a );
 
 							} else {
 
@@ -273,16 +274,18 @@ export class PathTracerMegaKernel extends ComputeKernel {
 								if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
 									// display the env map through transmissive surfaces
+									let background = ${ clampPathContributionFunc }( env.rgb * throughputColor, bounce, clampDirect, clampIndirect );
 									resultColor = vec4f(
-										resultColor.rgb + env.rgb * throughputColor,
+										resultColor.rgb + background,
 										1.0,
 									);
 
 								} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
 
 									// fade the background by the throughput color average
+									let background = ${ clampPathContributionFunc }( bg.a * bg.rgb * throughputColor, bounce, clampDirect, clampIndirect );
 									resultColor = vec4f(
-										resultColor.rgb + bg.a * bg.rgb * throughputColor,
+										resultColor.rgb + background,
 										1.0 - transparency,
 									);
 
@@ -290,8 +293,9 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 									// fade the background by the throughput color average, mixing in env lighting
 									var light = mix( env.rgb, bg.rgb, bg.a );
+									let background = ${ clampPathContributionFunc }( light * throughputColor, bounce, clampDirect, clampIndirect );
 									resultColor = vec4f(
-										resultColor.rgb + light * throughputColor,
+										resultColor.rgb + background,
 										1.0 - transparency,
 									);
 

--- a/src/webgpu/compute/wavefront/LightConnectionKernel.js
+++ b/src/webgpu/compute/wavefront/LightConnectionKernel.js
@@ -4,7 +4,7 @@ import { uniform, storage, globalId, texture, sampler } from 'three/tsl';
 import { hitQueueStruct } from './structs.js';
 import { proxy, proxyFn, wgslTagFn, rayStruct } from 'three-mesh-bvh/webgpu';
 import { misHeuristicFn } from '../../nodes/sampling.wgsl.js';
-import { offsetRayOriginFunc } from '../../nodes/utils.wgsl.js';
+import { clampPathContributionFunc, offsetRayOriginFunc } from '../../nodes/utils.wgsl.js';
 import { rngInit, rand2, RNG_INDEX_DIRECT_LIGHT_SAMPLE } from '../../nodes/random.wgsl.js';
 import { transmissionAttenuationFunc } from '../../nodes/material.wgsl.js';
 
@@ -20,6 +20,8 @@ export class LightConnectionKernel extends ComputeKernel {
 			// settings
 			misEnabled: uniform( 1, 'uint' ),
 			filterGlossy: uniform( 1 ),
+			clampDirect: uniform( 0 ),
+			clampIndirect: uniform( 0 ),
 
 			// rays
 			hitQueue: storage( new StorageBufferAttribute( 1, 1 ), hitQueueStruct ),
@@ -46,6 +48,8 @@ export class LightConnectionKernel extends ComputeKernel {
 				// settings
 				misEnabled: u32,
 				filterGlossy: f32,
+				clampDirect: f32,
+				clampIndirect: f32,
 
 				globalId: vec3u
 			) -> void {
@@ -119,7 +123,9 @@ export class LightConnectionKernel extends ComputeKernel {
 						let misWeight = ${ misHeuristicFn }( envSample.pdf, evalRec.pdf );
 
 						// deposit the contribution in place; ProcessHits reads this augmented resultColor
-						hitQueue.elements[ hitIndex ].resultColor += vec4f( throughputColor * envSample.color * evalRec.color * misWeight / envSample.pdf, 0.0 );
+						let directLight = throughputColor * envSample.color * evalRec.color * misWeight / envSample.pdf;
+						let contribution = ${ clampPathContributionFunc }( directLight, input.currentBounce + 1u, clampDirect, clampIndirect );
+						hitQueue.elements[ hitIndex ].resultColor += vec4f( contribution, 0.0 );
 
 					}
 

--- a/src/webgpu/compute/wavefront/LightConnectionKernel.js
+++ b/src/webgpu/compute/wavefront/LightConnectionKernel.js
@@ -21,7 +21,7 @@ export class LightConnectionKernel extends ComputeKernel {
 			misEnabled: uniform( 1, 'uint' ),
 			filterGlossy: uniform( 1 ),
 			clampDirect: uniform( 0 ),
-			clampIndirect: uniform( 0 ),
+			clampIndirect: uniform( 10 ),
 
 			// rays
 			hitQueue: storage( new StorageBufferAttribute( 1, 1 ), hitQueueStruct ),

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -5,7 +5,7 @@ import { rayQueueAtomicStruct, hitQueueStruct } from './structs.js';
 import { SAMPLE_COUNT_MASK, SAMPLE_DISPATCHED_FLAG } from '../../constants.js';
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
-import { isTerminatingScatterFunc, offsetRayOriginFunc } from '../../nodes/utils.wgsl.js';
+import { clampPathContributionFunc, isTerminatingScatterFunc, offsetRayOriginFunc } from '../../nodes/utils.wgsl.js';
 import { rngInit, rand1, RNG_INDEX_RUSSIAN_ROULETTE } from '../../nodes/random.wgsl.js';
 import { transmissionAttenuationFunc } from '../../nodes/material.wgsl.js';
 
@@ -26,6 +26,8 @@ export class ProcessHitsKernel extends ComputeKernel {
 			smoothNormals: uniform( 1 ),
 			bounces: uniform( 1 ),
 			filterGlossy: uniform( 1 ),
+			clampDirect: uniform( 0 ),
+			clampIndirect: uniform( 0 ),
 
 			// rays
 			rayQueue: storage( new StorageBufferAttribute( 1, 1 ), rayQueueAtomicStruct ),
@@ -48,6 +50,8 @@ export class ProcessHitsKernel extends ComputeKernel {
 				smoothNormals: u32,
 				bounces: u32,
 				filterGlossy: f32,
+				clampDirect: f32,
+				clampIndirect: f32,
 
 				globalId: vec3u
 			) -> void {
@@ -106,7 +110,8 @@ export class ProcessHitsKernel extends ComputeKernel {
 				}
 
 				// emission
-				var resultColor = input.resultColor + vec4f( throughputColor * surface.emission, 0.0 );
+				let emission = ${ clampPathContributionFunc }( throughputColor * surface.emission, input.currentBounce, clampDirect, clampIndirect );
+				var resultColor = input.resultColor + vec4f( emission, 0.0 );
 				if ( isMatte ) {
 
 					resultColor = vec4f( 0.0 );

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -27,7 +27,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 			bounces: uniform( 1 ),
 			filterGlossy: uniform( 1 ),
 			clampDirect: uniform( 0 ),
-			clampIndirect: uniform( 0 ),
+			clampIndirect: uniform( 10 ),
 
 			// rays
 			rayQueue: storage( new StorageBufferAttribute( 1, 1 ), rayQueueAtomicStruct ),
@@ -110,7 +110,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 				}
 
 				// emission
-				let emission = ${ clampPathContributionFunc }( throughputColor * surface.emission, input.currentBounce, clampDirect, clampIndirect );
+				let emission = ${ clampPathContributionFunc }( throughputColor * surface.emission, input.currentBounce + 1u, clampDirect, clampIndirect );
 				var resultColor = input.resultColor + vec4f( emission, 0.0 );
 				if ( isMatte ) {
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -125,7 +125,8 @@ export class RayIntersectionKernel extends ComputeKernel {
 						if ( input.currentBounce == 0u ) {
 
 							// sample the background directly if this is the primary ray
-							resultColor = vec4f( bg.a * bg.rgb, bg.a );
+							let background = ${ clampPathContributionFunc }( bg.a * bg.rgb, input.currentBounce, clampDirect, clampIndirect );
+							resultColor = vec4f( background, bg.a );
 
 						} else {
 
@@ -137,16 +138,18 @@ export class RayIntersectionKernel extends ComputeKernel {
 							if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
 								// display the env map through transmissive surfaces
+								let background = ${ clampPathContributionFunc }( env.rgb * input.throughputColor, input.currentBounce, clampDirect, clampIndirect );
 								resultColor = vec4f(
-									resultColor.rgb + env.rgb * input.throughputColor,
+									resultColor.rgb + background,
 									1.0,
 								);
 
 							} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
 
 								// fade the background by the throughput color average
+								let background = ${ clampPathContributionFunc }( bg.a * bg.rgb * input.throughputColor, input.currentBounce, clampDirect, clampIndirect );
 								resultColor = vec4f(
-									resultColor.rgb + bg.a * bg.rgb * input.throughputColor,
+									resultColor.rgb + background,
 									1.0 - transparency,
 								);
 
@@ -154,8 +157,9 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 								// fade the background by the throughput color average, mixing in env lighting
 								var light = mix( env.rgb, bg.rgb, bg.a );
+								let background = ${ clampPathContributionFunc }( light * input.throughputColor, input.currentBounce, clampDirect, clampIndirect );
 								resultColor = vec4f(
-									resultColor.rgb + light * input.throughputColor,
+									resultColor.rgb + background,
 									1.0 - transparency,
 								);
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -7,6 +7,7 @@ import { SAMPLE_COUNT_MASK, SAMPLE_DISPATCHED_FLAG } from '../../constants.js';
 import { proxy, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { misHeuristicFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
 import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_OVERLAY, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../../constants.js';
+import { clampPathContributionFunc } from '../../nodes/utils.wgsl.js';
 
 export class RayIntersectionKernel extends ComputeKernel {
 
@@ -28,6 +29,8 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 			// settings
 			misEnabled: uniform( 1, 'uint' ),
+			clampDirect: uniform( 0 ),
+			clampIndirect: uniform( 0 ),
 
 			transmissiveBackground: uniform( TRANSMISSIVE_BACKGROUND_OVERLAY ),
 
@@ -48,6 +51,8 @@ export class RayIntersectionKernel extends ComputeKernel {
 			fn compute(
 				// settings
 				misEnabled: u32,
+				clampDirect: f32,
+				clampIndirect: f32,
 
 				transmissiveBackground: u32,
 
@@ -107,7 +112,9 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 						}
 
-						resultColor += ${ sampleEnvColor }( input.direction ) * vec4f( input.throughputColor * misWeight, 0.0 );
+						let environment = ${ sampleEnvColor }( input.direction ).rgb * input.throughputColor * misWeight;
+						let contribution = ${ clampPathContributionFunc }( environment, input.currentBounce, clampDirect, clampIndirect );
+						resultColor += vec4f( contribution, 0.0 );
 
 					} else {
 

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -30,7 +30,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 			// settings
 			misEnabled: uniform( 1, 'uint' ),
 			clampDirect: uniform( 0 ),
-			clampIndirect: uniform( 0 ),
+			clampIndirect: uniform( 10 ),
 
 			transmissiveBackground: uniform( TRANSMISSIVE_BACKGROUND_OVERLAY ),
 
@@ -113,7 +113,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 						}
 
 						let environment = ${ sampleEnvColor }( input.direction ).rgb * input.throughputColor * misWeight;
-						let contribution = ${ clampPathContributionFunc }( environment, input.currentBounce, clampDirect, clampIndirect );
+						let contribution = ${ clampPathContributionFunc }( environment, input.currentBounce + 1u, clampDirect, clampIndirect );
 						resultColor += vec4f( contribution, 0.0 );
 
 					} else {
@@ -125,7 +125,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 						if ( input.currentBounce == 0u ) {
 
 							// sample the background directly if this is the primary ray
-							let background = ${ clampPathContributionFunc }( bg.a * bg.rgb, input.currentBounce, clampDirect, clampIndirect );
+							let background = ${ clampPathContributionFunc }( bg.a * bg.rgb, input.currentBounce + 1u, clampDirect, clampIndirect );
 							resultColor = vec4f( background, bg.a );
 
 						} else {
@@ -138,7 +138,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 							if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
 								// display the env map through transmissive surfaces
-								let background = ${ clampPathContributionFunc }( env.rgb * input.throughputColor, input.currentBounce, clampDirect, clampIndirect );
+								let background = ${ clampPathContributionFunc }( env.rgb * input.throughputColor, input.currentBounce + 1u, clampDirect, clampIndirect );
 								resultColor = vec4f(
 									resultColor.rgb + background,
 									1.0,
@@ -147,7 +147,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 							} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
 
 								// fade the background by the throughput color average
-								let background = ${ clampPathContributionFunc }( bg.a * bg.rgb * input.throughputColor, input.currentBounce, clampDirect, clampIndirect );
+								let background = ${ clampPathContributionFunc }( bg.a * bg.rgb * input.throughputColor, input.currentBounce + 1u, clampDirect, clampIndirect );
 								resultColor = vec4f(
 									resultColor.rgb + background,
 									1.0 - transparency,
@@ -157,7 +157,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 								// fade the background by the throughput color average, mixing in env lighting
 								var light = mix( env.rgb, bg.rgb, bg.a );
-								let background = ${ clampPathContributionFunc }( light * input.throughputColor, input.currentBounce, clampDirect, clampIndirect );
+								let background = ${ clampPathContributionFunc }( light * input.throughputColor, input.currentBounce + 1u, clampDirect, clampIndirect );
 								resultColor = vec4f(
 									resultColor.rgb + background,
 									1.0 - transparency,

--- a/src/webgpu/nodes/utils.wgsl.js
+++ b/src/webgpu/nodes/utils.wgsl.js
@@ -203,6 +203,37 @@ export const isTerminatingScatterFunc = wgslFn( /* wgsl */ `
 
 `, [ scatterRecordStruct ] );
 
+// Clamp individual light-path contributions by luminance while preserving chromaticity.
+export const clampPathContributionFunc = wgslFn( /* wgsl */ `
+
+	fn clampPathContribution( contribution: vec3f, pathDepth: u32, clampDirect: f32, clampIndirect: f32 ) -> vec3f {
+
+		if ( pathDepth == 0u ) {
+
+			return contribution;
+
+		}
+
+		let limit = select( clampIndirect, clampDirect, pathDepth == 1u );
+		if ( limit <= 0.0 ) {
+
+			return contribution;
+
+		}
+
+		let luminance = dot( max( contribution, vec3f( 0.0 ) ), vec3f( 0.2126, 0.7152, 0.0722 ) );
+		if ( luminance > limit ) {
+
+			return contribution * ( limit / luminance );
+
+		}
+
+		return contribution;
+
+	}
+
+` );
+
 export const applyWrapFunc = wgslFn( /* wgsl */ `
 
 	fn applyWrap( v: f32, wrapMode: i32 ) -> f32 {

--- a/src/webgpu/nodes/utils.wgsl.js
+++ b/src/webgpu/nodes/utils.wgsl.js
@@ -208,13 +208,7 @@ export const clampPathContributionFunc = wgslFn( /* wgsl */ `
 
 	fn clampPathContribution( contribution: vec3f, pathDepth: u32, clampDirect: f32, clampIndirect: f32 ) -> vec3f {
 
-		if ( pathDepth == 0u ) {
-
-			return contribution;
-
-		}
-
-		let limit = select( clampIndirect, clampDirect, pathDepth == 1u ) * 3.0;
+		let limit = select( clampIndirect, clampDirect, pathDepth <= 1u ) * 3.0;
 		if ( limit <= 0.0 ) {
 
 			return contribution;

--- a/src/webgpu/nodes/utils.wgsl.js
+++ b/src/webgpu/nodes/utils.wgsl.js
@@ -203,7 +203,7 @@ export const isTerminatingScatterFunc = wgslFn( /* wgsl */ `
 
 `, [ scatterRecordStruct ] );
 
-// Clamp individual light-path contributions by luminance while preserving chromaticity.
+// Clamp individual light-path contributions using Cycles' RGB sum while preserving chromaticity.
 export const clampPathContributionFunc = wgslFn( /* wgsl */ `
 
 	fn clampPathContribution( contribution: vec3f, pathDepth: u32, clampDirect: f32, clampIndirect: f32 ) -> vec3f {
@@ -214,17 +214,17 @@ export const clampPathContributionFunc = wgslFn( /* wgsl */ `
 
 		}
 
-		let limit = select( clampIndirect, clampDirect, pathDepth == 1u );
+		let limit = select( clampIndirect, clampDirect, pathDepth == 1u ) * 3.0;
 		if ( limit <= 0.0 ) {
 
 			return contribution;
 
 		}
 
-		let luminance = dot( max( contribution, vec3f( 0.0 ) ), vec3f( 0.2126, 0.7152, 0.0722 ) );
-		if ( luminance > limit ) {
+		let strength = dot( abs( contribution ), vec3f( 1.0 ) );
+		if ( strength > limit ) {
 
-			return contribution * ( limit / luminance );
+			return contribution * ( limit / strength );
 
 		}
 


### PR DESCRIPTION
## Description

I retested the firefly noise issue using the mis branch, which includes the merged filterGlossy code, and found that the noise was not eliminated. I then added clamping for both direct and indirect light; however, I noticed that this only reduced the brightness of the noise rather than removing it completely.

I submitted these changes as a mitigation for the firefly noise, and I will leave it to your discretion whether to merge this PR.

## Changes

- Add `clampDirect` and `clampIndirect` settings.

- Propagate the settings through both WaveFront and MegaKernel backends.

- Clamp contributions using `abs(R) + abs(G) + abs(B)`.

- Normalize limits by `3.0`, matching Cycles' user-facing threshold semantics.

- Preserve chromaticity by uniformly scaling RGB contributions.

- Apply clamping to environment lighting, BSDF environment misses, and emissive path contributions.

- Keep clamping disabled by default.

- Enable `clampIndirect = 10` in the WebGPU viewer example.

## Trade-offs

Contribution clamping introduces bias and may suppress very bright caustics or legitimate high-energy indirect lighting. Set the limits to `0` to disable clamping.

<img width="400" height="260" alt="image" src="https://github.com/user-attachments/assets/5ac3b86f-16e4-4f65-b472-de14f1ee4f28" />
