### PR TITLE
WebGPU: Move sample clamping to minimize MIS diff

### DIFF
--- a/src/webgpu/MegaKernelPathTracer.js
+++ b/src/webgpu/MegaKernelPathTracer.js
@@ -96,6 +96,14 @@ export class MegaKernelPathTracer extends PathTracerBackend {
 
 	}
 
+	setClamping( direct, indirect ) {
+
+		this.kernel.clampDirect = direct;
+		this.kernel.clampIndirect = indirect;
+		this.reset();
+
+	}
+
 	setEnvironment( envMap ) {
 
 		const { kernel, envInfo } = this;

--- a/src/webgpu/PathTracerBackend.js
+++ b/src/webgpu/PathTracerBackend.js
@@ -60,6 +60,10 @@ export class PathTracerBackend {
 
 	}
 
+	setClamping( _direct, _indirect ) {
+
+	}
+
 	setEnvironment(
 		envMap,
 		envMapIntensity,

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -143,6 +143,16 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 
 	}
 
+	setClamping( direct, indirect ) {
+
+		this.rayIntersectionKernel.clampDirect = direct;
+		this.rayIntersectionKernel.clampIndirect = indirect;
+		this.hitProcessKernel.clampDirect = direct;
+		this.hitProcessKernel.clampIndirect = indirect;
+		this.reset();
+
+	}
+
 	setEnvironment( envMap ) {
 
 		const { rayIntersectionKernel, envInfo } = this;

--- a/src/webgpu/WebGPUPathTracer.js
+++ b/src/webgpu/WebGPUPathTracer.js
@@ -195,6 +195,42 @@ export class WebGPUPathTracer {
 
 	}
 
+	get clampDirect() {
+
+		return this._clampDirect;
+
+	}
+
+	set clampDirect( v ) {
+
+		v = Math.max( 0, v );
+		if ( this._clampDirect !== v ) {
+
+			this._clampDirect = v;
+			this._pathTracer.setClamping( v, this._clampIndirect );
+
+		}
+
+	}
+
+	get clampIndirect() {
+
+		return this._clampIndirect;
+
+	}
+
+	set clampIndirect( v ) {
+
+		v = Math.max( 0, v );
+		if ( this._clampIndirect !== v ) {
+
+			this._clampIndirect = v;
+			this._pathTracer.setClamping( this._clampDirect, v );
+
+		}
+
+	}
+
 	// --- WebGLPathTracer compatibility stubs ---
 	// These mirror the WebGLPathTracer API surface so existing examples run unchanged.
 	// They are currently no-ops on the WebGPU path tracer until the corresponding
@@ -251,6 +287,7 @@ export class WebGPUPathTracer {
 		this._pathTracer.setRandom( this.random );
 		this._pathTracer.setTransmissiveBackground( this._transmissiveBackground );
 		this._pathTracer.setFilterGlossy( this._filterGlossyFactor );
+		this._pathTracer.setClamping( this._clampDirect, this._clampIndirect );
 		this.setCamera( this.camera );
 		this.updateEnvironment();
 
@@ -292,6 +329,8 @@ export class WebGPUPathTracer {
 		this.pause = false;
 
 		this.filterGlossyFactor = 1;
+		this._clampDirect = 0;
+		this._clampIndirect = 10;
 
 		// WebGLPathTracer compatibility stubs (see getters above)
 		// TOOD: implement these correctly

--- a/src/webgpu/compute/PathTracerMegaKernel.js
+++ b/src/webgpu/compute/PathTracerMegaKernel.js
@@ -4,7 +4,7 @@ import { texture, sampler, uniform, globalId, textureStore } from 'three/tsl';
 import { rngInit, rngNextBounce, rand1, rand2, RNG_INDEX_RAY_JITTER, RNG_INDEX_BACKGROUND_SAMPLE, RNG_INDEX_RUSSIAN_ROULETTE } from '../nodes/random.wgsl.js';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../nodes/sampling.wgsl.js';
 import { proxy, proxyFn, rayStruct, wgslTagFn } from 'three-mesh-bvh/webgpu';
-import { isTerminatingScatterFunc, offsetRayOriginFunc } from '../nodes/utils.wgsl.js';
+import { clampPathContributionFunc, isTerminatingScatterFunc, offsetRayOriginFunc } from '../nodes/utils.wgsl.js';
 import { transmissionAttenuationFunc } from '../nodes/material.wgsl.js';
 import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_OVERLAY, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../constants.js';
 
@@ -30,6 +30,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 			bounces: uniform( 5 ),
 			maxSamples: uniform( 0, 'uint' ),
 			filterGlossy: uniform( 1 ),
+			clampDirect: uniform( 0 ),
+			clampIndirect: uniform( 10 ),
 
 			// environment
 			envMap: texture( new DataTexture() ),
@@ -75,6 +77,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 				bounces: u32,
 				maxSamples: u32,
 				filterGlossy: f32,
+				clampDirect: f32,
+				clampIndirect: f32,
 
 				// environment
 				envMap: texture_2d<f32>,
@@ -192,7 +196,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						}
 
 						// emission
-						resultColor += vec4f( throughputColor * surface.emission, 0.0 );
+						let emission = ${ clampPathContributionFunc }( throughputColor * surface.emission, bounce + 1u, clampDirect, clampIndirect );
+						resultColor += vec4f( emission, 0.0 );
 
 						if ( ${ isTerminatingScatterFunc }( scatterRec ) ) {
 
@@ -239,7 +244,9 @@ export class PathTracerMegaKernel extends ComputeKernel {
 						let rng = ${ rand2 }( ${ RNG_INDEX_BACKGROUND_SAMPLE } );
 						if ( bounce > 0u && ! isFullyTransmissive ) {
 
-							resultColor += ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, ray.direction, rng ) * vec4f( throughputColor, 0.0 );
+							let environment = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, ray.direction, rng ).rgb * throughputColor;
+							let contribution = ${ clampPathContributionFunc }( environment, bounce + 1u, clampDirect, clampIndirect );
+							resultColor += vec4f( contribution, 0.0 );
 
 						} else {
 
@@ -249,7 +256,8 @@ export class PathTracerMegaKernel extends ComputeKernel {
 							if ( bounce == 0u ) {
 
 								// sample the background directly if this is the primary ray
-								resultColor = vec4f( bg.a * bg.rgb, bg.a );
+								let background = ${ clampPathContributionFunc }( bg.a * bg.rgb, bounce + 1u, clampDirect, clampIndirect );
+								resultColor = vec4f( background, bg.a );
 
 							} else {
 
@@ -261,16 +269,18 @@ export class PathTracerMegaKernel extends ComputeKernel {
 								if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
 									// display the env map through transmissive surfaces
+									let background = ${ clampPathContributionFunc }( env.rgb * throughputColor, bounce + 1u, clampDirect, clampIndirect );
 									resultColor = vec4f(
-										resultColor.rgb + env.rgb * throughputColor,
+										resultColor.rgb + background,
 										1.0,
 									);
 
 								} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
 
 									// fade the background by the throughput color average
+									let background = ${ clampPathContributionFunc }( bg.a * bg.rgb * throughputColor, bounce + 1u, clampDirect, clampIndirect );
 									resultColor = vec4f(
-										resultColor.rgb + bg.a * bg.rgb * throughputColor,
+										resultColor.rgb + background,
 										1.0 - transparency,
 									);
 
@@ -278,8 +288,9 @@ export class PathTracerMegaKernel extends ComputeKernel {
 
 									// fade the background by the throughput color average, mixing in env lighting
 									var light = mix( env.rgb, bg.rgb, bg.a );
+									let background = ${ clampPathContributionFunc }( light * throughputColor, bounce + 1u, clampDirect, clampIndirect );
 									resultColor = vec4f(
-										resultColor.rgb + light * throughputColor,
+										resultColor.rgb + background,
 										1.0 - transparency,
 									);
 

--- a/src/webgpu/compute/wavefront/ProcessHitsKernel.js
+++ b/src/webgpu/compute/wavefront/ProcessHitsKernel.js
@@ -5,7 +5,7 @@ import { rayQueueAtomicStruct, hitQueueStruct } from './structs.js';
 import { SAMPLE_COUNT_MASK, SAMPLE_DISPATCHED_FLAG } from '../../constants.js';
 import { proxy, proxyFn, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
-import { isTerminatingScatterFunc, offsetRayOriginFunc } from '../../nodes/utils.wgsl.js';
+import { clampPathContributionFunc, isTerminatingScatterFunc, offsetRayOriginFunc } from '../../nodes/utils.wgsl.js';
 import { rngInit, rand1, RNG_INDEX_RUSSIAN_ROULETTE } from '../../nodes/random.wgsl.js';
 import { transmissionAttenuationFunc } from '../../nodes/material.wgsl.js';
 
@@ -25,6 +25,8 @@ export class ProcessHitsKernel extends ComputeKernel {
 			smoothNormals: uniform( 1 ),
 			bounces: uniform( 1 ),
 			filterGlossy: uniform( 1 ),
+			clampDirect: uniform( 0 ),
+			clampIndirect: uniform( 10 ),
 
 			// rays
 			rayQueue: storage( new StorageBufferAttribute( 1, 1 ), rayQueueAtomicStruct ),
@@ -47,6 +49,8 @@ export class ProcessHitsKernel extends ComputeKernel {
 				smoothNormals: u32,
 				bounces: u32,
 				filterGlossy: f32,
+				clampDirect: f32,
+				clampIndirect: f32,
 
 				globalId: vec3u
 			) -> void {
@@ -105,7 +109,8 @@ export class ProcessHitsKernel extends ComputeKernel {
 				}
 
 				// emission
-				var resultColor = input.resultColor + vec4f( throughputColor * surface.emission, 0.0 );
+				let emission = ${ clampPathContributionFunc }( throughputColor * surface.emission, input.currentBounce + 1u, clampDirect, clampIndirect );
+				var resultColor = input.resultColor + vec4f( emission, 0.0 );
 				if ( isMatte ) {
 
 					resultColor = vec4f( 0.0 );

--- a/src/webgpu/compute/wavefront/RayIntersectionKernel.js
+++ b/src/webgpu/compute/wavefront/RayIntersectionKernel.js
@@ -7,6 +7,7 @@ import { SAMPLE_COUNT_MASK, SAMPLE_DISPATCHED_FLAG } from '../../constants.js';
 import { proxy, wgslTagFn } from 'three-mesh-bvh/webgpu';
 import { sampleEnvironmentFn, weightedAlphaBlendFn } from '../../nodes/sampling.wgsl.js';
 import { TRANSMISSIVE_BACKGROUND_ENVIRONMENT, TRANSMISSIVE_BACKGROUND_OVERLAY, TRANSMISSIVE_BACKGROUND_TRANSPARENT } from '../../constants.js';
+import { clampPathContributionFunc } from '../../nodes/utils.wgsl.js';
 
 export class RayIntersectionKernel extends ComputeKernel {
 
@@ -22,6 +23,10 @@ export class RayIntersectionKernel extends ComputeKernel {
 			// rays
 			rayQueue: storage( new StorageBufferAttribute( 1, 1 ), rayQueueStruct ),
 			hitQueue: storage( new StorageBufferAttribute( 1, 1 ), hitQueueAtomicStruct ),
+
+			// settings
+			clampDirect: uniform( 0 ),
+			clampIndirect: uniform( 10 ),
 
 			// environment
 			envMap: texture( new DataTexture() ),
@@ -46,6 +51,10 @@ export class RayIntersectionKernel extends ComputeKernel {
 		const fn = wgslTagFn /* wgsl */`
 
 			fn compute(
+				// settings
+				clampDirect: f32,
+				clampIndirect: f32,
+
 				// environment
 				envMap: texture_2d<f32>,
 				envMapSampler: sampler,
@@ -121,7 +130,9 @@ export class RayIntersectionKernel extends ComputeKernel {
 					var resultColor = input.resultColor;
 					if ( input.currentBounce > 0u && input.transmissiveRay == 0u ) {
 
-						resultColor += ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, input.direction, rng ) * vec4f( input.throughputColor, 0.0 );
+						let environment = ${ sampleEnvironmentFn }( envMap, envMapSampler, envInfo, input.direction, rng ).rgb * input.throughputColor;
+						let contribution = ${ clampPathContributionFunc }( environment, input.currentBounce + 1u, clampDirect, clampIndirect );
+						resultColor += vec4f( contribution, 0.0 );
 
 					} else {
 
@@ -131,7 +142,8 @@ export class RayIntersectionKernel extends ComputeKernel {
 						if ( input.currentBounce == 0u ) {
 
 							// sample the background directly if this is the primary ray
-							resultColor = vec4f( bg.a * bg.rgb, bg.a );
+							let background = ${ clampPathContributionFunc }( bg.a * bg.rgb, input.currentBounce + 1u, clampDirect, clampIndirect );
+							resultColor = vec4f( background, bg.a );
 
 						} else {
 
@@ -143,16 +155,18 @@ export class RayIntersectionKernel extends ComputeKernel {
 							if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_ENVIRONMENT }u ) {
 
 								// display the env map through transmissive surfaces
+								let background = ${ clampPathContributionFunc }( env.rgb * input.throughputColor, input.currentBounce + 1u, clampDirect, clampIndirect );
 								resultColor = vec4f(
-									resultColor.rgb + env.rgb * input.throughputColor,
+									resultColor.rgb + background,
 									1.0,
 								);
 
 							} else if ( transmissiveBackground == ${ TRANSMISSIVE_BACKGROUND_TRANSPARENT }u ) {
 
 								// fade the background by the throughput color average
+								let background = ${ clampPathContributionFunc }( bg.a * bg.rgb * input.throughputColor, input.currentBounce + 1u, clampDirect, clampIndirect );
 								resultColor = vec4f(
-									resultColor.rgb + bg.a * bg.rgb * input.throughputColor,
+									resultColor.rgb + background,
 									1.0 - transparency,
 								);
 
@@ -160,8 +174,9 @@ export class RayIntersectionKernel extends ComputeKernel {
 
 								// fade the background by the throughput color average, mixing in env lighting
 								var light = mix( env.rgb, bg.rgb, bg.a );
+								let background = ${ clampPathContributionFunc }( light * input.throughputColor, input.currentBounce + 1u, clampDirect, clampIndirect );
 								resultColor = vec4f(
-									resultColor.rgb + light * input.throughputColor,
+									resultColor.rgb + background,
 									1.0 - transparency,
 								);
 

--- a/src/webgpu/nodes/utils.wgsl.js
+++ b/src/webgpu/nodes/utils.wgsl.js
@@ -203,6 +203,33 @@ export const isTerminatingScatterFunc = wgslFn( /* wgsl */ `
 
 `, [ scatterRecordStruct ] );
 
+// Clamp individual light-path contributions using Cycles' RGB sum while preserving chromaticity.
+// Matches film_clamp_light in Cycles' kernel/film/light_passes.h, including the x3 limit
+// scaling applied to the user-facing clamp values in scene/integrator.cpp.
+export const clampPathContributionFunc = wgslFn( /* wgsl */ `
+
+	fn clampPathContribution( contribution: vec3f, pathDepth: u32, clampDirect: f32, clampIndirect: f32 ) -> vec3f {
+
+		let limit = select( clampIndirect, clampDirect, pathDepth <= 1u ) * 3.0;
+		if ( limit <= 0.0 ) {
+
+			return contribution;
+
+		}
+
+		let strength = dot( abs( contribution ), vec3f( 1.0 ) );
+		if ( strength > limit ) {
+
+			return contribution * ( limit / strength );
+
+		}
+
+		return contribution;
+
+	}
+
+` );
+
 export const applyWrapFunc = wgslFn( /* wgsl */ `
 
 	fn applyWrap( v: f32, wrapMode: i32 ) -> f32 {


### PR DESCRIPTION
Move non-MIS-specific sample clamping from #825 to webgpu-pathtracer.