### PR TITLE
WebGPUPathTracer: Fix max sample cap, camera updates not working properly

### DIFF
--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -118,6 +118,17 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 
 	}
 
+	rebuild() {
+
+		super.rebuild();
+
+		// MaterialKernel embeds the camera ray function off the bvh data, so swapping cameras
+		// has no effect until it recompiles
+		this.materialKernel.needsUpdate = true;
+		this.reset();
+
+	}
+
 	setRandom( random ) {
 
 		this.logicKernel.context.random = random;

--- a/src/webgpu/WaveFrontPathTracer.js
+++ b/src/webgpu/WaveFrontPathTracer.js
@@ -323,6 +323,7 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 				logicKernel.rayIntersectionsStorage = rayIntersectionsStorage;
 				logicKernel.shadowRayIntersectionsStorage = shadowRayIntersectionsStorage;
 				logicKernel.bounces = this.bounces;
+				logicKernel.rayCount = rayCount;
 				renderer.compute( logicKernel.kernel, logicKernel.getDispatchSize( rayCount, 1, 1 ) );
 
 				// Step 2: reset the trace queues for this frame's population
@@ -341,6 +342,7 @@ export class WaveFrontPathTracer extends PathTracerBackend {
 				materialKernel.sampleCountTarget = this.sampleCountTarget;
 				materialKernel.seed = this.seed;
 				materialKernel.maxSamples = this.maxSamples;
+				materialKernel.rayCount = rayCount;
 				materialKernel.maxTransparentBounces = maxTransparentBounces;
 				materialKernel.bounces = this.bounces;
 				materialKernel.targetDimensions.copy( targetDimensions );

--- a/src/webgpu/compute/wavefront/LogicKernel.js
+++ b/src/webgpu/compute/wavefront/LogicKernel.js
@@ -34,6 +34,7 @@ export class LogicKernel extends ComputeKernel {
 
 			// settings
 			misEnabled: uniform( 1, 'uint' ),
+			rayCount: uniform( 0, 'uint' ),
 			bounces: uniform( 5, 'uint' ),
 			clampDirect: uniform( 0 ),
 			clampIndirect: uniform( 10 ),
@@ -63,6 +64,7 @@ export class LogicKernel extends ComputeKernel {
 			fn compute(
 				// settings
 				misEnabled: u32,
+				rayCount: u32,
 				bounces: u32,
 				clampDirect: f32,
 				clampIndirect: f32,
@@ -75,8 +77,10 @@ export class LogicKernel extends ComputeKernel {
 				let rayIntersectionsStorage = &${ params.rayIntersectionsStorage };
 				let shadowRayIntersectionsStorage = &${ params.shadowRayIntersectionsStorage };
 
+				// "rayCount" rather than the pool length - the dispatch rounds up to the workgroup
+				// size and the slots past it were never assigned a pixel
 				let index = globalId.x;
-				if ( index >= arrayLength( rayDataStorage ) ) {
+				if ( index >= rayCount ) {
 
 					return;
 

--- a/src/webgpu/compute/wavefront/MaterialKernel.js
+++ b/src/webgpu/compute/wavefront/MaterialKernel.js
@@ -24,6 +24,7 @@ export class MaterialKernel extends ComputeKernel {
 			seed: uniform( 0, 'uint' ),
 			targetDimensions: uniform( new Vector2() ),
 			maxSamples: uniform( 0, 'uint' ),
+			rayCount: uniform( 0, 'uint' ),
 			filterGlossy: uniform( 1 ),
 			maxTransparentBounces: uniform( 5, 'uint' ),
 			bounces: uniform( 5, 'uint' ),
@@ -50,6 +51,7 @@ export class MaterialKernel extends ComputeKernel {
 				seed: u32,
 				targetDimensions: vec2u,
 				maxSamples: u32,
+				rayCount: u32,
 				filterGlossy: f32,
 				maxTransparentBounces: u32,
 				bounces: u32,
@@ -65,8 +67,12 @@ export class MaterialKernel extends ComputeKernel {
 				let materials = &${ proxy( 'bvhData.value.storage.materials', params ) };
 				let transforms = &${ proxy( 'bvhData.value.storage.transforms', params ) };
 
+				// "rayCount" rather than the pool length: the dispatch is rounded up to the
+				// workgroup size, and the slots past it were never assigned a pixel. Letting them
+				// run recycles their zeroed pixel index through the overflow queue, which both
+				// duplicates one pixel and drops the real one it swapped out
 				let index = globalId.x;
-				if ( index >= arrayLength( rayDataStorage ) ) {
+				if ( index >= rayCount ) {
 
 					return;
 


### PR DESCRIPTION
Related to #777 

- Fix "maxSamples" not clamping rays properly
- Fix "setCamera" not rebuilding kernels properly