### PR TITLE
WebGPU: stop repacking the texture atlas when only the order changed

### DIFF
--- a/src/webgpu/AtlasTexture.js
+++ b/src/webgpu/AtlasTexture.js
@@ -218,6 +218,7 @@ export class AtlasTexture {
 		this.textureInfo = [ new Vector4() ];
 
 		this.hashes = [];
+		this.placements = [];
 		this.quadMesh = new QuadMesh( new MeshBasicMaterial() );
 		this.quadMesh.material.blending = NoBlending;
 
@@ -225,9 +226,17 @@ export class AtlasTexture {
 
 	setTextures( renderer, textures ) {
 
+		// The order the textures arrive in follows material order, which can change without the
+		// set of textures changing. Pack in a uuid-stable order instead, and map the placements
+		// back to the caller's indices afterwards.
+		const order = textures.map( ( t, i ) => i );
+		order.sort( ( a, b ) => textures[ a ].source.uuid < textures[ b ].source.uuid ? - 1 : 1 );
+		textures = order.map( i => textures[ i ] );
+
 		// nothing to do if the set of textures is unchanged
 		if ( this._hashesMatch( textures ) ) {
 
+			this._buildCallerTextureInfo( order );
 			return;
 
 		}
@@ -248,8 +257,8 @@ export class AtlasTexture {
 		renderTarget.setSize( width, height, pageCount );
 		this.texture.isArrayTexture = true;
 
-		this._buildTextureInfo( placements );
 		this._renderTextures( renderer, textures, placements );
+		this.placements = placements;
 
 		// rebuild hashes and the texture -> index lookup
 		const hashes = new Array( textures.length );
@@ -261,6 +270,23 @@ export class AtlasTexture {
 		}
 
 		this.hashes = hashes;
+
+		this._buildCallerTextureInfo( order );
+
+	}
+
+	// The atlas packs in its own stable order, the shader indexes textureInfo with the order the
+	// caller passed the textures in - "order[ i ]" is where the i-th packed texture came from.
+	_buildCallerTextureInfo( order ) {
+
+		const placements = new Array( order.length );
+		for ( let i = 0, l = order.length; i < l; i ++ ) {
+
+			placements[ order[ i ] ] = this.placements[ i ];
+
+		}
+
+		this._buildTextureInfo( placements );
 
 	}
 

--- a/src/webgpu/AtlasTexture.js
+++ b/src/webgpu/AtlasTexture.js
@@ -443,7 +443,6 @@ export class AtlasTexture {
 			const texture = textures[ i ].clone();
 			texture.matrixAutoUpdate = false;
 			texture.matrix.identity();
-			texture.needsUpdate = true;
 
 			quadMesh.material.map = texture;
 


### PR DESCRIPTION
Fixes the repacking reported in #826.

**Stable pack order.** `AtlasTexture` compares the texture hashes by position, and the order it
gets them in comes from material order, which changes by itself: `updateMaterialsMap` sorts the
materials by uuid, and our editor assigns a new material instance per edit, so the list gets
reshuffled. The atlas then repacks an identical set of textures, 760 to 805 ms with 9 maps. This
sorts the textures by `source.uuid` before packing and maps the placements back to the caller's
indices, so `textureInfo` stays indexed the way the shader expects. I put the sort inside
`AtlasTexture` rather than at the call site, because by then the texture indices are already
packed into the material buffer and sorting there would mean remapping all of them.

**One redundant line.** `_renderTextures` sets `needsUpdate` on the clone. The clone shares its
source, so this bumps `source.version` on a texture the atlas only reads. The blit uploads the
clone either way. It is a separate commit, so feel free to drop it if you want to keep the flag.

Checked on a real GPU (Edge, WebGPU, r185): three textures, `setTextures` called five times, each
time in a different order, reading the packed pixels back through `textureInfo`. Before: 5 repacks
out of 5 calls. After: 1. Pixels correct in both. A sixth call with an added texture still repacks.