### PR TITLE
WebGPU: Update the material orb asset demo

### DIFF
--- a/example/materialOrb.html
+++ b/example/materialOrb.html
@@ -11,7 +11,7 @@
 				background-color: #111;
 			}
 
-			canvas {
+			#canvasContainer {
 				position: absolute;
 				top: 50%;
 				left: 50%;
@@ -49,7 +49,8 @@
 		</style>
 
 	</head>
-	<body class="checkerboard">
+	<body>
+		<div id="canvasContainer" class="checkerboard"></div>
 		<img id="materialImage"/>
 		<script src="./materialOrb.js" type="module"></script>
 	</body>

--- a/example/materialOrb.html
+++ b/example/materialOrb.html
@@ -34,6 +34,18 @@
 				bottom: 0;
 				right: 0;
 			}
+
+			#materialImage.overlay {
+				z-index: 1;
+				width: 50vmin;
+				height: 50vmin;
+				bottom: auto;
+				right: auto;
+				top: 50%;
+				left: 50%;
+				transform: translate( -50%, -50% );
+				pointer-events: none;
+			}
 		</style>
 
 	</head>

--- a/example/materialOrb.html
+++ b/example/materialOrb.html
@@ -11,6 +11,13 @@
 				background-color: #111;
 			}
 
+			canvas {
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				transform: translate( -50%, -50% );
+			}
+
 			.checkerboard {
 				background-image:
 					linear-gradient(45deg, #222 25%, transparent 25%),

--- a/example/materialOrb.js
+++ b/example/materialOrb.js
@@ -95,7 +95,7 @@ async function init() {
 	renderer.init();
 	renderer.toneMapping = AgXToneMapping;
 	renderer.toneMappingExposure = 1;
-	document.body.appendChild( renderer.domElement );
+	document.getElementById( 'canvasContainer' ).appendChild( renderer.domElement );
 
 	// path tracer
 	pathTracer = new WebGPUPathTracer( renderer );

--- a/example/materialOrb.js
+++ b/example/materialOrb.js
@@ -263,7 +263,9 @@ function applyDatabaseMaterial( info ) {
 
 		materialProperties.iridescence = 1;
 		materialProperties.iridescenceIOR = info.thinFilmIor;
-		materialProperties.iridescenceThickness = info.thinFilmThickness[ 2 ] ?? info.thinFilmThickness[ 0 ];
+		// thickness is [ min, max, nominal ] with the nominal sometimes absent
+		const [ min, max, nominal ] = info.thinFilmThickness;
+		materialProperties.iridescenceThickness = nominal ?? ( min + max ) / 2;
 
 	}
 
@@ -279,7 +281,7 @@ function applyDatabaseMaterial( info ) {
 
 	}
 
-	imgEl.src = Object.values( info.images[ 1 ] )[ 0 ];
+	imgEl.src = info.images[ 0 ][ '600' ];
 
 }
 

--- a/example/materialOrb.js
+++ b/example/materialOrb.js
@@ -1,10 +1,10 @@
 import {
-	ACESFilmicToneMapping,
 	Color,
 	Scene,
 	WebGPURenderer,
 	Vector3,
 	RectAreaLightNode,
+	AgXToneMapping,
 } from 'three/webgpu';
 import { RectAreaLightTexturesLib } from 'three/examples/jsm/lights/RectAreaLightTexturesLib.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
@@ -96,8 +96,8 @@ async function init() {
 	// renderer
 	renderer = new WebGPURenderer( { antialias: true, alpha: true } );
 	renderer.init();
-	renderer.toneMapping = ACESFilmicToneMapping;
-	renderer.toneMappingExposure = 0.02;
+	renderer.toneMapping = AgXToneMapping;
+	renderer.toneMappingExposure = 1;
 	document.body.appendChild( renderer.domElement );
 
 	// path tracer
@@ -129,6 +129,7 @@ async function init() {
 
 	// controls
 	controls = new OrbitControls( camera, renderer.domElement );
+	controls.enablePan = false;
 	controls.addEventListener( 'change', () => pathTracer.updateCamera() );
 
 	// shift target
@@ -292,9 +293,11 @@ function resetCamera() {
 
 function onResize() {
 
-	renderer.setSize( window.innerWidth, window.innerHeight );
+	// square canvas matching the format of the database reference renders
+	const dim = 0.5 * Math.min( window.innerWidth, window.innerHeight );
+	renderer.setSize( dim, dim );
 	renderer.setPixelRatio( window.devicePixelRatio );
-	camera.aspect = window.innerWidth / window.innerHeight;
+	camera.aspect = 1;
 	camera.updateProjectionMatrix();
 	pathTracer.updateCamera();
 

--- a/example/materialOrb.js
+++ b/example/materialOrb.js
@@ -62,6 +62,7 @@ const params = {
 
 	enable: true,
 	displaySampleDensity: false,
+	overlayReference: false,
 	multipleImportanceSampling: true,
 	bounces: 15,
 	renderScale: 1,
@@ -115,6 +116,16 @@ async function init() {
 	database = {};
 	dbJson.data.forEach( mat => database[ mat.name ] = mat );
 
+	// select the material named in the url query if present
+	const urlMaterial = new URLSearchParams( window.location.search ).get( 'material' );
+	if ( urlMaterial !== null && urlMaterial in database ) {
+
+		params.material = urlMaterial;
+		applyDatabaseMaterial( database[ urlMaterial ] );
+		imgEl.style.display = '';
+
+	}
+
 	// scene initialization
 	scene.add( orb.scene );
 	camera = orb.camera;
@@ -153,6 +164,11 @@ async function init() {
 	gui = new GUI();
 	gui.add( params, 'material', [ CUSTOM_MATERIAL, ...Object.keys( database ) ] ).onChange( onMaterialChange );
 	gui.add( { resetCamera }, 'resetCamera' ).name( 'reset camera' );
+	gui.add( params, 'overlayReference' ).onChange( v => {
+
+		imgEl.classList.toggle( 'overlay', v );
+
+	} );
 
 	const ptFolder = gui.addFolder( 'Path Tracer' );
 	ptFolder.add( params, 'enable' );
@@ -276,6 +292,20 @@ function onMaterialChange() {
 	}
 
 	imgEl.style.display = params.material === CUSTOM_MATERIAL ? 'none' : '';
+
+	// reflect the selected material in the url
+	const search = new URLSearchParams( window.location.search );
+	if ( params.material === CUSTOM_MATERIAL ) {
+
+		search.delete( 'material' );
+
+	} else {
+
+		search.set( 'material', params.material );
+
+	}
+
+	history.replaceState( null, '', search.size ? `?${ search }` : window.location.pathname );
 
 	gui.controllersRecursive().forEach( c => c.updateDisplay() );
 	onParamsChange();

--- a/example/materialOrb.js
+++ b/example/materialOrb.js
@@ -129,6 +129,8 @@ async function init() {
 	// scene initialization
 	scene.add( orb.scene );
 	camera = orb.camera;
+	camera.aspect = 1;
+	camera.updateProjectionMatrix();
 	material = orb.material;
 
 	// the model ships without tangents, which anisotropy needs to orient its frame
@@ -329,9 +331,6 @@ function onResize() {
 	const dim = 0.5 * Math.min( window.innerWidth, window.innerHeight );
 	renderer.setSize( dim, dim );
 	renderer.setPixelRatio( window.devicePixelRatio );
-	camera.aspect = 1;
-	camera.updateProjectionMatrix();
-	pathTracer.updateCamera();
 
 }
 

--- a/example/materialOrb.js
+++ b/example/materialOrb.js
@@ -16,9 +16,6 @@ import { MaterialOrbSceneLoader } from './src/MaterialOrbSceneLoader.js';
 const DB_URL = 'https://api.physicallybased.info/v2/materials';
 const CREDITS = 'Materials courtesy of "physicallybased.info"</br>Material orb model courtesy of USD Working Group';
 
-// preset entry for hand edited values, ie. not one of the database materials
-const CUSTOM_MATERIAL = 'Custom';
-
 let pathTracer, renderer, controls, material;
 let camera, scene, loader;
 let gui, database, imgEl;
@@ -29,7 +26,7 @@ const initialCameraTarget = new Vector3();
 
 const params = {
 
-	material: CUSTOM_MATERIAL,
+	material: '',
 
 	materialProperties: {
 		color: '#ffe6bd',
@@ -92,7 +89,6 @@ async function init() {
 
 	// reference photo for the selected database material, hidden while editing by hand
 	imgEl = document.getElementById( 'materialImage' );
-	imgEl.style.display = 'none';
 
 	// renderer
 	renderer = new WebGPURenderer( { antialias: true, alpha: true } );
@@ -116,15 +112,10 @@ async function init() {
 	database = {};
 	dbJson.data.forEach( mat => database[ mat.name ] = mat );
 
-	// select the material named in the url query if present
+	// select the material named in the url query if present, falling back to the first entry
 	const urlMaterial = new URLSearchParams( window.location.search ).get( 'material' );
-	if ( urlMaterial !== null && urlMaterial in database ) {
-
-		params.material = urlMaterial;
-		applyDatabaseMaterial( database[ urlMaterial ] );
-		imgEl.style.display = '';
-
-	}
+	params.material = urlMaterial !== null && urlMaterial in database ? urlMaterial : Object.keys( database )[ 0 ];
+	applyDatabaseMaterial( database[ params.material ] );
 
 	// scene initialization
 	scene.add( orb.scene );
@@ -164,13 +155,13 @@ async function init() {
 
 	// gui
 	gui = new GUI();
-	gui.add( params, 'material', [ CUSTOM_MATERIAL, ...Object.keys( database ) ] ).onChange( onMaterialChange );
-	gui.add( { resetCamera }, 'resetCamera' ).name( 'reset camera' );
+	gui.add( params, 'material', Object.keys( database ) ).onChange( onMaterialChange );
 	gui.add( params, 'overlayReference' ).onChange( v => {
 
 		imgEl.classList.toggle( 'overlay', v );
 
 	} );
+	gui.add( { resetCamera }, 'resetCamera' ).name( 'reset camera' );
 
 	const ptFolder = gui.addFolder( 'Path Tracer' );
 	ptFolder.add( params, 'enable' );
@@ -214,19 +205,6 @@ async function init() {
 	matFolder1.add( params.materialProperties, 'flatShading' ).onChange( onParamsChange );
 	matFolder1.add( params.materialProperties, 'castShadow' ).onChange( onParamsChange );
 	matFolder1.close();
-
-	// editing anything by hand means the values no longer match the selected preset
-	matFolder1.controllersRecursive().forEach( controller => {
-
-		controller.onFinishChange( () => {
-
-			params.material = CUSTOM_MATERIAL;
-			imgEl.style.display = 'none';
-			gui.controllers[ 0 ].updateDisplay();
-
-		} );
-
-	} );
 
 	animate();
 
@@ -289,27 +267,12 @@ function applyDatabaseMaterial( info ) {
 
 function onMaterialChange() {
 
-	if ( params.material !== CUSTOM_MATERIAL ) {
-
-		applyDatabaseMaterial( database[ params.material ] );
-
-	}
-
-	imgEl.style.display = params.material === CUSTOM_MATERIAL ? 'none' : '';
+	applyDatabaseMaterial( database[ params.material ] );
 
 	// reflect the selected material in the url
 	const search = new URLSearchParams( window.location.search );
-	if ( params.material === CUSTOM_MATERIAL ) {
-
-		search.delete( 'material' );
-
-	} else {
-
-		search.set( 'material', params.material );
-
-	}
-
-	history.replaceState( null, '', search.size ? `?${ search }` : window.location.pathname );
+	search.set( 'material', params.material );
+	history.replaceState( null, '', `?${ search }` );
 
 	gui.controllersRecursive().forEach( c => c.updateDisplay() );
 	onParamsChange();

--- a/example/src/MaterialOrbSceneLoader.js
+++ b/example/src/MaterialOrbSceneLoader.js
@@ -4,9 +4,7 @@ import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
 
 // TODO: this scene should technically be rendered at a 1000x smaller scale
 
-// TEMP: local v1.1 export for testing - upload to 3d-demo-data and restore the remote url
-// const ORB_SCENE_URL = 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/main/models/usd-shader-ball/usd-shaderball-scene.glb';
-const ORB_SCENE_URL = new URL( '../data/standard-shader-ball.glb', import.meta.url ).href;
+const ORB_SCENE_URL = 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/main/models/usd-shader-ball/standard-shader-ball.glb';
 
 // Light and camera values from the StandardShaderBall v1.1 layers. USD RectLight intensity
 // maps directly onto three.js' RectAreaLight intensity.

--- a/example/src/MaterialOrbSceneLoader.js
+++ b/example/src/MaterialOrbSceneLoader.js
@@ -1,18 +1,24 @@
-import { MeshPhysicalMaterial, RectAreaLight } from 'three';
+import { MathUtils, MeshPhysicalMaterial, RectAreaLight } from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 
 // TODO: this scene should technically be rendered at a 1000x smaller scale
 
-const ORB_SCENE_URL = 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/main/models/usd-shader-ball/usd-shaderball-scene.glb';
-function assignWatts( light, watts ) {
+// TEMP: local v1.1 export for testing - upload to 3d-demo-data and restore the remote url
+// const ORB_SCENE_URL = 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/main/models/usd-shader-ball/usd-shaderball-scene.glb';
+const ORB_SCENE_URL = new URL( '../data/standard-shader-ball.glb', import.meta.url ).href;
 
-	// https://github.com/will-ca/glTF-Blender-IO/blob/af9e7f06508a95425b05e485fa83681b268bbdfc/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_lights.py#L92-L97
-	const PBR_WATTS_TO_LUMENS = 683;
-	const area = light.width * light.height;
-	const lumens = PBR_WATTS_TO_LUMENS * watts;
-	light.intensity = lumens / ( area * 4 * Math.PI );
-
-}
+// Light and camera values from the StandardShaderBall v1.1 layers. USD RectLight intensity
+// maps directly onto three.js' RectAreaLight intensity.
+// https://github.com/usd-wg/assets/tree/main/full_assets/StandardShaderBall/layers
+const LEFT_LIGHT_SIZE = 14.96;
+const LEFT_LIGHT_INTENSITY = 9;
+const TOP_LIGHT_SIZE = 24.36;
+const TOP_LIGHT_INTENSITY = 6;
+const CAMERA_FOCAL_LENGTH = 50;
+const CAMERA_APERTURE = 20.955;
 
 export class MaterialOrbSceneLoader {
 
@@ -24,7 +30,11 @@ export class MaterialOrbSceneLoader {
 
 	loadAsync( url = ORB_SCENE_URL, ...rest ) {
 
+		const dracoLoader = new DRACOLoader();
+		dracoLoader.setDecoderPath( DRACO_DECODER_PATH );
+
 		return new GLTFLoader( this.manager )
+			.setDRACOLoader( dracoLoader )
 			.loadAsync( url, ...rest )
 			.then( gltf => {
 
@@ -33,21 +43,21 @@ export class MaterialOrbSceneLoader {
 					cameras,
 				} = gltf;
 
-				const leftLight = new RectAreaLight( 0xffffff, 1, 15, 15 );
-				assignWatts( leftLight, 6327.84 );
+				// USD RectLights emit along a different local axis than three.js' RectAreaLight
+				const leftLight = new RectAreaLight( 0xffffff, LEFT_LIGHT_INTENSITY, LEFT_LIGHT_SIZE, LEFT_LIGHT_SIZE );
+				leftLight.rotation.x = - Math.PI / 2;
 				scene.getObjectByName( 'light' ).add( leftLight );
 
 				for ( let i = 0; i < 4; i ++ ) {
 
-					const light = new RectAreaLight( 0xffffff, 1, 24.36, 24.36 );
-					assignWatts( light, 11185.5 );
+					const light = new RectAreaLight( 0xffffff, TOP_LIGHT_INTENSITY, TOP_LIGHT_SIZE, TOP_LIGHT_SIZE );
+					light.rotation.x = - Math.PI / 2;
 					scene.getObjectByName( 'light' + i ).add( light );
 
 				}
 
-				// TODO: why is this necessary?
 				const camera = cameras[ 0 ];
-				camera.fov *= 2.0;
+				camera.fov = 2 * Math.atan( CAMERA_APERTURE / ( 2 * CAMERA_FOCAL_LENGTH ) ) * MathUtils.RAD2DEG;
 				camera.updateProjectionMatrix();
 
 				// some objects in the scene use 16 bit float vertex colors and specify so

--- a/example/src/MaterialOrbSceneLoader.js
+++ b/example/src/MaterialOrbSceneLoader.js
@@ -2,8 +2,6 @@ import { MathUtils, MeshPhysicalMaterial, RectAreaLight } from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
 
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
-
 // TODO: this scene should technically be rendered at a 1000x smaller scale
 
 // TEMP: local v1.1 export for testing - upload to 3d-demo-data and restore the remote url
@@ -31,7 +29,6 @@ export class MaterialOrbSceneLoader {
 	loadAsync( url = ORB_SCENE_URL, ...rest ) {
 
 		const dracoLoader = new DRACOLoader();
-		dracoLoader.setDecoderPath( DRACO_DECODER_PATH );
 
 		return new GLTFLoader( this.manager )
 			.setDRACOLoader( dracoLoader )
@@ -83,6 +80,11 @@ export class MaterialOrbSceneLoader {
 					scene,
 
 				};
+
+			} )
+			.finally( () => {
+
+				dracoLoader.dispose();
 
 			} );
 

--- a/src/webgpu/AtlasTexture.js
+++ b/src/webgpu/AtlasTexture.js
@@ -8,7 +8,7 @@ import {
 	Vector4,
 } from 'three/webgpu';
 
-const MAX_TEXTURE_SIZE = 4096 * 2;
+const MAX_TEXTURE_SIZE = 4096;
 const _prevClearColor = new Color();
 
 function getTextureHash( texture ) {

--- a/src/webgpu/AtlasTexture.js
+++ b/src/webgpu/AtlasTexture.js
@@ -8,7 +8,7 @@ import {
 	Vector4,
 } from 'three/webgpu';
 
-const MAX_TEXTURE_SIZE = 4096;
+const MAX_TEXTURE_SIZE = 4096 * 2;
 const _prevClearColor = new Color();
 
 function getTextureHash( texture ) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,6 +27,6 @@ export default ( { mode } ) => ( {
 		},
 	},
 	optimizeDeps: {
-    	exclude: [ 'three-mesh-bvh', '@monogrid/gainmap-js' ],
+    	exclude: [ 'three', 'three-mesh-bvh', '@monogrid/gainmap-js' ],
   	},
 } );


### PR DESCRIPTION
- Updates the material orb asset based on the latest [usd standard shader ball](https://github.com/usd-wg/assets/tree/main/full_assets/StandardShaderBall) 
- Update the demo to use the same aspect ratio as the reference images (1:1)
- Add a button to overlay the reference on the rendered image
- Adjust tone mapping to AgX, exposure etc, so colors match
- Add a material url query parameter to jump to a specific material

Materials that require SSS or don't have the same material properties still can't be displayed accurately.

| Maerial | Reference | Path Traced |
|---|---|---|
| Anodized Aluminum | <img width="998" height="998" alt="image" src="https://github.com/user-attachments/assets/d4e27d6d-e4da-4fd2-a36d-bee29c7b776b" /> | <img width="998" height="998" alt="image" src="https://github.com/user-attachments/assets/f9258d7d-f1ee-45f2-8661-f2953ce70617" /> |
| White Wine | <img width="998" height="998" alt="image" src="https://github.com/user-attachments/assets/1414e192-e2ec-4421-9145-f2c57d02a599" /> | <img width="998" height="998" alt="image" src="https://github.com/user-attachments/assets/63d392a9-43dc-4ba5-af4e-dd989746c2e7" /> |

cc @AntonPalmqvist 
