### PR TITLE
WebGPU: Remove partial transparency handling during ray traversal

### DIFF
--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -183,6 +183,7 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 			renderer,
 			kernel,
 			bounces,
+			transparentBounces,
 
 			tiles,
 			outputTarget,
@@ -195,6 +196,7 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 		kernel.sampleCountTarget = sampleCountTarget;
 
 		kernel.bounces = bounces;
+		kernel.transparentBounces = transparentBounces;
 
 		// number of tile cycles that have finished, ie. the sample count every pixel has reached
 		let completedSamples = 0;

--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -183,7 +183,7 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 			renderer,
 			kernel,
 			bounces,
-			transparentBounces,
+			maxTransparentBounces,
 
 			tiles,
 			outputTarget,
@@ -196,7 +196,7 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 		kernel.sampleCountTarget = sampleCountTarget;
 
 		kernel.bounces = bounces;
-		kernel.transparentBounces = transparentBounces;
+		kernel.maxTransparentBounces = maxTransparentBounces;
 
 		// number of tile cycles that have finished, ie. the sample count every pixel has reached
 		let completedSamples = 0;

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -8,7 +8,7 @@ export class PathTracerBackend {
 
 		this.renderer = renderer;
 		this.bounces = 15;
-		this.transparentBounces = 15;
+		this.maxTransparentBounces = 15;
 		this.lowResMode = false;
 
 		// stop taking samples once a pixel reaches this count. zero means no limit.

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -8,6 +8,7 @@ export class PathTracerBackend {
 
 		this.renderer = renderer;
 		this.bounces = 15;
+		this.transparentBounces = 15;
 		this.lowResMode = false;
 
 		// stop taking samples once a pixel reaches this count. zero means no limit.

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -319,7 +319,7 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 		const {
 			renderer,
 			bounces,
-			transparentBounces,
+			maxTransparentBounces,
 
 			tiles,
 			sampleCountTarget,
@@ -422,7 +422,7 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 				// Step 5: attenuate ray color, scatter, run russian roulette over exactly the queued hits
 				hitProcessKernel.sampleCountTarget = sampleCountTarget;
 				hitProcessKernel.bounces = bounces;
-				hitProcessKernel.transparentBounces = transparentBounces;
+				hitProcessKernel.maxTransparentBounces = maxTransparentBounces;
 				hitProcessKernel.rayQueue = rayQueue;
 				hitProcessKernel.hitQueue = hitQueue;
 				renderer.compute( hitProcessKernel.kernel, hitDispatchConverter.outputDispatch );

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -319,6 +319,7 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 		const {
 			renderer,
 			bounces,
+			transparentBounces,
 
 			tiles,
 			sampleCountTarget,
@@ -421,6 +422,7 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 				// Step 5: attenuate ray color, scatter, run russian roulette over exactly the queued hits
 				hitProcessKernel.sampleCountTarget = sampleCountTarget;
 				hitProcessKernel.bounces = bounces;
+				hitProcessKernel.transparentBounces = transparentBounces;
 				hitProcessKernel.rayQueue = rayQueue;
 				hitProcessKernel.hitQueue = hitQueue;
 				renderer.compute( hitProcessKernel.kernel, hitDispatchConverter.outputDispatch );

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -127,15 +127,15 @@ export class WebGPUPathTracer {
 
 	}
 
-	get transparentBounces() {
+	get maxTransparentBounces() {
 
-		return this._pathTracer.transparentBounces;
+		return this._pathTracer.maxTransparentBounces;
 
 	}
 
-	set transparentBounces( v ) {
+	set maxTransparentBounces( v ) {
 
-		this._pathTracer.transparentBounces = v;
+		this._pathTracer.maxTransparentBounces = v;
 		this._pathTracer.reset();
 
 	}

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -127,6 +127,19 @@ export class WebGPUPathTracer {
 
 	}
 
+	get transparentBounces() {
+
+		return this._pathTracer.transparentBounces;
+
+	}
+
+	set transparentBounces( v ) {
+
+		this._pathTracer.transparentBounces = v;
+		this._pathTracer.reset();
+
+	}
+
 	// Stops taking samples once a pixel reaches this count. Zero means no limit.
 	get maxSamples() {
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -218,7 +218,14 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						// Stochastically pass through partially transparent surfaces by restarting
 						// the ray at the hit point, advancing the rng but not the bounce count.
-						if ( transparentBounce < transparentBounces && ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
+						if ( ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
+
+							// stop once the transparent bounces run out
+							if ( transparentBounce >= transparentBounces ) {
+
+								break;
+
+							}
 
 							ray.origin = ${ offsetRayOriginFunc }( vertexData.position.xyz, ray.direction, hitResult.normal );
 							${ rngNextBounce }();

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -32,6 +32,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			// settings
 			seed: uniform( 0 ),
 			bounces: uniform( 5 ),
+			transparentBounces: uniform( 15, 'uint' ),
 			misEnabled: uniform( 1, 'uint' ),
 			maxSamples: uniform( 0, 'uint' ),
 			filterGlossy: uniform( 1 ),
@@ -83,6 +84,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				// settings
 				seed: u32,
 				bounces: u32,
+				transparentBounces: u32,
 				misEnabled: u32,
 				maxSamples: u32,
 				filterGlossy: f32,
@@ -139,6 +141,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				var bsdfPdf = 0.0;
 				var isFullyTransmissive = true;
 				var minPdf = 1.0;
+				var transparentBounce = 0u;
 
 				// one-sample NEE selects between the analytic lights and the environment -
 				// lightsDenom is the number of options
@@ -215,10 +218,11 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 						// Stochastically pass through partially transparent surfaces by restarting
 						// the ray at the hit point, advancing the rng but not the bounce count.
-						if ( ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
+						if ( transparentBounce < transparentBounces && ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
 
 							ray.origin = ${ offsetRayOriginFunc }( vertexData.position.xyz, ray.direction, hitResult.normal );
 							${ rngNextBounce }();
+							transparentBounce ++;
 							bounce --;
 							continue;
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -1,7 +1,7 @@
 import { DataTexture, Matrix3, Vector2, StorageTexture } from 'three/webgpu';
 import { ComputeKernel } from './ComputeKernel.js';
 import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
-import { rngInit, rngNextBounce, rand1, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_ENVIRONMENT_SAMPLE, RNG_INDEX_RUSSIAN_ROULETTE } from '../nodes/random.wgsl.js';
+import { rngInit, rngNextBounce, rand1, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_ENVIRONMENT_SAMPLE, RNG_INDEX_RUSSIAN_ROULETTE, RNG_INDEX_ALPHA_TEST } from '../nodes/random.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
 import { proxy, proxyFn, rayStruct, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { isTerminatingScatterFunc } from '../nodes/utils.wgsl.js';
@@ -178,6 +178,18 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						let blurRoughness = sqrt( clamp( 1.0 - filterGlossy * minPdf, 0.0, 1.0 ) ) * 0.5;
 
 						let surface = ${ getSurfaceRecordFn }( material, vertexData, hitResult.side, hitResult.normal, view, blurRoughness );
+
+						// Stochastically pass through partially transparent surfaces by restarting
+						// the ray at the hit point, advancing the rng but not the bounce count.
+						if ( ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
+
+							ray.origin = vertexData.position.xyz;
+							${ rngNextBounce }();
+							bounce --;
+							continue;
+
+						}
+
 						let scatterRec = ${ bsdfSampleFn }( view, surface );
 
 						// attenuate the light transmitted through the volume when exiting a backface

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -32,7 +32,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			// settings
 			seed: uniform( 0 ),
 			bounces: uniform( 5 ),
-			transparentBounces: uniform( 15, 'uint' ),
+			maxTransparentBounces: uniform( 15, 'uint' ),
 			misEnabled: uniform( 1, 'uint' ),
 			maxSamples: uniform( 0, 'uint' ),
 			filterGlossy: uniform( 1 ),
@@ -84,7 +84,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				// settings
 				seed: u32,
 				bounces: u32,
-				transparentBounces: u32,
+				maxTransparentBounces: u32,
 				misEnabled: u32,
 				maxSamples: u32,
 				filterGlossy: f32,
@@ -221,7 +221,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						if ( ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
 
 							// stop once the transparent bounces run out
-							if ( transparentBounce >= transparentBounces ) {
+							if ( transparentBounce >= maxTransparentBounces ) {
 
 								break;
 

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -32,7 +32,7 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			// settings
 			seed: uniform( 0 ),
 			bounces: uniform( 5 ),
-			maxTransparentBounces: uniform( 15, 'uint' ),
+			maxTransparentBounces: uniform( 5, 'uint' ),
 			misEnabled: uniform( 1, 'uint' ),
 			maxSamples: uniform( 0, 'uint' ),
 			filterGlossy: uniform( 1 ),

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -103,7 +103,8 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 				// Stochastically pass through partially transparent surfaces by re-enqueueing
 				// the ray at the hit point, advancing the alpha depth but not the bounce count.
-				if ( input.alphaDepth < transparentBounces && ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
+				let passesThrough = ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity;
+				if ( passesThrough && input.alphaDepth < transparentBounces ) {
 
 					let rayQueueCapacity = arrayLength( &rayQueue.elements );
 					let index = atomicAdd( &rayQueue.end, 1 ) % rayQueueCapacity;
@@ -142,7 +143,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 				}
 
-				var isTerminated = isMatte || input.currentBounce >= bounces || ${ isTerminatingScatterFunc }( scatterRec );
+				var isTerminated = isMatte || passesThrough || input.currentBounce >= bounces || ${ isTerminatingScatterFunc }( scatterRec );
 
 				// russian roulette early out:
 				// Matches Cycles path_state_continuation_probability in integrator/path_state.h

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -25,7 +25,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 			// settings
 			smoothNormals: uniform( 1 ),
 			bounces: uniform( 1 ),
-			transparentBounces: uniform( 15, 'uint' ),
+			maxTransparentBounces: uniform( 15, 'uint' ),
 			filterGlossy: uniform( 1 ),
 			clampDirect: uniform( 0 ),
 			clampIndirect: uniform( 10 ),
@@ -50,7 +50,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 				// settings
 				smoothNormals: u32,
 				bounces: u32,
-				transparentBounces: u32,
+				maxTransparentBounces: u32,
 				filterGlossy: f32,
 				clampDirect: f32,
 				clampIndirect: f32,
@@ -104,7 +104,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 				// Stochastically pass through partially transparent surfaces by re-enqueueing
 				// the ray at the hit point, advancing the alpha depth but not the bounce count.
 				let passesThrough = ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity;
-				if ( passesThrough && input.alphaDepth < transparentBounces ) {
+				if ( passesThrough && input.alphaDepth < maxTransparentBounces ) {
 
 					let rayQueueCapacity = arrayLength( &rayQueue.elements );
 					let index = atomicAdd( &rayQueue.end, 1 ) % rayQueueCapacity;

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -25,7 +25,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 			// settings
 			smoothNormals: uniform( 1 ),
 			bounces: uniform( 1 ),
-			maxTransparentBounces: uniform( 15, 'uint' ),
+			maxTransparentBounces: uniform( 5, 'uint' ),
 			filterGlossy: uniform( 1 ),
 			clampDirect: uniform( 0 ),
 			clampIndirect: uniform( 10 ),

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -6,7 +6,7 @@ import { SAMPLE_COUNT_MASK, SAMPLE_DISPATCHED_FLAG } from '../../constants.js';
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
 import { isTerminatingScatterFunc } from '../../nodes/utils.wgsl.js';
-import { rngInit, rand1, RNG_INDEX_RUSSIAN_ROULETTE } from '../../nodes/random.wgsl.js';
+import { rngInit, rand1, RNG_INDEX_RUSSIAN_ROULETTE, RNG_INDEX_ALPHA_TEST } from '../../nodes/random.wgsl.js';
 import { transmissionAttenuationFunc } from '../../nodes/material.wgsl.js';
 
 export class ProcessHitsKernel extends ComputeKernel {
@@ -69,7 +69,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 				// get the ray info
 				let input = hitQueue.elements[ hitIndex ];
 				let indexUV = vec2u( input.pixel_x, input.pixel_y );
-				${ rngInit }( indexUV.xy, input.seed, input.currentBounce );
+				${ rngInit }( indexUV.xy, input.seed, input.currentBounce + input.alphaDepth );
 
 				let object = transforms[ input.objectIndex ];
 				var material = materials[ object.materialIndex ];
@@ -93,6 +93,27 @@ export class ProcessHitsKernel extends ComputeKernel {
 				let blurRoughness = sqrt( clamp( 1.0 - filterGlossy * input.minPdf, 0.0, 1.0 ) ) * 0.5;
 
 				let surface = ${ getSurfaceRecordFn }( material, vertexData, input.side, input.normal, input.view, blurRoughness );
+
+				// Stochastically pass through partially transparent surfaces by re-enqueueing
+				// the ray at the hit point, advancing the alpha depth but not the bounce count.
+				if ( ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
+
+					let rayQueueCapacity = arrayLength( &rayQueue.elements );
+					let index = atomicAdd( &rayQueue.end, 1 ) % rayQueueCapacity;
+					rayQueue.elements[ index ].origin = vertexData.position.xyz;
+					rayQueue.elements[ index ].direction = - input.view;
+					rayQueue.elements[ index ].pixel = indexUV;
+					rayQueue.elements[ index ].throughputColor = input.throughputColor;
+					rayQueue.elements[ index ].currentBounce = input.currentBounce;
+					rayQueue.elements[ index ].resultColor = input.resultColor;
+					rayQueue.elements[ index ].seed = input.seed;
+					rayQueue.elements[ index ].transmissiveRay = input.transmissiveRay;
+					rayQueue.elements[ index ].minPdf = input.minPdf;
+					rayQueue.elements[ index ].alphaDepth = input.alphaDepth + 1u;
+					return;
+
+				}
+
 				let scatterRec = ${ bsdfSampleFn }( input.view, surface );
 
 				var throughputColor = input.throughputColor;
@@ -164,6 +185,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 					rayQueue.elements[ index ].seed = input.seed;
 					rayQueue.elements[ index ].transmissiveRay = select( 0u, input.transmissiveRay, scatterRec.isTransmissive );
 					rayQueue.elements[ index ].minPdf = min( scatterRec.pdf, input.minPdf );
+					rayQueue.elements[ index ].alphaDepth = input.alphaDepth;
 
 				}
 

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -25,6 +25,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 			// settings
 			smoothNormals: uniform( 1 ),
 			bounces: uniform( 1 ),
+			transparentBounces: uniform( 15, 'uint' ),
 			filterGlossy: uniform( 1 ),
 			clampDirect: uniform( 0 ),
 			clampIndirect: uniform( 10 ),
@@ -49,6 +50,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 				// settings
 				smoothNormals: u32,
 				bounces: u32,
+				transparentBounces: u32,
 				filterGlossy: f32,
 				clampDirect: f32,
 				clampIndirect: f32,
@@ -101,7 +103,7 @@ export class ProcessHitsKernel extends ComputeKernel {
 
 				// Stochastically pass through partially transparent surfaces by re-enqueueing
 				// the ray at the hit point, advancing the alpha depth but not the bounce count.
-				if ( ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
+				if ( input.alphaDepth < transparentBounces && ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } ) > surface.opacity ) {
 
 					let rayQueueCapacity = arrayLength( &rayQueue.elements );
 					let index = atomicAdd( &rayQueue.end, 1 ) % rayQueueCapacity;

--- a/src/webgpu/compute/wavefront/RayGenerationKernel.js
+++ b/src/webgpu/compute/wavefront/RayGenerationKernel.js
@@ -97,6 +97,7 @@ export class RayGenerationKernel extends ComputeKernel {
 				rayQueue.elements[ index ].seed = seed + samples;
 				rayQueue.elements[ index ].transmissiveRay = 1u;
 				rayQueue.elements[ index ].minPdf = 1.0;
+				rayQueue.elements[ index ].alphaDepth = 0u;
 
 				// write the active params & dispatched flag
 				textureStore( ${ params.sampleCountTarget }, indexUV, vec4( ${ SAMPLE_ACTIVE_FLAG }u | ${ SAMPLE_DISPATCHED_FLAG }u | samples ) );

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -90,7 +90,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 				// get the ray info
 				let input = rayQueue.elements[ rayIndex % queueCapacity ];
 				let indexUV = input.pixel;
-				${ rngInit }( indexUV.xy, input.seed, input.currentBounce );
+				${ rngInit }( indexUV.xy, input.seed, input.currentBounce + input.alphaDepth );
 
 				// run intersection
 				let ray = Ray( input.origin, input.direction );
@@ -114,6 +114,7 @@ export class RayIntersectionKernel extends ComputeKernel {
 					hitQueue.elements[ index ].dist = hitResult.dist;
 					hitQueue.elements[ index ].transmissiveRay = input.transmissiveRay;
 					hitQueue.elements[ index ].minPdf = input.minPdf;
+					hitQueue.elements[ index ].alphaDepth = input.alphaDepth;
 
 				} else {
 

--- a/src/webgpu/compute/wavefront/structs.js
+++ b/src/webgpu/compute/wavefront/structs.js
@@ -32,7 +32,7 @@ export const queuedRayStruct = new StructTypeNode( {
 	seed: 'uint',
 
 	direction: 'vec3f',
-	_alignment0: 'uint',
+	alphaDepth: 'uint',
 
 	throughputColor: 'vec3f',
 	currentBounce: 'uint',
@@ -66,7 +66,7 @@ export const queuedHitStruct = new StructTypeNode( {
 	dist: 'float',
 	transmissiveRay: 'uint',
 	minPdf: 'float',
-	_alignment0: 'uint',
+	alphaDepth: 'uint',
 
 	resultColor: 'vec4f',
 

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -306,8 +306,7 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 
 								}
 
-								// Fully transparent surfaces never register a hit while partial opacity is resolved
-								// at the surface hit.
+								// Opacity is resolved at surface processing but skip full transparent hits here.
 								if ( material.transparent != 0 && opacity <= 0.0 ) {
 
 									continue;

--- a/src/webgpu/nodes/PathtracerBVHComputeData.js
+++ b/src/webgpu/nodes/PathtracerBVHComputeData.js
@@ -4,7 +4,6 @@ import { storage, float, texture, uniformArray, uint } from 'three/tsl';
 import { SkinnedMeshBVH, MeshBVH, SAH } from 'three-mesh-bvh';
 import { materialStruct } from './structs.wgsl.js';
 import { getTextureHash } from '../../core/utils/sceneUpdateUtils.js';
-import { rand1, RNG_INDEX_ALPHA_TEST } from './random.wgsl.js';
 import { sampleTexelFunc } from './utils.wgsl.js';
 import { getSurfaceRecordFunc } from './material.wgsl.js';
 import { AtlasTexture } from '../AtlasTexture.js';
@@ -307,17 +306,11 @@ export class PathtracerBVHComputeData extends BVHComputeData {
 
 								}
 
-								if ( material.transparent != 0 ) {
+								// Fully transparent surfaces never register a hit while partial opacity is resolved
+								// at the surface hit.
+								if ( material.transparent != 0 && opacity <= 0.0 ) {
 
-									// index the discard random sample on the triangle index - just using ray hit order
-									// can vary based on ray direction, causing artifacts.
-									let doDiscard = opacity < ${ rand1 }( ${ RNG_INDEX_ALPHA_TEST } + ti );
-
-									if ( doDiscard ) {
-
-										continue;
-
-									}
+									continue;
 
 								}
 

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -397,7 +397,6 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 		surf.color = albedo.rgb;
 		surf.emission = emission;
 
-		// only alpha-blended materials treat the albedo alpha as coverage
 		surf.opacity = select( 1.0, albedo.a, material.transparent != 0 );
 
 		surf.ior = material.ior;

--- a/src/webgpu/nodes/material.wgsl.js
+++ b/src/webgpu/nodes/material.wgsl.js
@@ -184,16 +184,21 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 		var albedo = vec4( material.color, material.opacity );
 		if ( material.vertexColors == 1 ) {
 
-			let vertexColor = getColor( vertexData ).xyz;
-			albedo *= vec4f( vertexColor, 1.0 );
+			albedo *= getColor( vertexData );
 
 		}
 
 		if ( material.map != -1 ) {
 
 			let uvPrime = material.mapTransform * vec3f( getUvFromChannel( vertexData, material.map ), 1 );
-			let texColor = sampleTexel( uvPrime.xy, material.map, 0 );
-			albedo *= vec4f( texColor.rgb, 1.0 );
+			albedo *= sampleTexel( uvPrime.xy, material.map, 0 );
+
+		}
+
+		if ( material.alphaMap != -1 ) {
+
+			let uvPrime = material.alphaMapTransform * vec3f( getUvFromChannel( vertexData, material.alphaMap ), 1 );
+			albedo.a *= sampleTexel( uvPrime.xy, material.alphaMap, 0 ).g;
 
 		}
 
@@ -391,6 +396,9 @@ export const getSurfaceRecordFunc = ( sampleTexel, getUvFromChannel, getColor ) 
 		surf.diffuseRoughness = material.diffuseRoughness;
 		surf.color = albedo.rgb;
 		surf.emission = emission;
+
+		// only alpha-blended materials treat the albedo alpha as coverage
+		surf.opacity = select( 1.0, albedo.a, material.transparent != 0 );
 
 		surf.ior = material.ior;
 		surf.transmission = transmission;

--- a/src/webgpu/nodes/random.wgsl.js
+++ b/src/webgpu/nodes/random.wgsl.js
@@ -1,4 +1,3 @@
-// Alpha test should be the last index as it is summed with triangle index
 export const RNG_INDEX_RAY_JITTER = 0;
 export const RNG_INDEX_ENVIRONMENT_SAMPLE = 1;
 export const RNG_INDEX_SCATTER_TYPE = 2;

--- a/src/webgpu/nodes/structs.wgsl.js
+++ b/src/webgpu/nodes/structs.wgsl.js
@@ -174,6 +174,7 @@ export const surfaceRecordStruct = new StructTypeNode( {
 	anisotropy: 'f32',
 	color: 'vec3f',
 	emission: 'vec3f',
+	opacity: 'f32',
 
 	// transmission
 	ior: 'f32',


### PR DESCRIPTION
- Remove partial alpha handing during ray traversal, resulting in seam artifacts (below) by evaluating stochastic transparency during surface evaluation.
- Add a "maxTransparentBounces" to limit alpha traversal

Before:
<img width="400" src="https://github.com/user-attachments/assets/c3259558-4bbb-49d3-97f8-87e0e75300f4" />
