### PR TITLE
fix(webgpu): stop atlas repacks when the texture set has not changed

### DIFF
--- a/src/webgpu/AtlasTexture.js
+++ b/src/webgpu/AtlasTexture.js
@@ -232,6 +232,15 @@ export class AtlasTexture {
 
 		}
 
+		// same textures in a different order: keep the existing
+		// placements and permute the per-index info to the new order
+		// instead of repacking (and re-uploading) every texture
+		if ( this._tryPermuteTextureInfo( textures ) ) {
+
+			return;
+
+		}
+
 		// calculate the maximum dimension of the atlas
 		let maxDim = textures.reduce( ( v, t ) => Math.max( v, t.width, t.height ), 1 );
 		maxDim = Math.min( MAX_TEXTURE_SIZE, maxDim );
@@ -290,6 +299,66 @@ export class AtlasTexture {
 
 		}
 
+		return true;
+
+	}
+
+	// Returns true (after rewriting this.hashes / this.textureInfo) when
+	// `textures` is a permutation of the packed set, i.e. every hash in the
+	// new order matches an unused hash of the packed one. Material traversal
+	// order is not stable across edits that replace material instances, but
+	// the texture *set* is — repacking those identical sources only re-blits
+	// the same texels into the same rects.
+	_tryPermuteTextureInfo( textures ) {
+
+		const hashes = this.hashes;
+		if ( hashes.length !== textures.length ) {
+
+			return false;
+
+		}
+
+		const slotsByHash = new Map();
+		for ( let i = 0, l = hashes.length; i < l; i ++ ) {
+
+			const hash = hashes[ i ];
+			if ( ! slotsByHash.has( hash ) ) {
+
+				slotsByHash.set( hash, [] );
+
+			}
+
+			slotsByHash.get( hash ).push( i );
+
+		}
+
+		const newHashes = new Array( textures.length );
+		const permutation = new Array( textures.length );
+		for ( let i = 0, l = textures.length; i < l; i ++ ) {
+
+			const hash = getTextureHash( textures[ i ] );
+			newHashes[ i ] = hash;
+
+			const slots = slotsByHash.get( hash );
+			if ( slots === undefined || slots.length === 0 ) {
+
+				// a texture we have not packed — repack
+				return false;
+
+			}
+
+			permutation[ i ] = slots.shift();
+
+		}
+
+		const previousInfo = this.textureInfo.slice();
+		for ( let i = 0, l = permutation.length; i < l; i ++ ) {
+
+			this.textureInfo[ i ] = previousInfo[ permutation[ i ] ];
+
+		}
+
+		this.hashes = newHashes;
 		return true;
 
 	}
@@ -409,6 +478,19 @@ export class AtlasTexture {
 
 		}
 
+		// `texture.needsUpdate = true` on the clones below also bumps the
+		// version of the *shared* source, and getTextureHash() hashes that
+		// value. Save the versions so the blit does not invalidate the
+		// hashes this atlas (or another atlas over the same sources) just
+		// computed. WebGPU uploads are gated per texture.version, so the
+		// clones still upload.
+		const prevSourceVersions = new Array( textures.length );
+		for ( let i = 0, l = textures.length; i < l; i ++ ) {
+
+			prevSourceVersions[ i ] = textures[ i ].source.version;
+
+		}
+
 		for ( let i = 0, l = textures.length; i < l; i ++ ) {
 
 			const { x, y, w, h, page } = placements[ i ];
@@ -428,6 +510,12 @@ export class AtlasTexture {
 			quadMesh.render( renderer );
 
 			texture.dispose();
+
+		}
+
+		for ( let i = 0, l = textures.length; i < l; i ++ ) {
+
+			textures[ i ].source.version = prevSourceVersions[ i ];
 
 		}
 

--- a/test/AtlasTexture.test.js
+++ b/test/AtlasTexture.test.js
@@ -1,0 +1,136 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Texture, Color } from 'three/webgpu';
+import { AtlasTexture } from '../src/webgpu/AtlasTexture.js';
+
+function makeTexture( width = 2, height = 2 ) {
+
+	const texture = new Texture( { width, height, data: null } );
+	texture.name = `tex-${ texture.uuid.slice( 0, 8 ) }`;
+	return texture;
+
+}
+
+// minimal renderer double: _renderTextures only drives renderer state around
+// the blit loop, the quad mesh render is stubbed separately per test
+function makeFakeRenderer() {
+
+	return {
+		toneMapping: 0,
+		autoClear: true,
+		getRenderTarget: () => null,
+		getScissorTest: () => false,
+		getClearAlpha: () => 1,
+		getClearColor: ( c ) => c.copy( new Color() ),
+		setScissorTest: () => {},
+		setClearColor: () => {},
+		setRenderTarget: () => {},
+		clear: () => {},
+	};
+
+}
+
+function stubPackAndRender( atlas, placements ) {
+
+	let repacks = 0;
+	atlas._packTextures = () => {
+
+		repacks ++;
+		return { placements: placements.map( p => ( { ...p } ) ), pageCount: 1 };
+
+	};
+
+	atlas._renderTextures = () => {};
+
+	return () => repacks;
+
+}
+
+test( 'reordered textures reuse placements instead of repacking', () => {
+
+	const atlas = new AtlasTexture();
+	const t1 = makeTexture();
+	const t2 = makeTexture();
+	const getRepacks = stubPackAndRender( atlas, [
+		{ x: 0, y: 0, w: 2, h: 2, page: 0 },
+		{ x: 2, y: 0, w: 2, h: 2, page: 0 },
+	] );
+
+	atlas.setTextures( makeFakeRenderer(), [ t1, t2 ] );
+	assert.equal( getRepacks(), 1 );
+	const infoAfterPack = atlas.textureInfo.slice();
+	assert.notEqual( infoAfterPack[ 0 ], infoAfterPack[ 1 ] );
+
+	// same two textures, swapped order: must not repack, must permute info
+	atlas.setTextures( makeFakeRenderer(), [ t2, t1 ] );
+	assert.equal( getRepacks(), 1, 'reordering must not repack' );
+	assert.equal( atlas.textureInfo[ 0 ], infoAfterPack[ 1 ], 'info follows the texture' );
+	assert.equal( atlas.textureInfo[ 1 ], infoAfterPack[ 0 ], 'info follows the texture' );
+
+	// and a third call with the original order still early-outs via the
+	// positional hash check
+	atlas.setTextures( makeFakeRenderer(), [ t1, t2 ] );
+	assert.equal( getRepacks(), 1 );
+	assert.equal( atlas.textureInfo[ 0 ], infoAfterPack[ 0 ] );
+	assert.equal( atlas.textureInfo[ 1 ], infoAfterPack[ 1 ] );
+
+} );
+
+test( 'a genuinely changed texture still repacks', () => {
+
+	const atlas = new AtlasTexture();
+	const t1 = makeTexture();
+	const t2 = makeTexture();
+	const getRepacks = stubPackAndRender( atlas, [
+		{ x: 0, y: 0, w: 2, h: 2, page: 0 },
+		{ x: 2, y: 0, w: 2, h: 2, page: 0 },
+	] );
+
+	atlas.setTextures( makeFakeRenderer(), [ t1, t2 ] );
+	assert.equal( getRepacks(), 1 );
+
+	// reordered but one source was genuinely edited (version bumped)
+	t2.needsUpdate = true;
+	atlas.setTextures( makeFakeRenderer(), [ t2, t1 ] );
+	assert.equal( getRepacks(), 2, 'edited source must repack' );
+
+	// a different texture set must repack too
+	const t3 = makeTexture();
+	atlas.setTextures( makeFakeRenderer(), [ t1, t3 ] );
+	assert.equal( getRepacks(), 3 );
+
+} );
+
+test( 'blitting does not bump the shared source version', async () => {
+
+	const atlas = new AtlasTexture();
+	const t1 = makeTexture();
+	const t2 = makeTexture();
+
+	// real _renderTextures, stubbed quad render and fake renderer state
+	atlas.quadMesh.render = () => {};
+
+	let blits = 0;
+	const originalRenderTextures = atlas._renderTextures.bind( atlas );
+	atlas._renderTextures = ( ...args ) => {
+
+		blits ++;
+		return originalRenderTextures( ...args );
+
+	};
+
+	const placements = [
+		{ x: 0, y: 0, w: 2, h: 2, page: 0 },
+		{ x: 2, y: 0, w: 2, h: 2, page: 0 },
+	];
+	atlas._packTextures = () => ( { placements, pageCount: 1 } );
+
+	const v1 = t1.source.version;
+	const v2 = t2.source.version;
+	atlas.setTextures( makeFakeRenderer(), [ t1, t2 ] );
+
+	assert.equal( blits, 1 );
+	assert.equal( t1.source.version, v1, 'shared source version must be preserved' );
+	assert.equal( t2.source.version, v2, 'shared source version must be preserved' );
+
+} );


### PR DESCRIPTION
Fixes #826 — repeated `updateMaterials()` calls with unchanged textures now hit an early out in `setTextures()` instead of repacking (and re-uploading) everything.

Two independent causes, both described in the issue:

**1 — the blit dirtied the shared source.** `_renderTextures()` sets `needsUpdate = true` on clones that share each texture's `source`; that bumps the shared `source.version`, which is exactly what `getTextureHash()` hashes. Every blit invalidated the hashes this atlas (or a second atlas over the same sources) had just stored, so the next call repacked again, forever. The fix saves each `source.version` before the blit loop and restores it after. This is safe on the WebGPU renderer because uploads there are gated per `texture.version` (see `WebGPUTextureUtils.updateTexture` → `textureData.version = texture.version`), not per source — the clones still upload.

**2 — the hash comparison was positional.** Texture order follows material traversal order, which jumps whenever material instances are replaced (each replacement gets a fresh uuid and the `materials.sort` in `updateMaterialsMap()` reshuffles slots). When the incoming list is a permutation of the packed set — same hashes, different order — the new `_tryPermuteTextureInfo()` reuses the existing placements and permutes `textureInfo` to the new order, so no page is re-packed and no texel re-blitted. A genuinely changed source (different `source.version`) or a different set still takes the full repack path.

I left the `uuid` sort in `updateMaterialsMap()` untouched — the permutation early-out makes the atlas robust to traversal-order instability regardless of its source, and the sort keeps material index assignment deterministic.

## Test plan

Added `test/AtlasTexture.test.js` (plain `node --test`, no GPU needed):

- reordered textures reuse placements instead of repacking — asserts the repack counter does not move and `textureInfo` follows each texture to its new index;
- a genuinely changed texture still repacks — `needsUpdate` on one source and a swapped-in third texture both take the repack path;
- blitting does not bump the shared source version — runs the real `_renderTextures` against a fake renderer and asserts both `source.version`s are unchanged.

Differential: on `webgpu/lights` without the fix, the first and third tests fail (repack happens; version bumps); with the fix all three pass (`node --test test/AtlasTexture.test.js` → 3/3). ESLint clean on both touched files.
